### PR TITLE
Request user's age before displaying the report

### DIFF
--- a/app.html
+++ b/app.html
@@ -34,6 +34,7 @@
 
     <ng-include src="'partials/paste-prompt.html'"></ng-include>
     <ng-include src="'partials/paste-confirm.html'"></ng-include>
+    <ng-include src="'partials/age-request.html'"></ng-include>
     <ng-include src="'partials/ssa-earnings-table.html'"></ng-include>
     <ng-include src="'partials/primary-insurance-amount.html'"></ng-include>
     <ng-include src="'partials/benefit-estimate.html'"></ng-include>

--- a/partials/age-request.html
+++ b/partials/age-request.html
@@ -1,0 +1,42 @@
+<div id="ageRequest" class="confirmation-prompt"
+     ng-show="showAgeRequest()">
+  <div>
+    <h3>Step 3 of 3: Select Birthdate Month and Year</h3>
+    <p>
+      Your birthdate determines when you can start
+      collecting social security benefits.
+    </p>
+  </div>
+
+  <div id=agePicker>
+    <div class=monthPicker>
+      <span ng-repeat="month in all_months | limitTo:6">
+       <input type=radio value="{{month}}" id="month-{{month}}"
+              class=radio ng-model="birth.month" ng-change="updateBirthdate()">
+        <label class="radio month" for="month-{{month}}">{{month}}</label>
+      </span>
+    </div>
+    <div class=monthPicker>
+      <span ng-repeat="month in all_months | limitTo:6:6">
+       <input type=radio value="{{month}}" id="month-{{month}}"
+              class=radio ng-model="birth.month" ng-change="updateBirthdate()">
+        <label class="radio month" for="month-{{month}}">{{month}}</label>
+      </span>
+    </div>
+    <div class=yearPicker>
+      <span ng-repeat="year in pastYears()">
+        <input type=radio id="year-{{year}}" value="{{year}}"
+               class=radio ng-model="birth.year" ng-change="updateBirthdate()">
+        <label class="radio year" for="year-{{year}}">{{year}}</label>
+      </span>
+    </div>
+  </div>
+  <br class=clear>
+
+  <div ng-show="birthDateSelected()">
+    You were born in <b>{{birth.month}}, {{birth.year}}</b>:
+    <button ng-click="confirmBirthDate()" class=success>
+      <ico>&#10003;</ico> Yes
+    </button>
+  </div>
+</div>

--- a/partials/benefit-estimate.html
+++ b/partials/benefit-estimate.html
@@ -11,49 +11,6 @@
   </p>
 
   <p>
-    To determine your normal retirement age, as well as learn more about your
-    options on when you can begin taking benefits, adjust your birth month and
-    year below.
-  </p>
-
-  <h4>I was born in:</h4>
-
-  <div id=agePicker>
-    <div class=monthPicker>
-      <span ng-repeat="month in all_months | limitTo:6">
-       <input type=radio value="{{month}}" id="month-{{month}}"
-              class=radio ng-model="birth.month" ng-change="updateBirthdate()">
-        <label class="radio month" for="month-{{month}}">{{month}}</label>
-      </span>
-    </div>
-    <div class=monthPicker>
-      <span ng-repeat="month in all_months | limitTo:6:6">
-       <input type=radio value="{{month}}" id="month-{{month}}"
-              class=radio ng-model="birth.month" ng-change="updateBirthdate()">
-        <label class="radio month" for="month-{{month}}">{{month}}</label>
-      </span>
-    </div>
-    <div class=yearPicker>
-      <span ng-repeat="year in pastYears()">
-        <input type=radio id="year-{{year}}" value="{{year}}"
-               class=radio ng-model="birth.year" ng-change="updateBirthdate()">
-        <label class="radio year" for="year-{{year}}">{{year}}</label>
-      </span>
-    </div>
-  </div>
-  <br class=clear>
-  
-  <div ng-show="showOver60Warning()" class=flashnotify>
-    <p>
-      <u>Quick Note</u>: The multiplier for earnings in the year you turn 60
-      (<b>{{taxEngine.dateAtAge(60, 0).year}}</b>) and later years is
-      fixed to <b>1.0</b>. When you adjusted your age, this affected
-      your calculation of your indexed earnings at the top of the page.
-    </p>
-  </div>
-
-
-  <p>
     For those born in <b>{{birth.year}}</b>, normal retirement age is
     <b>{{taxEngine.fullRetirement.ageYears}} years and 
     {{taxEngine.fullRetirement.ageMonths}} months</b>.
@@ -62,9 +19,10 @@
     <b>{{taxEngine.fullRetirementDate.month}}, 
     {{taxEngine.fullRetirementDate.year}}</b>.
   </p>
+
   <p>
-    If you start then, your benefit will be the primary insurance amount,
-    rounded down:
+    If you start collecting benefits then, your benefit will be the primary
+    insurance amount, rounded down:
     <ul>
       <li>
         <b>${{taxEngine.primaryInsuranceAmountFloored() | number}}</b> / month
@@ -76,7 +34,7 @@
     </ul>
   </p>
 
-  <h2>Early and Delated Retirement</h2>
+  <h2>Early and Delayed Retirement</h2>
   <p>
     You can also begin taking benefits as early as 62 years old
     (<b>{{taxEngine.dateAtAge(62, 0).month}}

--- a/partials/paste-confirm.html
+++ b/partials/paste-confirm.html
@@ -1,6 +1,7 @@
-<div id="earningsTable" class="earnings-paste"
+<div id="earningsTable" class="confirmation-prompt"
      ng-show="showPasteConfirmation()">
-  <div id="earningsConfirmation">
+  <div class="confirmation-left">
+    <h3>Step 2 of 3: Confirm Earnings Record</h3>
     <p>Is this the same table you copied from ssa.gov?</p>
     
     <button ng-click="confirmEarningsParse('correct')" class=success>
@@ -43,7 +44,7 @@
   </table>
 </div>
 
-<div id="earningsApology" class="earnings-paste" ng-show="showPasteApology()">
+<div id="earningsApology" class="confirmation-prompt" ng-show="showPasteApology()">
   <p>Sorry about that, let's try again.</p>
   <button ng-click="reset()" class=success>Click to restart.</button>
 </div>

--- a/partials/paste-prompt.html
+++ b/partials/paste-prompt.html
@@ -26,7 +26,8 @@
         Either way will work. Copy the text with 'Control+C'.
       </li>
       <li>
-        Return to this page, paste the result into the text area below.
+        Return to this page, paste the result into the text area below with
+        'Control+P'.
       </li>
     </ol>
   </div>

--- a/partials/ssa-earnings-table.html
+++ b/partials/ssa-earnings-table.html
@@ -1,4 +1,18 @@
 <div ng-show="showReport()" class="fixed-center-column ng-cloak">
+  <h2 ng-show="demoId > -1">Demo Data</h2>
+  <p ng-show="demoId === 0">
+    Retiree born in July, 1950, who earned roughly the US average wage for
+    most of their career.
+  </p>
+  <p ng-show="demoId === 1">
+    Retiree born in August, 1950, who earned the maximum social security wages
+    over five years, but nothing otherwise.
+  </p>
+  <p ng-show="demoId === 2">
+    Earner early in their career, born in September 1985, with a $40,000 per
+    year salary in 2005 and a 4% annual raise.
+  </p>
+
   <h2>Earnings Record</h2>
   <table class="fancy-table">
     <thead>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -186,7 +186,7 @@ div.instructions li > img {
   margin-right: auto;
   display: block;
 }
-div.earnings-paste button {
+div.confirmation-prompt button {
   border: 0 none;
   border-radius: 36px;
   color: #fff;
@@ -215,19 +215,19 @@ ul.demos button > ico {
   font-size: 22px;
 }
 
-div.earnings-paste {
+div.confirmation-prompt {
   margin-top: 20px;
   margin-right: 60px;
   font-size: 18px;
 }
 
-div.earnings-paste > div#earningsConfirmation {
+div.confirmation-prompt > div.confirmation-left {
   float: left;
   margin: 0;
   margin-top: 60px;
   text-align: center;
 }
-div.earnings-paste button {
+div.confirmation-prompt button {
   border: 0 none;
   border-radius: 36px;
   color: #fff;
@@ -237,20 +237,20 @@ div.earnings-paste button {
   min-width: 110px;
   cursor: pointer;
 }
-div.earnings-paste button.success {
+div.confirmation-prompt button.success {
   background: #4ac15a;
 }
-div.earnings-paste button.failure {
+div.confirmation-prompt button.failure {
   background: #d9534f;
 }
-div.earnings-paste button.success:hover {
+div.confirmation-prompt button.success:hover {
   background: #2aa13a;
 }
-div.earnings-paste button.failure:hover {
+div.confirmation-prompt button.failure:hover {
   background: #b9332f;
 }
 
-div.earnings-paste button > ico {
+div.confirmation-prompt button > ico {
   font-weight: bold;
   font-size: 22px;
 }
@@ -469,6 +469,10 @@ div.fixed-center-column {
 }
 
 /* The Age Picker buttons are simply heavily CSS'ed radio buttons. */
+div#agePicker {
+  font-size: 14px;
+}
+
 div.monthPicker {
   max-width: 620px;
   display: -webkit-flex;


### PR DESCRIPTION
Request user's age before displaying the report, rather than introducing the age picker inline in the report before explaining normal retirement age. This affects the PIA calculation for users nearing retirement.

Addresses #27 