### PR TITLE
Fix link to the about page from the guides page

### DIFF
--- a/guides.html
+++ b/guides.html
@@ -16,7 +16,7 @@
     <div id="topheader">
       <ul class="navpills">
         <li role="presentation"><a href=".">Calculator</a></li>
-        <li role="presentation"><a href="#">About</a></li>
+        <li role="presentation"><a href="about.html">About</a></li>
         <li role="presentation" class="active"><a href="/guides.html">Guides</a>
         </li>
         <li role="presentation"><a href="contributors.html">Contributors</a>


### PR DESCRIPTION
Just noticed that the link from the guides page to the about page didn't work