### PR TITLE
Add disableRemotePlayback attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,8 +250,8 @@
     </div>
     <div>
       <div class=shadow>
-        <video id=pia_vid autoplay playsinline loop muted width=576 height=294
-          poster="/static/copy-paste-demo-poster.png">
+        <video id=pia_vid autoplay playsinline loop muted disableRemotePlayback
+          width=576 height=294 poster="/static/copy-paste-demo-poster.png">
           <source src="/static/copy-paste-demo.mp4" type="video/mp4">
         </video>
       </div>
@@ -269,8 +269,9 @@
     </div>
     <div>
       <div class=shadow>
-        <video id=earnings_vid autoplay playsinline loop muted width=608
-          height=208 poster="/static/future-earnings-demo-poster.png">
+        <video id=earnings_vid autoplay playsinline loop muted
+          disableRemotePlayback width=608 height=208
+          poster="/static/future-earnings-demo-poster.png">
           <source src="/static/future-earnings-demo.mp4" type="video/mp4">
         </video>
       </div>
@@ -288,8 +289,8 @@
     </div>
     <div>
       <div class=shadow>
-        <video id=pia_vid autoplay playsinline loop muted width=608 height=448
-          poster="/static/pia-demo-poster.png">
+        <video id=pia_vid autoplay playsinline loop muted disableRemotePlayback
+          width=608 height=448 poster="/static/pia-demo-poster.png">
           <source src="/static/pia-demo.mp4" type="video/mp4">
         </video>
       </div>
@@ -310,8 +311,9 @@
     </div>
     <div>
       <div class=shadow>
-        <video id=combined_vid autoplay playsinline loop muted width=640
-          height=784 poster="/static/combined-demo-poster.png">
+        <video id=combined_vid autoplay playsinline loop muted
+          disableRemotePlayback width=640 height=784
+          poster="/static/combined-demo-poster.png">
           <source src="/static/combined-demo.mp4" type="video/mp4">
         </video>
       </div>


### PR DESCRIPTION
Add disableRemotePlayback attributes to the video tags on the root
page. This fixes an issue where you might see a chromecast icon prompt
in the corner of some of the videos.