### PR TITLE
Visual / Text tweaks

### DIFF
--- a/partials/benefit-estimate.html
+++ b/partials/benefit-estimate.html
@@ -120,7 +120,7 @@
       {{recipient.normalRetirementDate().year()}}</b>),
     your amount will be <u>permanently</u> <i>increased</i> by
     <b>{{recipient.delayIncreaseRate() * 100 | number: 2}}%</b> per year
-    <b>({{recipient.delayIncreaseRate() * 100 / 12 | number: 2}}%</b> per month)
+    (<b>{{recipient.delayIncreaseRate() * 100 / 12 | number: 2}}%</b> per month)
     that you delay.
   </p>
   <p>

--- a/partials/benefit-estimate.html
+++ b/partials/benefit-estimate.html
@@ -97,16 +97,15 @@
     If you choose to take benefits earlier than normal retirement age
     (<b>{{recipient.normalRetirementDate().monthFullName()}}
       {{recipient.normalRetirementDate().year()}}</b>),
-    your benefit amount will be <u>permanently</u> <i>reduced</i>
-    per year you start early by:
+    your benefit amount will be <u>permanently</u> <i>reduced</i> by:
   <ul>
-    <li><b>6.67%</b> per year if starting <i>after</i>
+    <li><b>6.67%</b> per year (<b>0.56%</b> per month) if starting <i>after</i>
       <b>{{recipient.normalRetirement.ageYears - 3}} years and
         {{recipient.normalRetirement.ageMonths}} months</b>
       (<b>{{recipient.spousalInflectionDate().monthFullName()}}
         {{recipient.spousalInflectionDate().year()}}</b>)
     </li>
-    <li><b>5.00%</b> per year if starting <i>before</i>
+    <li><b>5.00%</b> per year (<b>0.42%</b> per month) if starting <i>before</i>
       <b>{{recipient.normalRetirement.ageYears - 3}} years and
         {{recipient.normalRetirement.ageMonths}} months</b>
       (<b>{{recipient.spousalInflectionDate().monthFullName()}}
@@ -120,12 +119,13 @@
     (<b>{{recipient.normalRetirementDate().monthFullName()}}
       {{recipient.normalRetirementDate().year()}}</b>),
     your amount will be <u>permanently</u> <i>increased</i> by
-    <b>{{recipient.delayIncreaseRate() * 100 | number: 2}}%</b> per year that
-    you delay.
+    <b>{{recipient.delayIncreaseRate() * 100 | number: 2}}%</b> per year
+    <b>({{recipient.delayIncreaseRate() * 100 / 12 | number: 2}}%</b> per month)
+    that you delay.
   </p>
   <p>
-    Here is a table which shows how much your benefit would be at different
-    starting ages:
+    Here is a table which shows how much your benefit would be at a few
+    different starting ages. The benefit is assessed monthly:
   </p>
   <table
     ng-class="{'fancy-table': true, 'wide-age': recipient.birthdate().layBirthDayOfMonth() !== 2}"

--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -22,13 +22,16 @@
     </li>
     <li>
       <a href="#nav-eligibility" data-ng-click="scrollTo('nav-eligibility')">
-        <div class=navlabel>Retirement Benefits Eligibility</div>
+        <div class=navlabel>Benefits Eligibility</div>
         <i class="glyphicon glyphicon-chevron-right"></i>
       </a>
     </li>
     <li>
       <a href="#nav-pia" data-ng-click="scrollTo('nav-pia')">
-        <div class=navlabel>Primary Insurance Amount</div>
+        <!-- Shrinking the padding here makes this label fit on one line. -->
+        <div class=navlabel style="padding-right: 0px;">
+          Primary Insurance Amount
+        </div>
         <i class="glyphicon glyphicon-chevron-right"></i>
       </a>
     </li>
@@ -41,7 +44,9 @@
     <li ng-if="recipient.isEligible()">
       <a href="#nav-early-delayed"
         data-ng-click="scrollTo('nav-early-delayed')">
-        <div class=navlabel>Early and Delayed Retirement</div>
+        <!-- Shrinking the padding here makes this label fit on one line. -->
+        <div class=navlabel style="padding-right: 0px;">Early / Delayed
+          Retirement</div>
         <i class="glyphicon glyphicon-chevron-right"></i>
       </a>
     </li>
@@ -61,14 +66,14 @@
     <li ng-if="recipient.isEligible() && isMarried() && showSpousalBenefit">
       <a href="#nav-early-delayed-spouse"
         data-ng-click="scrollTo('nav-early-delayed-spouse')">
-        <div class=navlabel>Early and Delayed Spouse Retirement</div>
+        <div class=navlabel>Early / Delayed Spouse Retirement</div>
         <i class="glyphicon glyphicon-chevron-right"></i>
       </a>
     </li>
     <li ng-if="recipient.isEligible() && isMarried() && showSpousalBenefit">
       <a href="#nav-early-delayed-combined"
         data-ng-click="scrollTo('nav-early-delayed-combined')">
-        <div class=navlabel>Early and Delayed Combined Retirement</div>
+        <div class=navlabel>Early / Delayed Combined Retirement</div>
         <i class="glyphicon glyphicon-chevron-right"></i>
       </a>
     </li>
@@ -80,7 +85,7 @@
     </li>
     <li ng-if="recipient.isEligible()">
       <a href="#nav-age-decision" data-ng-click="scrollTo('nav-age-decision')">
-        <div class=navlabel>Deciding what age to start benefits</div>
+        <div class=navlabel>Starting Age Decision</div>
         <i class="glyphicon glyphicon-chevron-right"></i>
       </a>
     </li>

--- a/partials/primary-insurance-amount.html
+++ b/partials/primary-insurance-amount.html
@@ -200,9 +200,16 @@
     </div>
 
     <p>
-      This total
-      (<b>${{recipient.primaryInsuranceAmount() | number:2}}</b> / month) is
-      your primary insurance amount. In the chart below, you can see what your
+      This total is your <u>primary insurance amount (PIA)</u>.
+    </p>
+
+    <div class="pia-banner">
+      Primary Insurance Amount (PIA): <b>${{recipient.primaryInsuranceAmount() |
+        number:2}}</b> / month
+    </div>
+
+    <p>
+      In the chart below, you can see what your
       primary insurance amount would be if your indexed earnings were to
       increase. Move your mouse over the chart to see how the primary insurance
       amount changes.

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -394,6 +394,15 @@ p.birthdate {
   font-size: 18px;
 }
 
+div.pia-banner {
+  padding-left: 40px;
+  margin: 20px 0 20px;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: 0.04rem;
+  color: #443378;
+}
+
 /* earnings-record table styles match the SSA.gov site so that the table looks
  * similar when pasted in. The reason for consistency is that we are asking
  * the user if we have entered the data correctly and making it a similar


### PR DESCRIPTION
- Make the final PIA text larger and more visible in the text for easy copy / paste into other tools.
- Tweak the text around the reduction / increase in benefits for delayed / early retirement. Previously it could be misunderstood to be an effect that only occurs on year boundaries. Make it clearer that this is a monthly adjustment.
-  Tweak some CSS styles and text so that a few of the clickable navigation headers now fit on one line for most browsers.