### PR TITLE
Change the column height on the list of states that don't tax social

### DIFF
--- a/guide/federal-taxes.html
+++ b/guide/federal-taxes.html
@@ -93,7 +93,7 @@
       </p>
 
       <ul
-        style="display: flex; flex-direction: column; flex-wrap: wrap; height: 300px;">
+        style="display: flex; flex-direction: column; flex-wrap: wrap; height: 350px;">
         <li>Alabama</li>
         <li>Alaska</li>
         <li>Arizona</li>


### PR DESCRIPTION
security. On narrow screens (mobile), four colums don't fit well. By increasing the column height, the list becomes 3 columns.