### PR TITLE
2022 Constants

### DIFF
--- a/about.html
+++ b/about.html
@@ -78,7 +78,7 @@
         any decisions should be made after researching the subject yourself.
       </p>
       <p>
-        The site was most recently updated on Dec 24, 2019. This update included
+        The site was most recently updated on Dec 21, 2021. This update included
         the latest computed values from the Social Security Administration.
       </p>
       <h3>Why?</h3>

--- a/partials/primary-insurance-amount.html
+++ b/partials/primary-insurance-amount.html
@@ -191,6 +191,11 @@
           increased by {{adjustment.cola | number:1 }}% =
           <b>{{adjustment.end | number:2}}</b>
         </li>
+        <li ng-if="futureCola.isAvailable">
+          {{futureCola.year}}: At the <b>end</b> of the year,
+          <b>${{recipient.primaryInsuranceAmount() | number:2}}</b>
+          will be increased by {{futureCola.adjustment | number:1}}%.
+        </li>
       </ul>
     </div>
 

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -13,7 +13,7 @@ export { MAX_CREDITS };
 // EARNINGS_PER_CREDIT and MAXIMUM_EARNINGS, have been published.
 // This year's values are applied to years in the future if the user
 // manually manipulates the input string.
-const MAX_YEAR = 2021;
+const MAX_YEAR = 2022;
 export { MAX_YEAR };
 
  // Earnings required for one quarter of coverage
@@ -64,6 +64,7 @@ const EARNINGS_PER_CREDIT = {
   2019:	1360,
   2020:	1410,
   2021:	1470,
+  2022:	1510,
 };
 export { EARNINGS_PER_CREDIT };
 
@@ -136,6 +137,7 @@ const MAXIMUM_EARNINGS = {
   2019: 132900,
   2020: 137700,
   2021: 142800,
+  2022: 147000,
 };
 export { MAXIMUM_EARNINGS };
 
@@ -206,6 +208,7 @@ const TAX_RATES = {
   2018: .0515,
   2019: .053,
   2020: .053,
+  2021: .053,
   2021: .053,
 };
 export { TAX_RATES };
@@ -292,6 +295,7 @@ const WAGE_INDICES = {
   2017: 50321.89,
   2018: 52145.80,
   2019: 54099.99,
+  2020: 55628.60,
 };
 export { WAGE_INDICES };
 
@@ -343,6 +347,7 @@ const COLA = {
   2018: 2.8,
   2019: 1.6,
   2020: 1.3,
+  2021: 5.9,
 };
 export { COLA };
 

--- a/src/ssa.mjs
+++ b/src/ssa.mjs
@@ -382,6 +382,25 @@ ssaApp.controller("SSAController", function ($scope, $filter, $http, $timeout) {
   $scope.firstBendPoint = utils.firstBendPoint;
   $scope.secondBendPoint = utils.secondBendPoint;
 
+  $scope.futureCola = function() {
+    console.log('futureCola()');
+    if (!(constants.CURRENT_YEAR in constants.COLA)) {
+      // The future is unknown:
+      console.log('no future yet');
+      return {
+        'isAvailable': false,
+      }
+    } else {
+      // We have a crystal ball:
+      console.log('future known');
+      return {
+        'isAvailable': true,
+        'year': constants.CURRENT_YEAR,
+        'adjustment': constants.COLA[constants.CURRENT_YEAR],
+      }
+    }
+  }();
+
   /**
    * Special case method for init'ing an 'Age'. Ages are durations, and this
    * is syntactical sugar usable in template expressions.

--- a/src/ssa.mjs
+++ b/src/ssa.mjs
@@ -383,16 +383,13 @@ ssaApp.controller("SSAController", function ($scope, $filter, $http, $timeout) {
   $scope.secondBendPoint = utils.secondBendPoint;
 
   $scope.futureCola = function() {
-    console.log('futureCola()');
     if (!(constants.CURRENT_YEAR in constants.COLA)) {
       // The future is unknown:
-      console.log('no future yet');
       return {
         'isAvailable': false,
       }
     } else {
       // We have a crystal ball:
-      console.log('future known');
       return {
         'isAvailable': true,
         'year': constants.CURRENT_YEAR,


### PR DESCRIPTION
This update includes constants for 2022, such as updated COLA and wage indices.

A number of people have asked why the site doesn't display 2021 COLA increases, probably because the increase was so significant this year. I haven't displayed COLAs until they come into effect, which isn't until Jan 1, 2022. This is confusing though and leads people to believe the site isn't updated. So, I've added a line to the list of COLAs that displays the future COLA number if we have it, but shows it in a different format and calls out that it won't be applied until the following year.