### PR TITLE
Implement Eligibility Credits

### DIFF
--- a/app.html
+++ b/app.html
@@ -43,6 +43,7 @@
     <ng-include src="'partials/age-request.html'"></ng-include>
     <ng-include src="'partials/birthdate.html'"></ng-include>
     <ng-include src="'partials/ssa-earnings-table.html'"></ng-include>
+    <ng-include src="'partials/eligibility.html'"></ng-include>
     <ng-include src="'partials/primary-insurance-amount.html'"></ng-include>
     <ng-include src="'partials/benefit-estimate.html'"></ng-include>
     <ng-include src="'partials/spousal-benefit.html'"></ng-include>

--- a/partials/benefit-estimate.html
+++ b/partials/benefit-estimate.html
@@ -1,226 +1,228 @@
 <div id=benefitEstimate class="benefit-estimate fixed-center-column"
      ng-show="showReport()" ng-cloak>
 
-  <h2 id=nav-nra>Normal Retirement Age</h2>
-  <p>
-    Your primary insurance amount rounded down to the next lower whole dollar
-    is <b>${{recipient.primaryInsuranceAmountFloored() | number:0}}</b> / month
-    and is the benefit you will earn if you retire at your
-    <u>normal retirement age</u> (NRA). Normal Retirement Age is between 65
-    and 67, depending on when you were born. You may also see this
-    referred to as the <u>full retirement age</u> (FRA).
-  </p>
-
-  <p>
-    For those born in <b>{{birth.year}}</b>, normal retirement age is
-    <b>{{recipient.normalRetirement.ageYears}} years and 
-    {{recipient.normalRetirement.ageMonths}} months</b>.
-
-    This puts your normal retirement date at
-    <b>{{recipient.normalRetirementDate.monthFullName()}}, 
-    {{recipient.normalRetirementDate.year()}}</b>.
-  </p>
-
-  <div class=insetTextBox ng-show="birth.day === 1">
-    <h4>Special Rule</h4>
+  <div ng-show="recipient.isEligible()">
+    <h2 id=nav-nra>Normal Retirement Age</h2>
     <p>
-      The month you reach specific ages may seem "off by one" from what
-      you entered. Social Security follows English common law that finds that a
-      person "attains" an age on the day before the birthday. Because you were
-      born on the first of the month, this means that you attain age
-      <b>{{recipient.exampleAge().age}}</b> on
-      <b>{{recipient.exampleAge().month}} 
-         {{recipient.exampleAge().day}},
-         {{recipient.exampleAge().year}}</b>.
+      Your primary insurance amount rounded down to the next lower whole dollar
+      is <b>${{recipient.primaryInsuranceAmountFloored() | number:0}}</b> / month
+      and is the benefit you will earn if you retire at your
+      <u>normal retirement age</u> (NRA). Normal Retirement Age is between 65
+      and 67, depending on when you were born. You may also see this
+      referred to as the <u>full retirement age</u> (FRA).
     </p>
-  </div>
 
-  <p>
-    If you start collecting benefits at your normal retirement age, your
-    benefit will be the primary insurance amount, rounded down:
-    <ul>
-      <li>
-        <b>${{recipient.primaryInsuranceAmountFloored() | number}}</b> / month
-      </li>
-      <li>
-        <b>${{recipient.primaryInsuranceAmountFloored() * 12 | number}}</b>
-        / year
-      </li>
-    </ul>
-  </p>
-
-  <h2 id="nav-early-delayed">Early and Delayed Retirement</h2>
-  <p>
-		<span ng-show="birth.day === 2">
-    	You can begin taking benefits as early as 62 years old
-	    (<b>{{recipient.dateAtYearsOld(62).monthFullName()}}
-  	      {{recipient.dateAtYearsOld(62).year()}}</b>),
-    </span>
-    <span ng-show="birth.day !== 2">
-    	You can begin taking benefits as early as 62 years and 1 month old
-	    (<b>{{recipient.dateAtAge(initAge(62, 1)).monthFullName()}}
-  	      {{recipient.dateAtAge(initAge(62, 1)).year()}}</b>),
-		</span>
-    or wait until as late as 70 years old
-    (<b>{{recipient.dateAtYearsOld(70).monthFullName()}}
-        {{recipient.dateAtYearsOld(70).year()}}</b>),
-    or start any month in between. The longer you wait, the higher your
-    benefit will be.
-  </p>
-  <div class=insetTextBox ng-show="birth.day > 2">
-    <h4>Special Rule</h4>
     <p>
-      You may find it oddly specific that the earliest you can actually
-      begin benefits is at age 62 and 1 month. Benefit eligibility
-      is calculated based on the first month that you are a particular age
-      throughout the <u>entire</u> month. For most, this is the month
-      <i>after</i> their birthday.
-    </p>
-    <p>
-      For example, the first month that you are
-      <b>{{recipient.exampleAge().age}}</b>
-      throughout the <u>entire</u> month is
-      <b>{{followingMonth(recipient.exampleAge()).month}}
-         {{followingMonth(recipient.exampleAge()).year}}</b>.
-    </p>
-  </div>
-  <p>
-    If you choose to take benefits earlier than normal retirement age
-    (<b>{{recipient.normalRetirementDate.monthFullName()}} 
-        {{recipient.normalRetirementDate.year()}}</b>),
-    your benefit amount will be <u>permanently</u> <i>reduced</i> 
-    per year you start early by:
-    <ul>
-      <li><b>6.67%</b> per year if starting <i>after</i>
-        <b>{{recipient.normalRetirement.ageYears - 3}} years and 
-           {{recipient.normalRetirement.ageMonths}} months</b>
-        (<b>{{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).monthFullName()}}
-            {{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).year()}}</b>)
-      </li>
-      <li><b>5.00%</b> per year if starting <i>before</i>
-        <b>{{recipient.normalRetirement.ageYears - 3}} years and 
-           {{recipient.normalRetirement.ageMonths}} months</b>
-        (<b>{{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).monthFullName()}}
-            {{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).year()}}</b>)
-      </li>
-    </ul>
-  </p> 
-  <p>
-    If you choose instead to wait until later than normal retirement age to
-    start your benefits,
-    (<b>{{recipient.normalRetirementDate.monthFullName()}}
-        {{recipient.normalRetirementDate.year()}}</b>),
-     your amount will be <u>permanently</u> <i>increased</i> by
-    <b>{{recipient.delayIncreaseRate() * 100 | number: 2}}%</b> per year that
-    you delay.
-  </p>
-  <p>
-    Here is a table which shows how much your benefit would be at different
-    starting ages:
-  </p>
-  <table ng-class="{'fancy-table': true, 'wide-age': birth.day !== 2}">
-    <thead>
-      <tr>
-        <th colspan=3></th>
-        <th colspan=2>Benefit</th>
-      </tr>
-      <tr>
-        <th id="age">Age</th>
-        <th id="date">Date</th>
-        <th id="adjustment">Adjustment</th>
-        <th id="monthlybenefit">monthly</th>
-        <th id="annualbenefit">yearly</th>
-      </tr>
-    </thead> 
-    <tbody>
-		  <tr ng-show="birth.day === 2">
-        <td headers="age">62</td>
-        <td headers="date">
-          {{recipient.dateAtYearsOld(62).monthName()}}
-          {{recipient.dateAtYearsOld(62).year()}}
-        </td>
-        <td headers="adjustment">
-          {{recipient.benefitMultiplierAtAge(initAge(62)) * 100 | number:2}}%
-        </td>
-        <td headers="monthlybenefit">
-          ${{recipient.benefitAtAge(initAge(62)) | number:0}}
-        </td>
-        <td headers="annualbenefit">
-          ${{recipient.benefitAtAge(initAge(62)) * 12 | number:0}}
-        </td>
-      </tr>
-      <tr ng-show="birth.day !== 2">
-        <td headers="age">62 + 1m</td>
-        <td headers="date">
-          {{recipient.dateAtAge(initAge(62, 1)).monthName()}}
-          {{recipient.dateAtAge(initAge(62, 1)).year()}}
-        </td>
-        <td headers="adjustment">
-          {{recipient.benefitMultiplierAtAge(initAge(62, 1)) * 100 | number:2}}%
-        </td>
-        <td headers="monthlybenefit">
-          ${{recipient.benefitAtAge(initAge(62, 1)) | number:0}}
-        </td>
-        <td headers="annualbenefit">
-          ${{recipient.benefitAtAge(initAge(62, 1)) * 12 | number:0}}
-        </td>
-      </tr>
-      <tr ng-repeat="age in [63, 64, 65, 66, 67, 68, 69, 70]">
-        <td headers="age">{{age}}</td>
-        <td headers="date">
-          {{recipient.dateAtYearsOld(age).monthName()}}
-          {{recipient.dateAtYearsOld(age).year()}}
-        </td>
-        <td headers="adjustment">
-          {{recipient.benefitMultiplierAtAge(initAge(age)) * 100 | number:2}}%
-        </td>
-        <td headers="monthlybenefit">
-          ${{recipient.benefitAtAge(initAge(age)) | number:0}}
-        </td>
-        <td headers="annualbenefit">
-          ${{recipient.benefitAtAge(initAge(age)) * 12 | number:0}}
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  
-  <p>
-    You can also see this same thing in the interactive chart below, with the
-    age you choose to start taking benefits on the x-axis and the annual
-    benefit amount on the y-axis. Move your mouse over the chart to see how
-    the earnings change based on the age that you first start taking benefits.
-  </p>
+      For those born in <b>{{birth.year}}</b>, normal retirement age is
+      <b>{{recipient.normalRetirement.ageYears}} years and 
+      {{recipient.normalRetirement.ageMonths}} months</b>.
 
+      This puts your normal retirement date at
+      <b>{{recipient.normalRetirementDate.monthFullName()}}, 
+      {{recipient.normalRetirementDate.year()}}</b>.
+    </p>
 
-  <div class="chart-container">
-    <div class="chart-ylabel benefit-estimate" >
-      <span class="vertical-text">Adjusted Benefit</span>
+    <div class=insetTextBox ng-show="birth.day === 1">
+      <h4>Special Rule</h4>
+      <p>
+        The month you reach specific ages may seem "off by one" from what
+        you entered. Social Security follows English common law that finds that a
+        person "attains" an age on the day before the birthday. Because you were
+        born on the first of the month, this means that you attain age
+        <b>{{recipient.exampleAge().age}}</b> on
+        <b>{{recipient.exampleAge().month}} 
+          {{recipient.exampleAge().day}},
+          {{recipient.exampleAge().year}}</b>.
+      </p>
     </div>
 
-    <!-- canvas width/height must be set explicitly in HTML rather than CSS -->
-    <canvas id="age-chart-canvas" width=600 height=400>
-      Your browser does not support HTML canvas.
-    </canvas>
+    <p>
+      If you start collecting benefits at your normal retirement age, your
+      benefit will be the primary insurance amount, rounded down:
+      <ul>
+        <li>
+          <b>${{recipient.primaryInsuranceAmountFloored() | number}}</b> / month
+        </li>
+        <li>
+          <b>${{recipient.primaryInsuranceAmountFloored() * 12 | number}}</b>
+          / year
+        </li>
+      </ul>
+    </p>
 
-    <div class="chart-xlabel">
-      Age Starting Benefits
+    <h2 id="nav-early-delayed">Early and Delayed Retirement</h2>
+    <p>
+      <span ng-show="birth.day === 2">
+        You can begin taking benefits as early as 62 years old
+        (<b>{{recipient.dateAtYearsOld(62).monthFullName()}}
+            {{recipient.dateAtYearsOld(62).year()}}</b>),
+      </span>
+      <span ng-show="birth.day !== 2">
+        You can begin taking benefits as early as 62 years and 1 month old
+        (<b>{{recipient.dateAtAge(initAge(62, 1)).monthFullName()}}
+            {{recipient.dateAtAge(initAge(62, 1)).year()}}</b>),
+      </span>
+      or wait until as late as 70 years old
+      (<b>{{recipient.dateAtYearsOld(70).monthFullName()}}
+          {{recipient.dateAtYearsOld(70).year()}}</b>),
+      or start any month in between. The longer you wait, the higher your
+      benefit will be.
+    </p>
+    <div class=insetTextBox ng-show="birth.day > 2">
+      <h4>Special Rule</h4>
+      <p>
+        You may find it oddly specific that the earliest you can actually
+        begin benefits is at age 62 and 1 month. Benefit eligibility
+        is calculated based on the first month that you are a particular age
+        throughout the <u>entire</u> month. For most, this is the month
+        <i>after</i> their birthday.
+      </p>
+      <p>
+        For example, the first month that you are
+        <b>{{recipient.exampleAge().age}}</b>
+        throughout the <u>entire</u> month is
+        <b>{{followingMonth(recipient.exampleAge()).month}}
+          {{followingMonth(recipient.exampleAge()).year}}</b>.
+      </p>
     </div>
-  </div>
+    <p>
+      If you choose to take benefits earlier than normal retirement age
+      (<b>{{recipient.normalRetirementDate.monthFullName()}} 
+          {{recipient.normalRetirementDate.year()}}</b>),
+      your benefit amount will be <u>permanently</u> <i>reduced</i> 
+      per year you start early by:
+      <ul>
+        <li><b>6.67%</b> per year if starting <i>after</i>
+          <b>{{recipient.normalRetirement.ageYears - 3}} years and 
+            {{recipient.normalRetirement.ageMonths}} months</b>
+          (<b>{{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).monthFullName()}}
+              {{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).year()}}</b>)
+        </li>
+        <li><b>5.00%</b> per year if starting <i>before</i>
+          <b>{{recipient.normalRetirement.ageYears - 3}} years and 
+            {{recipient.normalRetirement.ageMonths}} months</b>
+          (<b>{{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).monthFullName()}}
+              {{recipient.dateAtYearsOld(recipient.normalRetirement.ageYears - 3).year()}}</b>)
+        </li>
+      </ul>
+    </p> 
+    <p>
+      If you choose instead to wait until later than normal retirement age to
+      start your benefits,
+      (<b>{{recipient.normalRetirementDate.monthFullName()}}
+          {{recipient.normalRetirementDate.year()}}</b>),
+      your amount will be <u>permanently</u> <i>increased</i> by
+      <b>{{recipient.delayIncreaseRate() * 100 | number: 2}}%</b> per year that
+      you delay.
+    </p>
+    <p>
+      Here is a table which shows how much your benefit would be at different
+      starting ages:
+    </p>
+    <table ng-class="{'fancy-table': true, 'wide-age': birth.day !== 2}">
+      <thead>
+        <tr>
+          <th colspan=3></th>
+          <th colspan=2>Benefit</th>
+        </tr>
+        <tr>
+          <th id="age">Age</th>
+          <th id="date">Date</th>
+          <th id="adjustment">Adjustment</th>
+          <th id="monthlybenefit">monthly</th>
+          <th id="annualbenefit">yearly</th>
+        </tr>
+      </thead> 
+      <tbody>
+        <tr ng-show="birth.day === 2">
+          <td headers="age">62</td>
+          <td headers="date">
+            {{recipient.dateAtYearsOld(62).monthName()}}
+            {{recipient.dateAtYearsOld(62).year()}}
+          </td>
+          <td headers="adjustment">
+            {{recipient.benefitMultiplierAtAge(initAge(62)) * 100 | number:2}}%
+          </td>
+          <td headers="monthlybenefit">
+            ${{recipient.benefitAtAge(initAge(62)) | number:0}}
+          </td>
+          <td headers="annualbenefit">
+            ${{recipient.benefitAtAge(initAge(62)) * 12 | number:0}}
+          </td>
+        </tr>
+        <tr ng-show="birth.day !== 2">
+          <td headers="age">62 + 1m</td>
+          <td headers="date">
+            {{recipient.dateAtAge(initAge(62, 1)).monthName()}}
+            {{recipient.dateAtAge(initAge(62, 1)).year()}}
+          </td>
+          <td headers="adjustment">
+            {{recipient.benefitMultiplierAtAge(initAge(62, 1)) * 100 | number:2}}%
+          </td>
+          <td headers="monthlybenefit">
+            ${{recipient.benefitAtAge(initAge(62, 1)) | number:0}}
+          </td>
+          <td headers="annualbenefit">
+            ${{recipient.benefitAtAge(initAge(62, 1)) * 12 | number:0}}
+          </td>
+        </tr>
+        <tr ng-repeat="age in [63, 64, 65, 66, 67, 68, 69, 70]">
+          <td headers="age">{{age}}</td>
+          <td headers="date">
+            {{recipient.dateAtYearsOld(age).monthName()}}
+            {{recipient.dateAtYearsOld(age).year()}}
+          </td>
+          <td headers="adjustment">
+            {{recipient.benefitMultiplierAtAge(initAge(age)) * 100 | number:2}}%
+          </td>
+          <td headers="monthlybenefit">
+            ${{recipient.benefitAtAge(initAge(age)) | number:0}}
+          </td>
+          <td headers="annualbenefit">
+            ${{recipient.benefitAtAge(initAge(age)) * 12 | number:0}}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+    <p>
+      You can also see this same thing in the interactive chart below, with the
+      age you choose to start taking benefits on the x-axis and the annual
+      benefit amount on the y-axis. Move your mouse over the chart to see how
+      the earnings change based on the age that you first start taking benefits.
+    </p>
 
-  <div class=insetTextBox>
-    <h4>Special Rule</h4>
-    <p>
-      Delayed "credits" are calculated based on the number of months earned in
-      the previous calendar year.
-    </p>
-    <p>
-      This means that if you begin delayed benefits in a month other than
-      January, your initial benefit will be a little smaller than the full
-      delayed benefit, at first. This difference will disappear beginning in
-      January of the following year, at which point your benefit will increase
-      to the full benefit amount. If you wait until age 70, your delayed
-      credits are applied immediately.
-    </p>
+
+    <div class="chart-container">
+      <div class="chart-ylabel benefit-estimate" >
+        <span class="vertical-text">Adjusted Benefit</span>
+      </div>
+
+      <!-- canvas width/height must be set explicitly in HTML rather than CSS -->
+      <canvas id="age-chart-canvas" width=600 height=400>
+        Your browser does not support HTML canvas.
+      </canvas>
+
+      <div class="chart-xlabel">
+        Age Starting Benefits
+      </div>
+    </div>
+
+    <div class=insetTextBox>
+      <h4>Special Rule</h4>
+      <p>
+        Delayed "credits" are calculated based on the number of months earned in
+        the previous calendar year.
+      </p>
+      <p>
+        This means that if you begin delayed benefits in a month other than
+        January, your initial benefit will be a little smaller than the full
+        delayed benefit, at first. This difference will disappear beginning in
+        January of the following year, at which point your benefit will increase
+        to the full benefit amount. If you wait until age 70, your delayed
+        credits are applied immediately.
+      </p>
+    </div>
   </div>
 </div>
 

--- a/partials/eligibility.html
+++ b/partials/eligibility.html
@@ -4,7 +4,7 @@
 
   <p>
     You must earn 40 <a href="https://www.ssa.gov/planners/credits.html">credits</a> to be eligible for for a normal 
-    retirement benefit from your own work history.  You can earn a maximum of four credits each year.
+    retirement benefit from your own work history.  You can earn a <u>maximum of 4 credits each year</u>.
     If you have a short work history, you may not be eligible to receive retirement benefits from
     Social Security on your own work history.  You may still be eligible to receive spousal benefits.
   </p>

--- a/partials/eligibility.html
+++ b/partials/eligibility.html
@@ -1,0 +1,92 @@
+<div id=Credits class="credits fixed-center-column"
+                        ng-show="showReport()" ng-cloak>
+  <h2 id="nav-credits">Retirement Benefits Eligibility</h2>
+
+  <p>
+    You must earn 40 <a href="https://www.ssa.gov/planners/credits.html">credits</a> to be eligible for for a normal 
+    retirement benefit from your own work history.  You can earn a maximum of four credits each year.
+    If you have a short work history, you may not be eligible to receive retirement benefits from
+    Social Security on your own work history.  You may still be eligible to receive spousal benefits.
+  </p>
+
+  <span ng-if="recipient.earnedCredits > 0">
+    <table class="fancy-table">
+    <thead>
+      <tr>
+        <th id="workyear">Year</th>
+        <th id="age">Age</th>
+        <th id="taxedearnings">Taxed Earnings</th>
+        <th id="epc">Earnings Per Credit</th>
+        <th id="credits">Credits<th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="earningRecord in earningsRecords()">
+        <td headers="workyear">{{earningRecord.year}}</td>
+        <td headers="age">{{recipient.exampleAge(earningRecord.year).age}}</td>
+        <td headers="taxedearnings" ng-show="earningRecord.taxedEarnings >= 0">
+          ${{earningRecord.taxedEarnings | number:0}}</td>
+        <td headers="epc">${{recipient.getEarningsPerCreditForYear(earningRecord.year) | number:0}}</td>
+        <td headers="credits" ng-show="earningRecord.credits >= 0">
+          {{earningRecord.credits | number:0}}</td>
+      </tr>
+    </tbody>
+    </table>
+  </span>
+
+  <p>
+    <span ng-if="futureYears.length > 0">If you work {{recipient.futureEarningsYears | number:0}} 
+      additional years, you will earn {{recipient.plannedCredits | number:0}} additional credits. 
+    </span>
+  </p>
+
+  <span ng-if="futureYears.length > 0">
+    <table class="fancy-table">
+    <thead>
+      <tr>
+        <th id="workyear">Year</th>
+        <th id="age">Age</th>
+        <th id="taxedearnings">Taxed Earnings</th>
+        <th id="epc">Earnings Per Credit</th>
+        <th id="credits">Credits<th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="year in futureYears">
+        <td headers="workyear">{{year}}</td>
+        <td headers="age">{{recipient.exampleAge(year).age}}</td>
+        <td headers="taxedearnings">${{futureWageWorkSlider.minValue | number:0}}</td>
+        <td headers="epc">${{recipient.getEarningsPerCreditForYear(2018) | number:0}}</td>
+        <td headers="credits">{{recipient.calculateCredits(futureWageWorkSlider.minValue, 2018) | number:0}}</td>
+      </tr>
+    </tbody>
+    </table>
+  </span>
+  
+  <p>
+    <span ng-if="recipient.earnedCredits >= 40">You have earned the required 40 credits to be 
+      <u>permanently eligible</u> for retirement benefits on your own work record. 
+    </span>
+    <span ng-if="40 > recipient.earnedCredits && recipient.totalCredits >= 40">You will have 40 credits
+      when you complete {{recipient.neededYears | number:0}} additional years of work earning 
+      ${{futureWageWorkSlider.minValue | number:0}} per year.  You will become <u>permanently eligible</u>
+      for retirement benefits on your own work record when you have earned 40 credits.
+    </span>
+    <span ng-if="40 > recipient.totalCredits">You have earned {{recipient.earnedCredits | number:0}} credits 
+      and will earn {{recipient.plannedCredits | number:0}} credits for a total of 
+      {{recipient.totalCredits | number:0}} credits, which is not enough to be eligible for retirement benefits 
+      on your own work record.  You may be eligible for spousal benefits.  You will become 
+      <u>permanently eligible</u> for retirement benefits on your own work record when you have earned 
+      40 credits.
+    </span>
+  </p>
+
+  <div class=insetTextBox>
+    <h4>Special Rule</h4>
+    <p>
+      You can earn enough credits to become eligible for social security retirement benefits
+      after age 70.  You will not be able to apply and receive benefits until you become eligible.
+    </p>
+  </div>
+    
+</div>

--- a/partials/eligibility.html
+++ b/partials/eligibility.html
@@ -1,6 +1,6 @@
 <div id=Credits class="credits fixed-center-column"
                         ng-show="showReport()" ng-cloak>
-  <h2 id="nav-credits">Retirement Benefits Eligibility</h2>
+  <h2 id="nav-eligibility">Retirement Benefits Eligibility</h2>
 
   <p>
     You must earn 40 <a href="https://www.ssa.gov/planners/credits.html">credits</a> to be eligible for for a normal 
@@ -63,28 +63,27 @@
     </table>
   </span>
   
-  <div ng-if="recipient.earningsBefore1978" class=insetTextBox>
-      <h4>Special Rule</h4>
-      <p>
-        Earnings before 1978 were reported quarterly, and you earned one credit per quarter.
-        Because this website uses yearly earnings, credits may not be calculated correctly for
-        years before 1978.
-      </p>
-    </div>
-  
+  <div ng-if="recipient.hasEarningsBefore1978" class=insetTextBox>
+    <h4>Special Rule</h4>
+    <p>
+      Earnings before 1978 were reported quarterly, and you earned one credit per quarter.
+      Because this website uses yearly earnings, credits may not be calculated correctly for
+      years before 1978.
+    </p>
+  </div>
 
   <p>
-    <span ng-if="recipient.earnedCredits >= 40">You have earned the required 40 credits to be 
+    <span ng-if="recipient.earnedCredits >= 40">You have earned the required <b>40</b> credits to be 
       <u>permanently eligible</u> for retirement benefits on your own work record. 
     </span>
-    <span ng-if="40 > recipient.earnedCredits && recipient.totalCredits >= 40">You will have 40 credits
-      when you complete {{recipient.neededYears | number:0}} additional years of work earning 
-      ${{futureWageWorkSlider.minValue | number:0}} per year.  You will become <u>permanently eligible</u>
+    <span ng-if="40 > recipient.earnedCredits && recipient.totalCredits >= 40">You will have <b>40</b> credits
+      when you complete <b>{{recipient.neededYears | number:0}}</b> additional years of work earning 
+      <b>${{futureWageWorkSlider.minValue | number:0}}</b> per year.  You will become <u>permanently eligible</u>
       for retirement benefits on your own work record when you have earned 40 credits.
     </span>
-    <span ng-if="40 > recipient.totalCredits">You have earned {{recipient.earnedCredits | number:0}} credits 
-      and will earn {{recipient.plannedCredits | number:0}} credits for a total of 
-      {{recipient.totalCredits | number:0}} credits, which is not enough to be eligible for retirement benefits 
+    <span ng-if="40 > recipient.totalCredits">You have earned <b>{{recipient.earnedCredits | number:0}}</b> credits 
+      and will earn <b>{{recipient.plannedCredits | number:0}}</b> credits for a total of 
+      <b>{{recipient.totalCredits | number:0}}</b> credits, which is not enough to be eligible for retirement benefits 
       on your own work record.  You may be eligible for spousal benefits.  You will become 
       <u>permanently eligible</u> for retirement benefits on your own work record when you have earned 
       40 credits.
@@ -95,7 +94,8 @@
     <h4>Special Rule</h4>
     <p>
       You can earn enough credits to become eligible for social security retirement benefits
-      after age 70.  You will not be able to apply and receive benefits until you become eligible.
+      after age 70.  You will not be able to apply for and receive retirement benefits on your own
+      work record until you become eligible.
     </p>
   </div>
     

--- a/partials/eligibility.html
+++ b/partials/eligibility.html
@@ -63,6 +63,16 @@
     </table>
   </span>
   
+  <div ng-if="recipient.earningsBefore1978" class=insetTextBox>
+      <h4>Special Rule</h4>
+      <p>
+        Earnings before 1978 were reported quarterly, and you earned one credit per quarter.
+        Because this website uses yearly earnings, credits may not be calculated correctly for
+        years before 1978.
+      </p>
+    </div>
+  
+
   <p>
     <span ng-if="recipient.earnedCredits >= 40">You have earned the required 40 credits to be 
       <u>permanently eligible</u> for retirement benefits on your own work record. 

--- a/partials/filing-date.html
+++ b/partials/filing-date.html
@@ -1,100 +1,102 @@
-<div id=filingDate class="fixed-center-column" ng-show="showReport()" ng-cloak>
+<div ng-show="recipient.isEligible()">
+  <div id=filingDate class="fixed-center-column" ng-show="showReport()" ng-cloak>
 
-  <h2 id="nav-age-decision">Deciding what age to start benefits</h2>
+    <h2 id="nav-age-decision">Deciding what age to start benefits</h2>
 
-  <p>
-    As you can see, choosing a date to start your benefit is an important
-    decision. The above charts display the consequences of each choice. By
-    delaying, you will have to wait to receive any benefits. However when your
-    benefits finally start they will be permanently increased compared to an
-    earlier start date.
-  </p>
-  <h3>What do most Americans do?</h3>
-  <p>
-    According to a 2015 report by the Center for Retirement Research at
-    Boston College,
-    <a href="http://crr.bc.edu/wp-content/uploads/2015/05/IB_15-8.pdf"
-    target="_blank">Trends in Social Security Claiming</a>:
-  </p>
-  <p>The most popular age to start benefits is as early as possible: 62</p>
-  <ul>
-    <li>42% of men start benefits at age 62</li>
-    <li>48% of women start benefits at age 62</li>
-  </ul>
-  <p>
-    The next most popular age to start benefits is at Normal Retirement Age:
-    65-66
-  </p>
-  <ul>
-    <li>34% of men start benefits at Normal Retirement Age</li>
-    <li>27% of women start benefits at Normal Retirement Age</li>
-  </ul>
-  <p>
-    The trend is towards starting benefits later in life. In the last 25 years,
-    the number of people claiming benefits at 62 has been dropping.
-  <p>
-  <ul>
-    <li>16.6% fewer men claiming at 62</li>
-    <li> 8.2% fewer women claiming at 62</li>
-  </ul>
-  <h3>Reasons to start early</h3>
-  <p>
-    One consideration might be your health at the time of retirement - if you
-    are unlikely to earn many years of Social Security benefits, you may want
-    to choose to begin benefits sooner.
-  </p>
-  <p>
-    Another reason is personal necessity. For many, personal retirement savings
-    are insufficient for the demands of living completely without a paycheck
-    from work, and early Social Security benefits can assist with that burden.
-  </p>
-  <h3>Reasons to delay</h3>
-  <p>
-    Typically retirees have to worry more about finances the longer they live.
-    Spending down savings over a longer number of years increases the chance
-    of running out of money before death. Delaying Social Security benefits
-    can be seen as insurance against the financial risk of living a long life.
-    This is sometimes compared to an annuity and can be considered "longevity
-    insurance", that is, insurance against living much longer than you
-    anticipated.
-  </p>
-  <p>
-    The value of the Survivor Benefit may also be something to consider when
-    choosing initial benefit dates for each spouse, but especially
-    the higher earner. Delaying benefits for the higher earning spouse can
-    allow the lower earning spouse to have a permanently increased survivor
-    benefit. This can be considered as a type of life insurance.
-  </p>
-  <h3>Optimization</h3>
-  <p>
-    The lifetime optimized value of different choices, that is, the claiming
-    dates that provide the most money for you and your spouse over your
-    lifetimes, depends on the one input that nobody can know: the date of death
-    for you and your spouse. Online services exist which will help calculate
-    the optimal strategy, but they all must make some assumptions about your
-    expected lifespan.
-  </p>
-  <p>
-    The best financial strategy for an individual or a couple is not always
-    choosing the highest expected lifetime payments. For some, it is beneficial
-    to receive payments during their early years of retirement, perhaps when
-    spending needs may be higher due to personal reasons. For others, protecting
-    against running out of money in anticipation of living a long healthy life
-    is the primary concern.
-  </p>
-  <p>
-    SocialSecurity.Tools does not currently provide a mathematical optimizer
-    feature, but we can recommend the calculator at
-    <a href="https://opensocialsecurity.com/" target=_blank
-      >Open Social Security</a>.
-  </p>
-  <p>
-    If you enter your estimated Primary Insurance Amount (PIA) into Open
-    Social Security you'll get a recommended filing strategy. This calculator
-    weighs your options using average mortality tables. Alternately, you
-    can enter your specific estimate for your date of death. The Open Social
-    Security calculator also accounts for the "discount rate" of money, which
-    takes into account the fact that a dollar you receive now is more valuable
-    than a dollar received later.
-  </p>
-</div><!-- id=filingDate -->
+    <p>
+      As you can see, choosing a date to start your benefit is an important
+      decision. The above charts display the consequences of each choice. By
+      delaying, you will have to wait to receive any benefits. However when your
+      benefits finally start they will be permanently increased compared to an
+      earlier start date.
+    </p>
+    <h3>What do most Americans do?</h3>
+    <p>
+      According to a 2015 report by the Center for Retirement Research at
+      Boston College,
+      <a href="http://crr.bc.edu/wp-content/uploads/2015/05/IB_15-8.pdf"
+      target="_blank">Trends in Social Security Claiming</a>:
+    </p>
+    <p>The most popular age to start benefits is as early as possible: 62</p>
+    <ul>
+      <li>42% of men start benefits at age 62</li>
+      <li>48% of women start benefits at age 62</li>
+    </ul>
+    <p>
+      The next most popular age to start benefits is at Normal Retirement Age:
+      65-66
+    </p>
+    <ul>
+      <li>34% of men start benefits at Normal Retirement Age</li>
+      <li>27% of women start benefits at Normal Retirement Age</li>
+    </ul>
+    <p>
+      The trend is towards starting benefits later in life. In the last 25 years,
+      the number of people claiming benefits at 62 has been dropping.
+    <p>
+    <ul>
+      <li>16.6% fewer men claiming at 62</li>
+      <li> 8.2% fewer women claiming at 62</li>
+    </ul>
+    <h3>Reasons to start early</h3>
+    <p>
+      One consideration might be your health at the time of retirement - if you
+      are unlikely to earn many years of Social Security benefits, you may want
+      to choose to begin benefits sooner.
+    </p>
+    <p>
+      Another reason is personal necessity. For many, personal retirement savings
+      are insufficient for the demands of living completely without a paycheck
+      from work, and early Social Security benefits can assist with that burden.
+    </p>
+    <h3>Reasons to delay</h3>
+    <p>
+      Typically retirees have to worry more about finances the longer they live.
+      Spending down savings over a longer number of years increases the chance
+      of running out of money before death. Delaying Social Security benefits
+      can be seen as insurance against the financial risk of living a long life.
+      This is sometimes compared to an annuity and can be considered "longevity
+      insurance", that is, insurance against living much longer than you
+      anticipated.
+    </p>
+    <p>
+      The value of the Survivor Benefit may also be something to consider when
+      choosing initial benefit dates for each spouse, but especially
+      the higher earner. Delaying benefits for the higher earning spouse can
+      allow the lower earning spouse to have a permanently increased survivor
+      benefit. This can be considered as a type of life insurance.
+    </p>
+    <h3>Optimization</h3>
+    <p>
+      The lifetime optimized value of different choices, that is, the claiming
+      dates that provide the most money for you and your spouse over your
+      lifetimes, depends on the one input that nobody can know: the date of death
+      for you and your spouse. Online services exist which will help calculate
+      the optimal strategy, but they all must make some assumptions about your
+      expected lifespan.
+    </p>
+    <p>
+      The best financial strategy for an individual or a couple is not always
+      choosing the highest expected lifetime payments. For some, it is beneficial
+      to receive payments during their early years of retirement, perhaps when
+      spending needs may be higher due to personal reasons. For others, protecting
+      against running out of money in anticipation of living a long healthy life
+      is the primary concern.
+    </p>
+    <p>
+      SocialSecurity.Tools does not currently provide a mathematical optimizer
+      feature, but we can recommend the calculator at
+      <a href="https://opensocialsecurity.com/" target=_blank
+        >Open Social Security</a>.
+    </p>
+    <p>
+      If you enter your estimated Primary Insurance Amount (PIA) into Open
+      Social Security you'll get a recommended filing strategy. This calculator
+      weighs your options using average mortality tables. Alternately, you
+      can enter your specific estimate for your date of death. The Open Social
+      Security calculator also accounts for the "discount rate" of money, which
+      takes into account the fact that a dollar you receive now is more valuable
+      than a dollar received later.
+    </p>
+  </div><!-- id=filingDate -->
+</div><!-- recipient.isEligible() -->

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -21,6 +21,12 @@
       </a>
     </li>
     <li>
+      <a href="#nav-eligibility" data-ng-click="scrollTo('nav-eligibility')">
+        <div class=navlabel>Retirement Benefits Eligibility</div>
+        <i class="glyphicon glyphicon-chevron-right"></i>
+      </a>
+    </li>
+    <li>
       <a href="#nav-pia" data-ng-click="scrollTo('nav-pia')">
         <div class=navlabel>Primary Insurance Amount</div>
         <i class="glyphicon glyphicon-chevron-right"></i>

--- a/partials/primary-insurance-amount.html
+++ b/partials/primary-insurance-amount.html
@@ -1,197 +1,211 @@
 <div id=topEarningsData class="top-earnings-data fixed-center-column"
                         ng-show="showReport()" ng-cloak>
   <h2 id="nav-pia">Primary Insurance Amount</h2>
-  <p>
-    Your Social Security benefits are best thought of in terms of your 
-    <u>primary insurance amount</u> (PIA). This is the dollar amount that
-    Social Security will pay you every month starting at your
-    <u>normal retirement age</u> (NRA). We are going to walk you through the
-    calculation of your PIA, and ultimately your actual estimated benefit.
-    If applicable, we will also walk you through how your Social Security
-    record will earn a benefit for your spouse.
-  </p>
 
-  <p>
-    Don't let the government mandated acronyms confuse you. Think of the primary
-    insurance amount like a salary: it's the amount of money you can expect to
-    earn in retirement every month starting at your normal retirement age. Your
-    normal retirement age is between 65 and 67, depending on what year you were
-    born. We'll look at normal retirement age in more detail later in this
-    report.
-  </p>
-
-  <p>
-    You have Social Security earnings recorded for
-    <b>{{recipient.numEarningsYears()}}</b> total years. Your PIA is based on
-    your <u>Averaged Indexed Monthly Earnings</u> (AIME), a straightforward
-    calculation from your lifetime earnings record. So, that's our first step.
-  </p>
-
-  <p ng-if="recipient.numEarningsYears() >= 35">
-    Only the top 35 years of <u>indexed earnings</u> values are used in
-    the calculation of your Averaged Indexed Monthly Earnings (and thus, your
-    Primary Insurance Amount). Indexed earnings are simply the payroll wages
-    you earned in a year multiplied by a number that adjusts for wage growth
-    (similar to an inflation adjustment).
-    In your case, this means that years where the indexed earnings value
-    falls below <b>${{recipient.cutoffIndexedEarnings | number}}</b> do not
-    affect your benefit calculation because they are not among the top 35. If
-    you were to earn additional years of wages in the future, they would only
-    affect your Social Security if you earned more than
-    <b>${{recipient.cutoffIndexedEarnings | number}}</b> in those years.
-  </p>
-
-  <p ng-if="recipient.numEarningsYears() < 35">
-    The top 35 <u>indexed earnings</u> values are used in the calculation of
-    your Averaged Indexed Monthly Earnings (and thus, your Primary Insurance
-    Amount). Indexed earnings are simply the capped payroll wages you earned
-    in a year multiplied by a number that adjusts for wage growth (similar to
-    an inflation adjustment). As you don't have 35 years of earnings yet, every
-    additional year you work will increase your benefit a little more. Once
-    you reach 35 years of earnings values, increasing your Averaged Indexed
-    Monthly Earnings amount requires earning more than previous years' indexed
-    values.
-  </p>
-  
-  <p ng-if="!recipient.isOver60()">
-    The multipliers in the above table will increase every year through age 60,
-    at which point they are fixed at 1.0 for everyone. The increase in the
-    multipliers through age 60 is determined by US wage growth. Thus, your 
-    indexed earnings in a given year are scaled to be equivalent to modern
-    wages.
-  </p>
-
-  <p>
-   Currently, your total indexed earnings:
-    <b>${{recipient.totalIndexedEarnings | number:0}}</b>
-  </p>
-
-  </p>
-    This is simply the sum of the highest 35 values in the indexed earnings
-    column above.
-  </p>
-
-  <p>
-    <!-- ugly alignment to avoid a space appearing between months
-         and period/comma. -->
-    Your Average Indexed Monthly Earnings is simply your total indexed
-    earnings divided by 35 years divided by 12 months<span ng-if="recipient.numEarningsYears() >= 35">, as follows:
-    </span><span ng-if="recipient.numEarningsYears() < 35">. As you have fewer than 35 years of earnings, this average is calculated
-      using zeroes for the additional years, as follows:
-    </span>
-  </p>
-
-  <p>
-    Monthly average indexed earnings:
-    <b>${{recipient.totalIndexedEarnings | number:0}}</b> / 35 / 12 =
-    <b>${{recipient.monthlyIndexedEarnings | number:0}}</b>
-  </p>
-
-  <p>
-    Your primary insurance amount is based on your monthly indexed earnings 
-    using <a href="https://www.ssa.gov/oact/cola/piaformula.html"
-             target="_blank">a formula</a>
-    that increases your Primary Insurance Amount as your earnings increase,
-    but increases more slowly for higher total earnings. Your Primary Insurance
-    Amount is calculated from your monthly indexed earnings as follows:
-  </p>
-
-  <table class=benefitBrackets>
-    <tr>
-      <td>
-        Any amount less than
-        ${{firstBendPoint(recipient.indexingYear()) | number:0}}
-        is multiplied by 90%:
-      </td>
-      <td>
-        <b>${{recipient.primaryInsuranceAmountByBracket(0) | number:2}}</b>
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>
-        The amount more than
-        ${{firstBendPoint(recipient.indexingYear()) | number:0}}
-        and less than
-        ${{secondBendPoint(recipient.indexingYear()) | number:0}}
-        is multiplied by 32%:
-      </td>
-      <td>
-        <b>${{recipient.primaryInsuranceAmountByBracket(1) | number:2}}</b>
-      </td>
-      <td></td>
-    <tr>
-    </tr>
-      <td>
-        Any remaining amount more than
-        ${{secondBendPoint(recipient.indexingYear()) | number: 0}}
-        is multiplied by 15%:
-      </td>
-      <td>
-        <b>
-          ${{recipient.primaryInsuranceAmountByBracket(2) | number:2}}
-        </b>
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Total:</td>
-      <td>
-        <b>${{recipient.primaryInsuranceAmountUnadjusted() | number:2}}</b>
-      </td>
-      <td>&nbsp;/ month</td>
-    </tr>
-  </table>  
-
-  <div class=insetTextBox>
-    <h4>Special Rule</h4>
+  <div ng-if="!recipient.isEligible()">
+    <p>You do not have enough credits for to be eligible to receive retirement benefits
+      on your own earnings.  You may be eligible to receive benefits on your spouse's 
+      earnings.
+    </p>
     <p>
-      You may notice that some of these numbers are short a few pennies.
-      Social Security rounds the Primary Insurance Amount down to the dime,
-      while benefits are rounded down to the dollar.
+      Your <u>primary insurance amount</u> (PIA) is <b>${{0 | number}}</b>
     </p>
   </div>
 
-  <div ng-if="recipient.shouldAdjustForCOLA()">
+  <div ng-show="recipient.isEligible()">
     <p>
-      After attaining age 62, your primary insurance amount will increase
-      annually in proportion to the consumer price index (CPI-W), a measure of
-      inflation. This will continue every year, even after beginning
-      to collect your benefit. These adjustments are called 
-      <u>Cost of Living Adjustments</u> (COLA). Here are the adjustments
-      in past years which affect your current Primary Insurance Amount.
+      Your Social Security benefits are best thought of in terms of your 
+      <u>primary insurance amount</u> (PIA). This is the dollar amount that
+      Social Security will pay you every month starting at your
+      <u>normal retirement age</u> (NRA). We are going to walk you through the
+      calculation of your PIA, and ultimately your actual estimated benefit.
+      If applicable, we will also walk you through how your Social Security
+      record will earn a benefit for your spouse.
     </p>
-    <ul>
-      <li ng-repeat="adjustment in recipient.colaAdjustments() | orderBy : adjustment.year">
-        {{adjustment.year}}: <b>{{adjustment.start | number:2}}</b>
-        increased by {{adjustment.cola | number:1 }}% =
-        <b>{{adjustment.end | number:2}}</b>
-      </li>
-    </ul>
-  </div>
 
-  <p>
-    This total
-    (<b>${{recipient.primaryInsuranceAmount() | number:2}}</b> / month) is
-    your primary insurance amount. In the chart below, you can see what your
-    primary insurance amount would be if your indexed earnings were to
-    increase. Move your mouse over the chart to see how the primary insurance
-    amount changes.
-  </p>
+    <p>
+      Don't let the government mandated acronyms confuse you. Think of the primary
+      insurance amount like a salary: it's the amount of money you can expect to
+      earn in retirement every month starting at your normal retirement age. Your
+      normal retirement age is between 65 and 67, depending on what year you were
+      born. We'll look at normal retirement age in more detail later in this
+      report.
+    </p>
 
-  <div class="chart-container">
-    <div class="chart-ylabel pia" >
-      <span class="vertical-text">Primary Insurance Amount</span>
+    <p>
+      You have Social Security earnings recorded for
+      <b>{{recipient.numEarningsYears()}}</b> total years. Your PIA is based on
+      your <u>Averaged Indexed Monthly Earnings</u> (AIME), a straightforward
+      calculation from your lifetime earnings record. So, that's our first step.
+    </p>
+
+    <p ng-if="recipient.numEarningsYears() >= 35">
+      Only the top 35 years of <u>indexed earnings</u> values are used in
+      the calculation of your Averaged Indexed Monthly Earnings (and thus, your
+      Primary Insurance Amount). Indexed earnings are simply the payroll wages
+      you earned in a year multiplied by a number that adjusts for wage growth
+      (similar to an inflation adjustment).
+      In your case, this means that years where the indexed earnings value
+      falls below <b>${{recipient.cutoffIndexedEarnings | number}}</b> do not
+      affect your benefit calculation because they are not among the top 35. If
+      you were to earn additional years of wages in the future, they would only
+      affect your Social Security if you earned more than
+      <b>${{recipient.cutoffIndexedEarnings | number}}</b> in those years.
+    </p>
+
+    <p ng-if="recipient.numEarningsYears() < 35">
+      The top 35 <u>indexed earnings</u> values are used in the calculation of
+      your Averaged Indexed Monthly Earnings (and thus, your Primary Insurance
+      Amount). Indexed earnings are simply the capped payroll wages you earned
+      in a year multiplied by a number that adjusts for wage growth (similar to
+      an inflation adjustment). As you don't have 35 years of earnings yet, every
+      additional year you work will increase your benefit a little more. Once
+      you reach 35 years of earnings values, increasing your Averaged Indexed
+      Monthly Earnings amount requires earning more than previous years' indexed
+      values.
+    </p>
+    
+    <p ng-if="!recipient.isOver60()">
+      The multipliers in the above table will increase every year through age 60,
+      at which point they are fixed at 1.0 for everyone. The increase in the
+      multipliers through age 60 is determined by US wage growth. Thus, your 
+      indexed earnings in a given year are scaled to be equivalent to modern
+      wages.
+    </p>
+
+    <p>
+    Currently, your total indexed earnings:
+      <b>${{recipient.totalIndexedEarnings | number:0}}</b>
+    </p>
+
+    </p>
+      This is simply the sum of the highest 35 values in the indexed earnings
+      column above.
+    </p>
+
+    <p>
+      <!-- ugly alignment to avoid a space appearing between months
+          and period/comma. -->
+      Your Average Indexed Monthly Earnings is simply your total indexed
+      earnings divided by 35 years divided by 12 months<span ng-if="recipient.numEarningsYears() >= 35">, as follows:
+      </span><span ng-if="recipient.numEarningsYears() < 35">. As you have fewer than 35 years of earnings, this average is calculated
+        using zeroes for the additional years, as follows:
+      </span>
+    </p>
+
+    <p>
+      Monthly average indexed earnings:
+      <b>${{recipient.totalIndexedEarnings | number:0}}</b> / 35 / 12 =
+      <b>${{recipient.monthlyIndexedEarnings | number:0}}</b>
+    </p>
+
+    <p>
+      Your primary insurance amount is based on your monthly indexed earnings 
+      using <a href="https://www.ssa.gov/oact/cola/piaformula.html"
+              target="_blank">a formula</a>
+      that increases your Primary Insurance Amount as your earnings increase,
+      but increases more slowly for higher total earnings. Your Primary Insurance
+      Amount is calculated from your monthly indexed earnings as follows:
+    </p>
+
+    <table class=benefitBrackets>
+      <tr>
+        <td>
+          Any amount less than
+          ${{firstBendPoint(recipient.indexingYear()) | number:0}}
+          is multiplied by 90%:
+        </td>
+        <td>
+          <b>${{recipient.primaryInsuranceAmountByBracket(0) | number:2}}</b>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>
+          The amount more than
+          ${{firstBendPoint(recipient.indexingYear()) | number:0}}
+          and less than
+          ${{secondBendPoint(recipient.indexingYear()) | number:0}}
+          is multiplied by 32%:
+        </td>
+        <td>
+          <b>${{recipient.primaryInsuranceAmountByBracket(1) | number:2}}</b>
+        </td>
+        <td></td>
+      <tr>
+      </tr>
+        <td>
+          Any remaining amount more than
+          ${{secondBendPoint(recipient.indexingYear()) | number: 0}}
+          is multiplied by 15%:
+        </td>
+        <td>
+          <b>
+            ${{recipient.primaryInsuranceAmountByBracket(2) | number:2}}
+          </b>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Total:</td>
+        <td>
+          <b>${{recipient.primaryInsuranceAmountUnadjusted() | number:2}}</b>
+        </td>
+        <td>&nbsp;/ month</td>
+      </tr>
+    </table>  
+
+    <div class=insetTextBox>
+      <h4>Special Rule</h4>
+      <p>
+        You may notice that some of these numbers are short a few pennies.
+        Social Security rounds the Primary Insurance Amount down to the dime,
+        while benefits are rounded down to the dollar.
+      </p>
     </div>
 
-    <!-- canvas width/height must be set explicitly in HTML rather than CSS -->
-    <canvas id="breakpoint-chart-canvas" width=600 height=400>
-      Your browser does not support HTML canvas.
-    </canvas>
-
-    <div class="chart-xlabel">
-      Monthly Indexed Earnings
+    <div ng-if="recipient.shouldAdjustForCOLA()">
+      <p>
+        After attaining age 62, your primary insurance amount will increase
+        annually in proportion to the consumer price index (CPI-W), a measure of
+        inflation. This will continue every year, even after beginning
+        to collect your benefit. These adjustments are called 
+        <u>Cost of Living Adjustments</u> (COLA). Here are the adjustments
+        in past years which affect your current Primary Insurance Amount.
+      </p>
+      <ul>
+        <li ng-repeat="adjustment in recipient.colaAdjustments() | orderBy : adjustment.year">
+          {{adjustment.year}}: <b>{{adjustment.start | number:2}}</b>
+          increased by {{adjustment.cola | number:1 }}% =
+          <b>{{adjustment.end | number:2}}</b>
+        </li>
+      </ul>
     </div>
+
+    <p>
+      This total
+      (<b>${{recipient.primaryInsuranceAmount() | number:2}}</b> / month) is
+      your primary insurance amount. In the chart below, you can see what your
+      primary insurance amount would be if your indexed earnings were to
+      increase. Move your mouse over the chart to see how the primary insurance
+      amount changes.
+    </p>
+
+    <div class="chart-container">
+      <div class="chart-ylabel pia" >
+        <span class="vertical-text">Primary Insurance Amount</span>
+      </div>
+
+      <!-- canvas width/height must be set explicitly in HTML rather than CSS -->
+      <canvas id="breakpoint-chart-canvas" width=600 height=400>
+        Your browser does not support HTML canvas.
+      </canvas>
+
+      <div class="chart-xlabel">
+        Monthly Indexed Earnings
+      </div>
+    </div>
+
   </div>
 
 </div>

--- a/partials/spousal-benefit.html
+++ b/partials/spousal-benefit.html
@@ -1,499 +1,502 @@
-<div id=spousalBenefit class="benefit-estimate fixed-center-column"
+<div ng-show="recipient.isEligible()">
+
+  <div id=spousalBenefit class="benefit-estimate fixed-center-column"
      ng-show="showReport()" ng-cloak>
 
-  <h2 id="nav-spouse">Spouse's Data</h2>
-  <p ng-show="isMarried()">
-    If you are not married, you can hide this section.
-  </p>
-  <p ng-show="!isMarried()">
-    If you are married, you can expand this section.
-  </p>
+    <h2 id="nav-spouse">Spouse's Data</h2>
+    <p ng-show="isMarried()">
+      If you are not married, you can hide this section.
+    </p>
+    <p ng-show="!isMarried()">
+      If you are married, you can expand this section.
+    </p>
 
-  <div class=married-options>
-    <input type=radio ng-model="married.value" value=false id=not-married checked ng-change="refreshSlider()">
-    <label for=not-married class=clickCursor>Not Married</label>
-    <input type=radio ng-model="married.value" value=true id=married ng-change="refreshSlider()">
-    <label for=married class=clickCursor>Married</label>
+    <div class=married-options>
+      <input type=radio ng-model="married.value" value=false id=not-married checked ng-change="refreshSlider()">
+      <label for=not-married class=clickCursor>Not Married</label>
+      <input type=radio ng-model="married.value" value=true id=married ng-change="refreshSlider()">
+      <label for=married class=clickCursor>Married</label>
+    </div>
+
   </div>
 
-</div>
+  <div id=isMarried class="benefit-estimate fixed-center-column"
+      ng-show="showReport() && isMarried()" ng-cloak>
 
-<div id=isMarried class="benefit-estimate fixed-center-column"
-     ng-show="showReport() && isMarried()" ng-cloak>
-
-  <p>
-    In addition to your own <u>primary</u> benefit, married couples may earn
-    <u>spousal</u> Social Security benefits based on each other's records.
-  <p>
-
-  <p>
-    To make it easier to read this section of the report, please enter
-    a name for yourself and for your spouse below. The names need not be real,
-    just something you can use to keep track of who is who in the remainder
-    of the report.
-  </p>
-
-  <p class=nameEntry>
-    Your name: <input type="text"
-                      name="yourName"
-                      ng-model="recipient.name">
-    Spouse's name: <input type="text"
-                          name="spouseName"
-                          ng-model="spouse.name">
-  </p>
-
-  <p>
-    For <span class=names>{{recipient.name}}</span>, we will use the values
-   based on your <u>primary insurance amount</u> of
-    (<b>${{recipient.primaryInsuranceAmountFloored() | number:0}}</b> / month)
-    and your birthdate (<b>{{birth.month}}, {{birth.year}}</b>).
-    For <span class=names>{{spouse.name}}</span>, you must enter these two
-    values.
-  </p>
- 
-  <h3>
-    Enter <span class=names>{{spouse.name}}'s</span>
-    Primary Insurance Amount
-  </h3>
-  <p>
-    You can compute <span class=names>{{spouse.name}}'s</span>
-    <u>primary insurance amount</u> by using this tool once for
-    <span class=names>{{spouse.name}}</span>. Note the value, and then
-    reload using this tool for <span class=names>{{recipient.name}}</span>,
-    entering <span class=names>{{spouse.name}}'s</span>
-    <u>primary insurance amount</u> below.
-  </p>
-
-  <p>
-    <span class=names>{{recipient.name}}'s</span>
-    Primary Insurance Amount:
-    <b>${{recipient.primaryInsuranceAmountFloored() | number:0}}</b> / month
-  </p>
-
-  <p>
-    <span class=names>{{spouse.name}}'s</span>
-    Primary Insurance Amount: <b>$</b>
-    <input type="number" min=0 max={{maxPIA()}} size=6 style="width: 68px"
-           name="spousalPia" cast-to-integer
-           ng-model="spouse.primaryInsuranceAmountValue"
-           ng-change="refreshSlider()">
-    / month
-  </p>
-
-  <h3>Enter <span class=names>{{spouse.name}}'s</span> Birthdate</h3>
-    <div class=agePicker>
-    <div class=picker>
-      <span ng-repeat="day in [1,2,3,4,5,6,7,8]">
-       <input type=radio value="{{day}}" id="spouse-day-{{day}}"
-              class=radio ng-model="spouseBirth.day"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio day" for="spouse-day-{{day}}">
-         <span>{{day}}</span>
-       </label>
-      </span>
-    </div>
-    <div class=picker>
-      <span ng-repeat="day in [9,10,11,12,13,14,15,16]">
-       <input type=radio value="{{day}}" id="spouse-day-{{day}}"
-              class=radio ng-model="spouseBirth.day"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio day" for="spouse-day-{{day}}">
-         <span>{{day}}</span>
-       </label>
-      </span>
-    </div>
-    <div class=picker>
-      <span ng-repeat="day in [17,18,19,20,21,22,23,24]">
-       <input type=radio value="{{day}}" id="spouse-day-{{day}}"
-              class=radio ng-model="spouseBirth.day"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio day" for="spouse-day-{{day}}">
-         <span>{{day}}</span>
-       </label>
-      </span>
-    </div>
-    <div class=picker>
-      <span ng-repeat="day in [25,26,27,28,29,30,31]">
-       <input type=radio value="{{day}}" id="spouse-day-{{day}}"
-              class=radio ng-model="spouseBirth.day"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio day" for="spouse-day-{{day}}">
-         <span>{{day}}</span>
-       </label>
-      </span>
-      <span ng-repeat="day in [32]" class=onlyHidden>
-       <input type=radio value="{{day}}" id="spouse-day-{{day}}"
-              class=radio ng-model="spouseBirth.day"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio day" for="spouse-day-{{day}}">
-         <span>{{day}}</span>
-       </label>
-      </span>
-    </div>
-    <p></p>
-    <div class=picker>
-      <span ng-repeat="month in all_months | limitTo:6">
-       <input type=radio value="{{month}}" id="spouse-month-{{month}}"
-              class=radio ng-model="spouseBirth.month"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio month" for="spouse-month-{{month}}"
-         ><span>{{month}}</span></label>
-      </span>
-    </div>
-    <div class=picker>
-      <span ng-repeat="month in all_months | limitTo:6:6">
-       <input type=radio value="{{month}}" id="spouse-month-{{month}}"
-              class=radio ng-model="spouseBirth.month"
-              ng-change="updateSpouseBirthdate()">
-       <label class="radio month" for="spouse-month-{{month}}"
-         ><span>{{month}}</span></label>
-      </span>
-    </div>
-    <p></p>
-    <div class=picker>
-      <span ng-repeat="year in allAgeYears()">
-        <input type=radio id="spouse-year-{{year}}" value="{{year}}"
-               class=radio ng-model="spouseBirth.year"
-               ng-change="updateSpouseBirthdate()">
-        <label class="radio year" for="spouse-year-{{year}}"
-          ><span>{{year}}</span></label>
-      </span>
-    </div>
-  </div>
-  <br class=clear>
-
-  <p class=birthdate>
-    <span class=names>{{spouse.name}}</span> was born on
-    <b>{{spouseBirth.month}} {{spouseBirth.day}}, {{spouseBirth.year}}</b>.
-  </p>
-
-  <h2 id="nav-spouse-benefit">Spousal Benefit</h2>
-  <h3>{{higherEarner().name}}</h3>
-  <p>
-    <span class=names>{{higherEarner().name}}</span> has the higher
-    Primary Insurance Amount, which means that
-    <span class=names>{{higherEarner().name}}</span> is not eligible for
-    any spousal benefits. This is because the benefit one receives is
-    always the larger of the personal or spousal benefit. Because
-    <span class=names>{{higherEarner().name}}'s</span> own benefit is 
-    larger than <span class=names>{{higherEarner().name}}'s</span>
-    spousal benefit, <span class=names>{{higherEarner().name}}</span> does not
-    get any spousal benefit.
-  </p>
-
-  <h3>{{lowerEarner().name}}</h3>
-  <div ng-show="!isSpousalBenefit()">
-  <p>
-    <span class=names>{{lowerEarner().name}}</span> has the lower
-    Primary Insurance Amount, therefore
-    <span class=names>{{lowerEarner().name}}</span> may be eligible to
-    receive a <u>spousal benefit</u> based on
-    <span class=names>{{higherEarner().name}}'s</span> personal benefit.
-    However, in this case, <span class=names>{{lowerEarner().name}}</span>
-    will not receive a <u>spousal benefit</u> as 
-    <span class=names>{{lowerEarner().name}}'s</span> own personal benefit
-    is more than the spousal benefit earned on
-    <span class=names>{{higherEarner().name}}'s</span> Social Security record.
-  </p>
-  </div><!-- !isSpousalBenefit() -->
-
-  <div ng-show="isSpousalBenefit()">
-  <p>
-    <span class=names>{{lowerEarner().name}}</span> has the lower
-    Primary Insurance Amount, therefore
-    <span class=names>{{lowerEarner().name}}</span> may be eligible to
-    receive a <u>spousal benefit</u> based on
-    <span class=names>{{higherEarner().name}}'s</span> personal benefit.
-  <p>
- 
-  <p>
-    <!-- TODO: Compute NRA here. -->
-    Let's start by calculating
-    <span class=names>{{lowerEarner().name}}'s</span> spousal benefit at
-    <span class=names>{{lowerEarner().name}}'s</span> <u>normal retirement
-    age</u>: 50% of <span class=names>{{higherEarner().name}}'s</span> personal
-    benefit minus <span class=names>{{lowerEarner().name}}'s</span> own
-    personal benefit.
-  </p>
-  </div><!-- isSpousalBenefit() -->
-
-  <ul>
-    <li>
-      <span class=names>{{lowerEarner().name}}'s</span> Personal Benefit:
-      <b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>
-    </li>
-
-    <li>
-      <span class=names>{{higherEarner().name}}'s</span> Personal Benefit:
-      <b>${{higherEarner().primaryInsuranceAmountFloored() | number:0}}</b>
-    </li>
-  </ul>
-
-  <p>
-    <span class=names>{{lowerEarner().name}}'s</span> Spousal Benefit:
-    ( <b>${{higherEarner().primaryInsuranceAmountFloored() | number:0}}</b>
-      <span class=multsymbol>x</span>
-      50%
-    ) - <b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>
-    <span class=multsymbol>=</span> <b>${{spousalBenefit() | number:0}}</b>
-  </pi>
-
-  <p ng-show="isSpousalBenefit()">
-    This spousal benefit (<b>${{spousalBenefit() | number:0}}</b>) is the amount
-    <span class=names>{{lowerEarner().name}}</span> will receive in addition to
-    <span class=names>{{lowerEarner().name}}'s</span> own personal benefit of
-    <b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>.
-  </p>
-
-  <div ng-show="!isSpousalBenefit()">
-  <h3>Final Conclusion</h3>
-  <p>
-    Since neither <span class=names>{{recipient.name}}</span> nor
-    <span class=names>{{spouse.name}}</span> are eligible for a spousal benefit,
-    the date each person selects to begin recieving benefits has no effect on
-    the total benefit of the other person.
-
-    Use the calculations above for <u>Early and Delayed Retirement</u> to make
-    a decision about the best time for each person to begin retirement benefits.
-  <p>
-  </div><!-- !isSpousalBenefit() -->
-
-  <div ng-show="isSpousalBenefit() && lowerEarner().primaryInsuranceAmountFloored() > 0">
-    <div style="width: 100%">
-      <div style="width: {{Math.min(75, spousalBenefitFraction())}}%; text-align: center; float:left; white-space:nowrap;">
-        Personal (<b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>)
-      </div>
-      <div style="width: {{Math.max(25, 100 - spousalBenefitFraction())}}%; text-align: center; float:left; white-space:nowrap;">
-        Spousal (<b>${{spousalBenefit() | number:0}}</b>)
-      </div>
-    </div>
-    <br style="clear: both">
-    <div style="width: 100%; background-color: #0db9f0; height: 20px; border: 1px solid #666;">
-      <div style="width: {{spousalBenefitFraction()}}%; background-color: #5cb85c; height: 100%; border-right: 1px solid #666">
-      </div>
-    </div>
-    <img style="width: 100%; max-height: 30px; padding-top: 2px;" src="static/horiz-curly.png">
-    <div style="width: 100%; text-align: center;">
-      Total: <b>${{spousalMax() | number:0}}</b>
-    </div>
-  </div>
-
-  <p>
-    Note that <span class=names>{{lowerEarner().name}}'s</span> <i>total</i>
-    benefit (combined personal and spousal benefit) is equal to 50% of
-    <span class=names>{{higherEarner().name}}'s</span> <i>personal</i> benefit,
-    regardless of
-    <span class=names>{{lowerEarner().name}}'s</span> <i>personal</i> benefit.
-    This is the case, as long as
-    <span class=names>{{lowerEarner().name}}'s</span>
-    personal benefit is less than 50% of 
-    <span class=names>{{higherEarner().name}}'s</span> personal benefit.
-  </p>     
-
-  <h2 id="nav-early-delayed-spouse">Early and Delayed Spouse Retirement</h2>
-  <p>
-    The personal benefit section at the top of this document describes how
-    personal benefits are adjusted when beginning benefits earlier than the
-    Normal Retirement Age (NRA) or alternately, delaying past NRA.
-  </p>
-  <p>
-    Spousal benefits do not increase if claimed after Normal Retirement Age,
-    but are reduced before Normal Retirement Age 
-    (<b>{{lowerEarner().normalRetirementDate.monthFullName()}}
-         {{recipient.normalRetirementDate.year()}}</b>) at the same rate as
-    personal benefits.
-  </p>
-  <div class=insetTextBox ng-show="spouseBirth.day === 1 && birth.day !== 1">
-    <h4>Special Rule</h4>
     <p>
-      The month <span class=names>{{spouse.name}}</span> reaches specific ages
-      may seem "off by one" from what you entered. Social Security follows
-      English common law that finds that a person "attains" an age on the day
-      before the birthday. Because <span class=names>{{spouse.name}}</span> was
-      born on the first of the month, this means that
-      <span class=names>{{spouse.name}}</span> attains age
-			<b>{{spouse.exampleAge().age}}</b> on
-      <b>{{spouse.exampleAge().month}} {{spouse.exampleAge().day}},
-         {{spouse.exampleAge().year}}</b>.
-    </p>
-  </div>
-  <p>
-    If <span class=names>{{lowerEarner().name}}</span> begins spousal
-    benefits before Normal Retirement Age
-    (<b>{{lowerEarner().normalRetirementDate.monthFullName()}} 
-         {{recipient.normalRetirementDate.year()}}</b>),
-    the spousal benefit will be <u>permanently</u> <i>reduced</i> per year you
-    start early by:
-  </p>
-  <ul>
-    <li><b>6.67%</b> per year if starting AFTER
-      <b>{{lowerEarner().normalRetirement.ageYears - 3}} years and 
-         {{lowerEarner().normalRetirement.ageMonths}} months</b>
-      (<b>{{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).monthFullName()}}
-          {{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).year()}}</b>)
-    </li>
-    <li><b>5.00%</b> per year if starting BEFORE
-      <b>{{lowerEarner().normalRetirement.ageYears - 3}} years and 
-         {{lowerEarner().normalRetirement.ageMonths}} months</b>
-      (<b>{{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).monthFullName()}}
-          {{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).year()}}</b>)
-    </li>
-  </ul>
+      In addition to your own <u>primary</u> benefit, married couples may earn
+      <u>spousal</u> Social Security benefits based on each other's records.
+    <p>
 
-  <p>
-    The date that <span class=names>{{lowerEarner().name}}'s</span> spousal
-    benefits start is the later of either
-    <span class=names>{{lowerEarner().name}}</span>'s benefits start date or
-    <span class=names>{{higherEarner().name}}</span>'s benefits start date. This
-    can lead to different reduction multipliers for the personal and spousal
-    benefits.
-  </p>
-
-  <p>
-  There are two rules that apply to the date that
-  <span class=names>{{lowerEarner().name}}</span> can begin taking benefits:
-  <ul>
-    <li>
-      <span class=names>{{lowerEarner().name}}</span> is not eligible to
-      begin collecting spousal benefits until
-      <span class=names>{{higherEarner().name}}</span> begins collecting
-      <span class=names>{{higherEarner().name}}'s</span> primary benefit.
-    </li>
-    <li>
-      <span class=names>{{lowerEarner().name}}</span> must elect to collect
-      all of the benefits <span class=names>{{lowerEarner().name}}</span> is
-      eligible for, or none at all.
-      For example, <span class=names>{{lowerEarner().name}}</span> cannot
-      choose to delay personal benefits but collect spousal benefits if
-      eligible for both benefits. This is known as the <u>deeming</u> rule:
-      you are deemed to be filing for all benefits you are eligible for once
-      one decides to file.
-    </li>
-  </ul>
-  </p>
-
-  <h2 id="nav-early-delayed-combined">Early and Delayed Combined Retirement</h2>
-  <p>
-    You can see how the starting benefit dates for both spouses will affect
-    affect the final monthly benefits, using the sliders below.
-  </p>
-
-  <div id=spousal-box>
-    <canvas id=spousal-chart-canvas width=620 height=620></canvas>
-    <p style="margin-bottom: 2px; z-index: 2">
-      <b><span class=names>{{higherEarner().name}}</span> starts benefits
-        at age:</b>
+    <p>
+      To make it easier to read this section of the report, please enter
+      a name for yourself and for your spouse below. The names need not be real,
+      just something you can use to keep track of who is who in the remainder
+      of the report.
     </p>
 
-    <!-- See http://angular-slider.github.io/angularjs-slider/ -->
-    <div class="force-ticks-above" id="higherEarnerSlider">
-      <rzslider rz-slider-model="higherEarnerSlider.value"
-                rz-slider-options="higherEarnerSlider.options"
+    <p class=nameEntry>
+      Your name: <input type="text"
+                        name="yourName"
+                        ng-model="recipient.name">
+      Spouse's name: <input type="text"
+                            name="spouseName"
+                            ng-model="spouse.name">
+    </p>
+
+    <p>
+      For <span class=names>{{recipient.name}}</span>, we will use the values
+    based on your <u>primary insurance amount</u> of
+      (<b>${{recipient.primaryInsuranceAmountFloored() | number:0}}</b> / month)
+      and your birthdate (<b>{{birth.month}}, {{birth.year}}</b>).
+      For <span class=names>{{spouse.name}}</span>, you must enter these two
+      values.
+    </p>
+  
+    <h3>
+      Enter <span class=names>{{spouse.name}}'s</span>
+      Primary Insurance Amount
+    </h3>
+    <p>
+      You can compute <span class=names>{{spouse.name}}'s</span>
+      <u>primary insurance amount</u> by using this tool once for
+      <span class=names>{{spouse.name}}</span>. Note the value, and then
+      reload using this tool for <span class=names>{{recipient.name}}</span>,
+      entering <span class=names>{{spouse.name}}'s</span>
+      <u>primary insurance amount</u> below.
+    </p>
+
+    <p>
+      <span class=names>{{recipient.name}}'s</span>
+      Primary Insurance Amount:
+      <b>${{recipient.primaryInsuranceAmountFloored() | number:0}}</b> / month
+    </p>
+
+    <p>
+      <span class=names>{{spouse.name}}'s</span>
+      Primary Insurance Amount: <b>$</b>
+      <input type="number" min=0 max={{maxPIA()}} size=6 style="width: 68px"
+            name="spousalPia" cast-to-integer
+            ng-model="spouse.primaryInsuranceAmountValue"
+            ng-change="refreshSlider()">
+      / month
+    </p>
+
+    <h3>Enter <span class=names>{{spouse.name}}'s</span> Birthdate</h3>
+      <div class=agePicker>
+      <div class=picker>
+        <span ng-repeat="day in [1,2,3,4,5,6,7,8]">
+        <input type=radio value="{{day}}" id="spouse-day-{{day}}"
+                class=radio ng-model="spouseBirth.day"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio day" for="spouse-day-{{day}}">
+          <span>{{day}}</span>
+        </label>
+        </span>
+      </div>
+      <div class=picker>
+        <span ng-repeat="day in [9,10,11,12,13,14,15,16]">
+        <input type=radio value="{{day}}" id="spouse-day-{{day}}"
+                class=radio ng-model="spouseBirth.day"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio day" for="spouse-day-{{day}}">
+          <span>{{day}}</span>
+        </label>
+        </span>
+      </div>
+      <div class=picker>
+        <span ng-repeat="day in [17,18,19,20,21,22,23,24]">
+        <input type=radio value="{{day}}" id="spouse-day-{{day}}"
+                class=radio ng-model="spouseBirth.day"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio day" for="spouse-day-{{day}}">
+          <span>{{day}}</span>
+        </label>
+        </span>
+      </div>
+      <div class=picker>
+        <span ng-repeat="day in [25,26,27,28,29,30,31]">
+        <input type=radio value="{{day}}" id="spouse-day-{{day}}"
+                class=radio ng-model="spouseBirth.day"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio day" for="spouse-day-{{day}}">
+          <span>{{day}}</span>
+        </label>
+        </span>
+        <span ng-repeat="day in [32]" class=onlyHidden>
+        <input type=radio value="{{day}}" id="spouse-day-{{day}}"
+                class=radio ng-model="spouseBirth.day"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio day" for="spouse-day-{{day}}">
+          <span>{{day}}</span>
+        </label>
+        </span>
+      </div>
+      <p></p>
+      <div class=picker>
+        <span ng-repeat="month in all_months | limitTo:6">
+        <input type=radio value="{{month}}" id="spouse-month-{{month}}"
+                class=radio ng-model="spouseBirth.month"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio month" for="spouse-month-{{month}}"
+          ><span>{{month}}</span></label>
+        </span>
+      </div>
+      <div class=picker>
+        <span ng-repeat="month in all_months | limitTo:6:6">
+        <input type=radio value="{{month}}" id="spouse-month-{{month}}"
+                class=radio ng-model="spouseBirth.month"
+                ng-change="updateSpouseBirthdate()">
+        <label class="radio month" for="spouse-month-{{month}}"
+          ><span>{{month}}</span></label>
+        </span>
+      </div>
+      <p></p>
+      <div class=picker>
+        <span ng-repeat="year in allAgeYears()">
+          <input type=radio id="spouse-year-{{year}}" value="{{year}}"
+                class=radio ng-model="spouseBirth.year"
+                ng-change="updateSpouseBirthdate()">
+          <label class="radio year" for="spouse-year-{{year}}"
+            ><span>{{year}}</span></label>
+        </span>
+      </div>
+    </div>
+    <br class=clear>
+
+    <p class=birthdate>
+      <span class=names>{{spouse.name}}</span> was born on
+      <b>{{spouseBirth.month}} {{spouseBirth.day}}, {{spouseBirth.year}}</b>.
+    </p>
+
+    <h2 id="nav-spouse-benefit">Spousal Benefit</h2>
+    <h3>{{higherEarner().name}}</h3>
+    <p>
+      <span class=names>{{higherEarner().name}}</span> has the higher
+      Primary Insurance Amount, which means that
+      <span class=names>{{higherEarner().name}}</span> is not eligible for
+      any spousal benefits. This is because the benefit one receives is
+      always the larger of the personal or spousal benefit. Because
+      <span class=names>{{higherEarner().name}}'s</span> own benefit is 
+      larger than <span class=names>{{higherEarner().name}}'s</span>
+      spousal benefit, <span class=names>{{higherEarner().name}}</span> does not
+      get any spousal benefit.
+    </p>
+
+    <h3>{{lowerEarner().name}}</h3>
+    <div ng-show="!isSpousalBenefit()">
+    <p>
+      <span class=names>{{lowerEarner().name}}</span> has the lower
+      Primary Insurance Amount, therefore
+      <span class=names>{{lowerEarner().name}}</span> may be eligible to
+      receive a <u>spousal benefit</u> based on
+      <span class=names>{{higherEarner().name}}'s</span> personal benefit.
+      However, in this case, <span class=names>{{lowerEarner().name}}</span>
+      will not receive a <u>spousal benefit</u> as 
+      <span class=names>{{lowerEarner().name}}'s</span> own personal benefit
+      is more than the spousal benefit earned on
+      <span class=names>{{higherEarner().name}}'s</span> Social Security record.
+    </p>
+    </div><!-- !isSpousalBenefit() -->
+
+    <div ng-show="isSpousalBenefit()">
+    <p>
+      <span class=names>{{lowerEarner().name}}</span> has the lower
+      Primary Insurance Amount, therefore
+      <span class=names>{{lowerEarner().name}}</span> may be eligible to
+      receive a <u>spousal benefit</u> based on
+      <span class=names>{{higherEarner().name}}'s</span> personal benefit.
+    <p>
+  
+    <p>
+      <!-- TODO: Compute NRA here. -->
+      Let's start by calculating
+      <span class=names>{{lowerEarner().name}}'s</span> spousal benefit at
+      <span class=names>{{lowerEarner().name}}'s</span> <u>normal retirement
+      age</u>: 50% of <span class=names>{{higherEarner().name}}'s</span> personal
+      benefit minus <span class=names>{{lowerEarner().name}}'s</span> own
+      personal benefit.
+    </p>
+    </div><!-- isSpousalBenefit() -->
+
+    <ul>
+      <li>
+        <span class=names>{{lowerEarner().name}}'s</span> Personal Benefit:
+        <b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>
+      </li>
+
+      <li>
+        <span class=names>{{higherEarner().name}}'s</span> Personal Benefit:
+        <b>${{higherEarner().primaryInsuranceAmountFloored() | number:0}}</b>
+      </li>
+    </ul>
+
+    <p>
+      <span class=names>{{lowerEarner().name}}'s</span> Spousal Benefit:
+      ( <b>${{higherEarner().primaryInsuranceAmountFloored() | number:0}}</b>
+        <span class=multsymbol>x</span>
+        50%
+      ) - <b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>
+      <span class=multsymbol>=</span> <b>${{spousalBenefit() | number:0}}</b>
+    </pi>
+
+    <p ng-show="isSpousalBenefit()">
+      This spousal benefit (<b>${{spousalBenefit() | number:0}}</b>) is the amount
+      <span class=names>{{lowerEarner().name}}</span> will receive in addition to
+      <span class=names>{{lowerEarner().name}}'s</span> own personal benefit of
+      <b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>.
+    </p>
+
+    <div ng-show="!isSpousalBenefit()">
+    <h3>Final Conclusion</h3>
+    <p>
+      Since neither <span class=names>{{recipient.name}}</span> nor
+      <span class=names>{{spouse.name}}</span> are eligible for a spousal benefit,
+      the date each person selects to begin recieving benefits has no effect on
+      the total benefit of the other person.
+
+      Use the calculations above for <u>Early and Delayed Retirement</u> to make
+      a decision about the best time for each person to begin retirement benefits.
+    <p>
+    </div><!-- !isSpousalBenefit() -->
+
+    <div ng-show="isSpousalBenefit() && lowerEarner().primaryInsuranceAmountFloored() > 0">
+      <div style="width: 100%">
+        <div style="width: {{Math.min(75, spousalBenefitFraction())}}%; text-align: center; float:left; white-space:nowrap;">
+          Personal (<b>${{lowerEarner().primaryInsuranceAmountFloored() | number:0}}</b>)
+        </div>
+        <div style="width: {{Math.max(25, 100 - spousalBenefitFraction())}}%; text-align: center; float:left; white-space:nowrap;">
+          Spousal (<b>${{spousalBenefit() | number:0}}</b>)
+        </div>
+      </div>
+      <br style="clear: both">
+      <div style="width: 100%; background-color: #0db9f0; height: 20px; border: 1px solid #666;">
+        <div style="width: {{spousalBenefitFraction()}}%; background-color: #5cb85c; height: 100%; border-right: 1px solid #666">
+        </div>
+      </div>
+      <img style="width: 100%; max-height: 30px; padding-top: 2px;" src="static/horiz-curly.png">
+      <div style="width: 100%; text-align: center;">
+        Total: <b>${{spousalMax() | number:0}}</b>
+      </div>
+    </div>
+
+    <p>
+      Note that <span class=names>{{lowerEarner().name}}'s</span> <i>total</i>
+      benefit (combined personal and spousal benefit) is equal to 50% of
+      <span class=names>{{higherEarner().name}}'s</span> <i>personal</i> benefit,
+      regardless of
+      <span class=names>{{lowerEarner().name}}'s</span> <i>personal</i> benefit.
+      This is the case, as long as
+      <span class=names>{{lowerEarner().name}}'s</span>
+      personal benefit is less than 50% of 
+      <span class=names>{{higherEarner().name}}'s</span> personal benefit.
+    </p>     
+
+    <h2 id="nav-early-delayed-spouse">Early and Delayed Spouse Retirement</h2>
+    <p>
+      The personal benefit section at the top of this document describes how
+      personal benefits are adjusted when beginning benefits earlier than the
+      Normal Retirement Age (NRA) or alternately, delaying past NRA.
+    </p>
+    <p>
+      Spousal benefits do not increase if claimed after Normal Retirement Age,
+      but are reduced before Normal Retirement Age 
+      (<b>{{lowerEarner().normalRetirementDate.monthFullName()}}
+          {{recipient.normalRetirementDate.year()}}</b>) at the same rate as
+      personal benefits.
+    </p>
+    <div class=insetTextBox ng-show="spouseBirth.day === 1 && birth.day !== 1">
+      <h4>Special Rule</h4>
+      <p>
+        The month <span class=names>{{spouse.name}}</span> reaches specific ages
+        may seem "off by one" from what you entered. Social Security follows
+        English common law that finds that a person "attains" an age on the day
+        before the birthday. Because <span class=names>{{spouse.name}}</span> was
+        born on the first of the month, this means that
+        <span class=names>{{spouse.name}}</span> attains age
+        <b>{{spouse.exampleAge().age}}</b> on
+        <b>{{spouse.exampleAge().month}} {{spouse.exampleAge().day}},
+          {{spouse.exampleAge().year}}</b>.
+      </p>
+    </div>
+    <p>
+      If <span class=names>{{lowerEarner().name}}</span> begins spousal
+      benefits before Normal Retirement Age
+      (<b>{{lowerEarner().normalRetirementDate.monthFullName()}} 
+          {{recipient.normalRetirementDate.year()}}</b>),
+      the spousal benefit will be <u>permanently</u> <i>reduced</i> per year you
+      start early by:
+    </p>
+    <ul>
+      <li><b>6.67%</b> per year if starting AFTER
+        <b>{{lowerEarner().normalRetirement.ageYears - 3}} years and 
+          {{lowerEarner().normalRetirement.ageMonths}} months</b>
+        (<b>{{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).monthFullName()}}
+            {{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).year()}}</b>)
+      </li>
+      <li><b>5.00%</b> per year if starting BEFORE
+        <b>{{lowerEarner().normalRetirement.ageYears - 3}} years and 
+          {{lowerEarner().normalRetirement.ageMonths}} months</b>
+        (<b>{{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).monthFullName()}}
+            {{lowerEarner().dateAtYearsOld(lowerEarner().normalRetirement.ageYears - 3).year()}}</b>)
+      </li>
+    </ul>
+
+    <p>
+      The date that <span class=names>{{lowerEarner().name}}'s</span> spousal
+      benefits start is the later of either
+      <span class=names>{{lowerEarner().name}}</span>'s benefits start date or
+      <span class=names>{{higherEarner().name}}</span>'s benefits start date. This
+      can lead to different reduction multipliers for the personal and spousal
+      benefits.
+    </p>
+
+    <p>
+    There are two rules that apply to the date that
+    <span class=names>{{lowerEarner().name}}</span> can begin taking benefits:
+    <ul>
+      <li>
+        <span class=names>{{lowerEarner().name}}</span> is not eligible to
+        begin collecting spousal benefits until
+        <span class=names>{{higherEarner().name}}</span> begins collecting
+        <span class=names>{{higherEarner().name}}'s</span> primary benefit.
+      </li>
+      <li>
+        <span class=names>{{lowerEarner().name}}</span> must elect to collect
+        all of the benefits <span class=names>{{lowerEarner().name}}</span> is
+        eligible for, or none at all.
+        For example, <span class=names>{{lowerEarner().name}}</span> cannot
+        choose to delay personal benefits but collect spousal benefits if
+        eligible for both benefits. This is known as the <u>deeming</u> rule:
+        you are deemed to be filing for all benefits you are eligible for once
+        one decides to file.
+      </li>
+    </ul>
+    </p>
+
+    <h2 id="nav-early-delayed-combined">Early and Delayed Combined Retirement</h2>
+    <p>
+      You can see how the starting benefit dates for both spouses will affect
+      affect the final monthly benefits, using the sliders below.
+    </p>
+
+    <div id=spousal-box>
+      <canvas id=spousal-chart-canvas width=620 height=620></canvas>
+      <p style="margin-bottom: 2px; z-index: 2">
+        <b><span class=names>{{higherEarner().name}}</span> starts benefits
+          at age:</b>
+      </p>
+
+      <!-- See http://angular-slider.github.io/angularjs-slider/ -->
+      <div class="force-ticks-above" id="higherEarnerSlider">
+        <rzslider rz-slider-model="higherEarnerSlider.value"
+                  rz-slider-options="higherEarnerSlider.options"
+                  class="with-legend sliderZ"></rzslider>
+      </div>
+
+      <p style="margin-bottom: 2px; z-index: 2">
+        <b style="background-color: white">
+          <span class=names>{{lowerEarner().name}}</span> starts benefits
+          at age:
+        </b>
+      </p>
+
+      <!-- See http://angular-slider.github.io/angularjs-slider/ -->
+      <div class="force-ticks-above" id="lowerEarnerSlider">
+      <rzslider rz-slider-model="lowerEarnerSlider.value"
+                rz-slider-options="lowerEarnerSlider.options"
                 class="with-legend sliderZ"></rzslider>
+      </div>
     </div>
 
-    <p style="margin-bottom: 2px; z-index: 2">
-      <b style="background-color: white">
-        <span class=names>{{lowerEarner().name}}</span> starts benefits
-        at age:
-      </b>
-    </p>
+    <!-- Div which positions text at the correct y-position below the spousal
+      canvas element -->
+    <div style="height: 436px;"></div>
 
-    <!-- See http://angular-slider.github.io/angularjs-slider/ -->
-    <div class="force-ticks-above" id="lowerEarnerSlider">
-    <rzslider rz-slider-model="lowerEarnerSlider.value"
-              rz-slider-options="lowerEarnerSlider.options"
-              class="with-legend sliderZ"></rzslider>
+    <div ng-show="spousalSelection.show" class=totalSpousalAtDate> 
+      <table class=combinedBenefit>
+        <tr>
+          <td colspan=3>
+            <b>In {{spousalSelection.dateText}},</b>
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <td>
+            <span class=higherEarner>{{higherEarner().name}}'s Benefit</span>:
+          </td><td>
+            ${{spousalSelection.higherEarnerBenefit | number:0}}
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <td>
+            <span class=lowerEarner>{{lowerEarner().name}}'s Benefit</span>:
+          </td><td>
+            ${{spousalSelection.lowerEarnerBenefit | number:0}}
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+          <td>
+            <b>Total Benefit</b>:
+          </td><td>
+            ${{(spousalSelection.higherEarnerBenefit + 
+                spousalSelection.lowerEarnerBenefit) | number:0}}
+          </td>
+        </tr>
+      </table>
     </div>
-  </div>
 
-  <!-- Div which positions text at the correct y-position below the spousal
-    canvas element -->
-  <div style="height: 436px;"></div>
+    <div class=insetTextBox ng-show="spouseBirth.day > 2 && birth.day <= 2">
+      <h4>Special Rule</h4>
+      <p>
+        You may find it oddly specific that the earliest 
+        <span class=names>{{spouse.name}}</span> can actually
+        begin benefits is at age 62 and 1 month. Benefit eligibility
+        is calculated based on the first month that you are a particular age
+        throughout the <u>entire</u> month. For most, this is the month
+        <i>after</i> their birthday.
+      </p>
+      <p>
+        For example, the first month that <span class=names>{{spouse.name}}</span>
+        is <b>{{spouse.exampleAge().age}}</b> throughout the <u>entire</u> month is
+        <b>{{followingMonth(spouse.exampleAge()).month}}
+          {{followingMonth(spouse.exampleAge()).year}}</b>.
+      </p>
+    </div>
 
-  <div ng-show="spousalSelection.show" class=totalSpousalAtDate> 
-    <table class=combinedBenefit>
-      <tr>
-        <td colspan=3>
-          <b>In {{spousalSelection.dateText}},</b>
-        </td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>
-          <span class=higherEarner>{{higherEarner().name}}'s Benefit</span>:
-        </td><td>
-          ${{spousalSelection.higherEarnerBenefit | number:0}}
-        </td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>
-          <span class=lowerEarner>{{lowerEarner().name}}'s Benefit</span>:
-        </td><td>
-          ${{spousalSelection.lowerEarnerBenefit | number:0}}
-        </td>
-      </tr>
-      <tr>
-        <td></td>
-        <td>
-          <b>Total Benefit</b>:
-        </td><td>
-          ${{(spousalSelection.higherEarnerBenefit + 
-              spousalSelection.lowerEarnerBenefit) | number:0}}
-        </td>
-      </tr>
-    </table>
-  </div>
-
-  <div class=insetTextBox ng-show="spouseBirth.day > 2 && birth.day <= 2">
-    <h4>Special Rule</h4>
+    <h2 id="nav-survivor">Survivor Benefits</h2>
     <p>
-      You may find it oddly specific that the earliest 
-      <span class=names>{{spouse.name}}</span> can actually
-      begin benefits is at age 62 and 1 month. Benefit eligibility
-      is calculated based on the first month that you are a particular age
-      throughout the <u>entire</u> month. For most, this is the month
-      <i>after</i> their birthday.
+      Upon the death of <span class=names>{{higherEarner().name}}</span>,
+      <span class=names>{{lowerEarner().name}}</span> will receive Survivor
+      Benefits. Survivor benefits for
+      <span class=names>{{lowerEarner().name}}</span> will replace
+      <span class=names>{{lowerEarner().name}}</span>'s own benefit, if
+      the Survivor Benefit is larger.
     </p>
     <p>
-      For example, the first month that <span class=names>{{spouse.name}}</span>
-      is <b>{{spouse.exampleAge().age}}</b> throughout the <u>entire</u> month is
-      <b>{{followingMonth(spouse.exampleAge()).month}}
-         {{followingMonth(spouse.exampleAge()).year}}</b>.
+      The amount of the Survivor Benefit is typically the amount of
+      <span class=names>{{higherEarner().name}}</span>'s personal benefit at the
+      date of death. This will be reduced if
+      <span class=names>{{lowerEarner().name}}</span> begins collecting the
+      Survivor Benefit before <span class=names>{{lowerEarner().name}}</span>'s
+      Normal Retirement Age
+      (<b>{{lowerEarner().normalRetirementDate.monthFullName()}} 
+          {{recipient.normalRetirementDate.year()}}</b>).
     </p>
+    <p>
+      More detail on Survivor Benefits can be found at
+      <a href="https://www.ssa.gov/planners/survivors/"
+        target="_blank">ssa.gov/planners/survivors</a>.
+    </p>
+    <p>
+      The value of the Survivor Benefit may be something to consider when
+      choosing initial benefit dates for both spouses, but especially 
+      <span class=names>{{higherEarner().name}}</span>. Delaying current 
+      benefits can have an effect similar to life insurance by providing a higher
+      Survivor Benefit which will persist throughout the surviving spouse's life.
+    </p>
+    </div><!-- isSpousalBenefit() -->
   </div>
-
-  <h2 id="nav-survivor">Survivor Benefits</h2>
-  <p>
-    Upon the death of <span class=names>{{higherEarner().name}}</span>,
-    <span class=names>{{lowerEarner().name}}</span> will receive Survivor
-    Benefits. Survivor benefits for
-    <span class=names>{{lowerEarner().name}}</span> will replace
-    <span class=names>{{lowerEarner().name}}</span>'s own benefit, if
-    the Survivor Benefit is larger.
-  </p>
-  <p>
-    The amount of the Survivor Benefit is typically the amount of
-    <span class=names>{{higherEarner().name}}</span>'s personal benefit at the
-    date of death. This will be reduced if
-    <span class=names>{{lowerEarner().name}}</span> begins collecting the
-    Survivor Benefit before <span class=names>{{lowerEarner().name}}</span>'s
-    Normal Retirement Age
-    (<b>{{lowerEarner().normalRetirementDate.monthFullName()}} 
-         {{recipient.normalRetirementDate.year()}}</b>).
-  </p>
-  <p>
-    More detail on Survivor Benefits can be found at
-    <a href="https://www.ssa.gov/planners/survivors/"
-      target="_blank">ssa.gov/planners/survivors</a>.
-  </p>
-  <p>
-    The value of the Survivor Benefit may be something to consider when
-    choosing initial benefit dates for both spouses, but especially 
-    <span class=names>{{higherEarner().name}}</span>. Delaying current 
-    benefits can have an effect similar to life insurance by providing a higher
-    Survivor Benefit which will persist throughout the surviving spouse's life.
-  </p>
-  </div><!-- isSpousalBenefit() -->
-</div>
+</div><!-- recipient.isEligible() -->

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,58 @@
  * regularly.
  */
 
+ // The number of credits needed to qualify for retirement benefits
+ // https://www.ssa.gov/planners/credits.html
+const MAX_CREDITS = 40
+
+ // Earnings required for one quarter of coverage
+ // https://www.ssa.gov/OACT/COLA/QC.html
+
+const EARNINGS_PER_CREDIT = {
+  1978:	250,
+  1979:	260,
+  1980:	290,
+  1981:	310,
+  1982:	340,
+  1983:	370,
+  1984:	390,
+  1985:	410,
+  1986:	440,
+  1987:	460,
+  1988:	470,
+  1989:	500,
+  1990:	520,
+  1991:	540,
+  1992:	570,
+  1993:	590,
+  1994:	620,
+  1995:	630,
+  1996:	640,
+  1997:	670,
+  1998:	700,
+  1999:	740,
+  2000:	780,
+  2001:	830,
+  2002:	870,
+  2003:	890,
+  2004:	900,
+  2005:	920,
+  2006:	970,
+  2007:	1000,
+  2008:	1050,
+  2009:	1090,
+  2010:	1120,
+  2011:	1120,
+  2012:	1130,
+  2013:	1160,
+  2014:	1200,
+  2015:	1220,
+  2016:	1260,
+  2017:	1300,
+  2018:	1320,
+  2019:	1360,
+};
+
 // Maximum earnings in each year which contribute to social security benefits.
 // https://www.ssa.gov/OACT/COLA/cbb.html
 const MAXIMUM_EARNINGS = {

--- a/src/recipient.js
+++ b/src/recipient.js
@@ -65,6 +65,9 @@ function Recipient(name) {
   // total credits = earnedCredits + planned credits
   this.totalCredits = 0;
 
+  // Have earnings before 1978
+  this.earningsBefore1978 = false;
+
   // Additional years of work needed, -1 means not earning enough to get a credit
   this.neededYears = -1;
 
@@ -259,6 +262,10 @@ Recipient.prototype.processIndexedEarnings_ = function() {
   var allIndexedValues = [];
   for (var i = 0; i < this.earningsRecords.length; ++i) {
     var earningRecord = this.earningsRecords[i];
+
+    if (earningRecord.year < 1978) {
+      this.earningsBefore1978 = true;
+    }
 
     earningRecord.earningsCap = MAXIMUM_EARNINGS[earningRecord.year];
 

--- a/src/recipient.js
+++ b/src/recipient.js
@@ -10,6 +10,7 @@ function EarningRecord() {
   this.earningsCap = -1;
   this.indexFactor = -1;
   this.isTopEarningsYear = null;
+  this.credits = 0;
 }
       
 /**
@@ -54,6 +55,21 @@ function Recipient(name) {
   // This value is the your average monthly earnings (floored) over the <= 35
   // years of earning history: total earnings / 35 / 12.
   this.monthlyIndexedEarnings = 0;
+
+  // The total credits earned, maximum of 40
+  this.earnedCredits = 0;
+
+  // The total of credits that would be earned in the planned work
+  this.plannedCredits = 0;
+
+  // total credits = earnedCredits + planned credits
+  this.totalCredits = 0;
+
+  // Additional years of work needed, -1 means not earning enough to get a credit
+  this.neededYears = -1;
+
+  // Last year of credits needed to get to 40
+  this.lastYearOfEarnedCredits = 0;
 
   // This is the monthly primary insurance amount, calculated either from
   // monthlyIndexedEarnings or set directly.
@@ -235,7 +251,11 @@ Recipient.prototype.processIndexedEarnings_ = function() {
   if (this.monthlyIndexedEarnings === 0 &&
       this.earningsRecords.length === 0)
     return;
-
+  
+  this.earnedCredits = 0;
+  this.plannedCredits = 0;
+  this.neededYears = -1;
+  this.lastNeededYear = 100000;
   var allIndexedValues = [];
   for (var i = 0; i < this.earningsRecords.length; ++i) {
     var earningRecord = this.earningsRecords[i];
@@ -259,12 +279,24 @@ Recipient.prototype.processIndexedEarnings_ = function() {
     
     if (earningRecord.taxedEarnings !== -1)
       allIndexedValues.push(earningRecord.indexedEarning());
-  }
-  if (this.futureEarningsWage > 0) {
-    for (var i = 0; i < this.futureEarningsYears; ++i) {
-      allIndexedValues.push(this.futureEarningsWage);
+
+    earningRecord.credits = this.calculateCredits(earningRecord.taxedEarnings, earningRecord.year);
+    this.earnedCredits = Math.min(40, this.earnedCredits + earningRecord.credits);
+    if (this.earnedCredits == 40) {
+      this.lastYearOfEarnedCredits = earningRecord.year;
     }
   }
+  var neededCredits = 40 - this.earnedCredits;
+  if (this.futureEarningsWage > 0) {
+    var credits = this.calculateCredits(this.futureEarningsWage, CURRENT_YEAR);
+    this.neededYears = Math.ceil(neededCredits / credits);
+    this.lastNeededYear = CURRENT_YEAR + this.neededYears;
+    for (var i = 0; i < this.futureEarningsYears; ++i) {
+      allIndexedValues.push(this.futureEarningsWage);
+      this.plannedCredits = Math.min(neededCredits, this.plannedCredits + credits);
+    }
+  }
+  this.totalCredits = this.earnedCredits + this.plannedCredits;
 
   // Reverse sort the indexed values. Yay javascript, sorting numbers
   // alphabetically!
@@ -631,3 +663,19 @@ Recipient.prototype.totalBenefitAtDate = function(
   return maxBenefitWithSpousal;
 }
 
+Recipient.prototype.getPlannedCredits = function() {
+  return this.plannedCredits;
+}
+
+Recipient.prototype.getEarningsPerCreditForYear = function(year) {
+  if (year > 1978)
+    return EARNINGS_PER_CREDIT[year];
+
+  return 50;
+}
+
+Recipient.prototype.calculateCredits = function(earnings, year) {
+  if (year === undefined)
+    year = CURRENT_YEAR;
+  return Math.min(4, Math.floor(earnings/this.getEarningsPerCreditForYear(year)))
+}

--- a/src/recipient.js
+++ b/src/recipient.js
@@ -66,13 +66,10 @@ function Recipient(name) {
   this.totalCredits = 0;
 
   // Have earnings before 1978
-  this.earningsBefore1978 = false;
+  this.hasEarningsBefore1978 = false;
 
   // Additional years of work needed, -1 means not earning enough to get a credit
   this.neededYears = -1;
-
-  // Last year of credits needed to get to 40
-  this.lastYearOfEarnedCredits = 0;
 
   // This is the monthly primary insurance amount, calculated either from
   // monthlyIndexedEarnings or set directly.
@@ -258,13 +255,12 @@ Recipient.prototype.processIndexedEarnings_ = function() {
   this.earnedCredits = 0;
   this.plannedCredits = 0;
   this.neededYears = -1;
-  this.lastNeededYear = 100000;
   var allIndexedValues = [];
   for (var i = 0; i < this.earningsRecords.length; ++i) {
     var earningRecord = this.earningsRecords[i];
 
     if (earningRecord.year < 1978) {
-      this.earningsBefore1978 = true;
+      this.hasEarningsBefore1978 = true;
     }
 
     earningRecord.earningsCap = MAXIMUM_EARNINGS[earningRecord.year];
@@ -289,15 +285,11 @@ Recipient.prototype.processIndexedEarnings_ = function() {
 
     earningRecord.credits = this.calculateCredits(earningRecord.taxedEarnings, earningRecord.year);
     this.earnedCredits = Math.min(40, this.earnedCredits + earningRecord.credits);
-    if (this.earnedCredits == 40) {
-      this.lastYearOfEarnedCredits = earningRecord.year;
-    }
   }
   var neededCredits = 40 - this.earnedCredits;
   if (this.futureEarningsWage > 0) {
     var credits = this.calculateCredits(this.futureEarningsWage, CURRENT_YEAR);
     this.neededYears = Math.ceil(neededCredits / credits);
-    this.lastNeededYear = CURRENT_YEAR + this.neededYears;
     for (var i = 0; i < this.futureEarningsYears; ++i) {
       allIndexedValues.push(this.futureEarningsWage);
       this.plannedCredits = Math.min(neededCredits, this.plannedCredits + credits);
@@ -685,4 +677,8 @@ Recipient.prototype.calculateCredits = function(earnings, year) {
   if (year === undefined)
     year = CURRENT_YEAR;
   return Math.min(4, Math.floor(earnings/this.getEarningsPerCreditForYear(year)))
+}
+
+Recipient.prototype.isEligible = function() {
+  return this.totalCredits >= 40;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -359,7 +359,23 @@ table.fancy-table td[headers='indexedearnings'] {
 table.fancy-table td[headers='indexedearnings'] {
   padding-right: 20px;
 }
-
+table.fancy-table th#epc,
+  table.fancy-table td[headers='epc'] {
+    text-align: right;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+table.fancy-table td[headers='epc'] {
+  padding-right: 23px;
+}
+table.fancy-table th#credits,
+table.fancy-table td[headers='credits'] {
+  padding-left: 5px;
+  text-align: center;
+}
+table.fancy-table td[headers='credits'] {
+  padding-right: 8px;
+}
 table.fancy-table td[headers='top35indicators'] {
   width: 81px;
   white-space: nowrap;


### PR DESCRIPTION
First cut at credits.  

Credits are an important aspect of social security retirement benefits, as the second demo example doesn't earn the required 40 credits and their PIA is actually 0.

It doesn't zero out PIA calculations if you are not eligible.  I wanted to discuss with you what should be shown in the PIA and subsequent sections when the recipient is not eligible.  Should it just show PIA = 0?  Should it show the current calculations and then an override to 0 with a reference back to the eligibility section?
