### PR TITLE
Add Google Analytics reporting for Signed HTTP Exchange Web Vitals data.

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About: Social Security Calculator</title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
 
   <link rel="stylesheet" href="/src/stylesheet.css" />
 </head>

--- a/calculator.html
+++ b/calculator.html
@@ -8,6 +8,9 @@
   <meta name="description" content="Enter your social security earning record to
   get started calculating your benefit and primary insurance amount">
   <title>Social Security Calculator: Get Started</title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
 
   <link rel="stylesheet"
     href="//cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">

--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Contact: Social Security Calculator</title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
 
   <link rel="stylesheet" href="/src/stylesheet.css" />
 </head>

--- a/contributors.html
+++ b/contributors.html
@@ -6,6 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Constributors: Social Security Calculator</title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
 
   <link rel="stylesheet" href="/src/stylesheet.css" />
 </head>

--- a/guide/covid-awi-drop.html
+++ b/guide/covid-awi-drop.html
@@ -10,6 +10,9 @@
   <title>
     Effect of Covid-19 on Social Security Benefits
   </title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
   <link rel="stylesheet" href="/src/stylesheet.css" />
 
   <script type="application/ld+json">
@@ -178,7 +181,8 @@
         <tr>
           <td rowspan=2>Indexed Earnings (year X) =</td>
           <td style="border-bottom: 1px solid black;">Taxed Earnings (year X) x
-            <b>AWI (year 2020)</b></td>
+            <b>AWI (year 2020)</b>
+          </td>
         </tr>
         <tr>
           <td>AWI (year X)</td>

--- a/guide/earnings-cap.html
+++ b/guide/earnings-cap.html
@@ -10,6 +10,9 @@
   <title>
     Social Security Earnings Caps
   </title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
   <link rel="stylesheet" href="/src/stylesheet.css" />
 
   <script type="text/javascript"

--- a/guide/indexing-factors.html
+++ b/guide/indexing-factors.html
@@ -10,6 +10,9 @@
   <title>
     Social Security Indexing Factors | SSA.tools
   </title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
   <link rel="stylesheet" href="/src/stylesheet.css" />
 
   <script type="application/ld+json">

--- a/guide/inflation.html
+++ b/guide/inflation.html
@@ -10,6 +10,9 @@
   <title>
     Social Security Inflation Calculator
   </title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
   <link rel="stylesheet" href="/src/stylesheet.css" />
 
   <script type="application/ld+json">

--- a/guide/maximum.html
+++ b/guide/maximum.html
@@ -11,6 +11,9 @@
   <title>
     Social Security Maximum
   </title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
   <link rel="stylesheet" href="/src/stylesheet.css" />
 
   <script type="text/javascript"

--- a/guides.html
+++ b/guides.html
@@ -6,6 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About: Social Security Calculator</title>
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
 
   <link rel="stylesheet" href="/src/stylesheet.css" />
 </head>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
   <link rel="og:site_name" href="ssa.tools">
   <link rel="og:type" href="website">
   <meta property="og:url" content="https://ssa.tools">
+  <!-- Analytics bit for measuring performance changes from
+           Signed HTTP Exchanges. -->
+  <script data-issxg-var>window.isSXG = false</script>
 
   <link rel="stylesheet" href="/src/stylesheet.css">
   <link rel="shortcut icon" href="/favicon.ico">

--- a/src/analytics.mjs
+++ b/src/analytics.mjs
@@ -1,3 +1,33 @@
+ // Web Vitals Module
+import { getCLS, getFID, getLCP } from 'https://unpkg.com/web-vitals?module';
+
+// Web Vitals Data Reporting
+function sendToGoogleAnalytics({name, delta, id}) {
+  // Assumes the global `ga()` function exists, see:
+  // https://developers.google.com/analytics/devguides/collection/analyticsjs
+  ga('send', 'event', {
+    eventCategory: 'Web Vitals',
+    eventAction: name,
+    // The `id` value will be unique to the current page load. When sending
+    // multiple values from the same page (e.g. for CLS), Google Analytics can
+    // compute a total by grouping on this ID (note: requires `eventLabel` to
+    // be a dimension in your report).
+    eventLabel: id,
+    // Google Analytics metrics must be integers, so the value is rounded.
+    // For CLS the value is first multiplied by 1000 for greater precision
+    // (note: increase the multiplier for greater precision if needed).
+    eventValue: Math.round(name === 'CLS' ? delta * 1000 : delta),
+    // Use a non-interaction event to avoid affecting bounce rate.
+    nonInteraction: true,
+    // Use `sendBeacon()` if the browser supports it.
+    transport: 'beacon',
+
+    dimension1: String(isSXG),
+    dimension2: document.referrer,
+    // ...
+  });
+}
+
 // Only load Google Analytics code if the site is being accessed at
 // https://socialsecurity.tools/ or https://ssa.tools/
 //
@@ -19,7 +49,11 @@ if (document.location.hostname.search('socialsecurity.tools') !== -1 ||
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};
+  window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) };
+
+  getCLS(sendToGoogleAnalytics);
+  getFID(sendToGoogleAnalytics);
+  getLCP(sendToGoogleAnalytics);
 } else {
   // Otherwise, register a window.ga dummy function.
   //

--- a/src/analytics.mjs
+++ b/src/analytics.mjs
@@ -24,7 +24,6 @@ function sendToGoogleAnalytics({name, delta, id}) {
 
     dimension1: String(isSXG),
     dimension2: document.referrer,
-    // ...
   });
 }
 


### PR DESCRIPTION
This doesn't reveal anything about the user, only about the loading
performance (how fast the page loads).