### PR TITLE
Improve the ssa-parse.mjs method.

### DIFF
--- a/src/ssa-parse.mjs
+++ b/src/ssa-parse.mjs
@@ -1,5 +1,5 @@
 import * as constants from './constants.mjs';
-import { EarningRecord } from './recipient.mjs';
+import {EarningRecord} from './recipient.mjs';
 
 /**
  * Given a string which we know to be a number containing possibly a leading
@@ -11,16 +11,16 @@ var dollarStringToNumber = function(dollar_string) {
   // For the current year, the SSA site will display 'Not yet recorded'
   // if the data is unavailable so far, presumably because taxes haven't
   // yet been filed. Record this as a -1 sentinel for now.
-  if (dollar_string === 'NotYetRecorded')
-    return -1;
-  if (dollar_string === 'MedicareBeganIn1966')
-    return 0;
-  if (dollar_string === '')
-    return 0;
+  if (dollar_string === 'NotYetRecorded') return -1;
+  if (dollar_string === 'MedicareBeganIn1966') return 0;
+  if (dollar_string === '') return 0;
   var number_string = dollar_string.replace(/[$,]/g, '');
-  return Number(number_string);
-}
-export { dollarStringToNumber };
+  var value = Number(number_string);
+  if (Number.isNaN(value)) return 0;
+  if (value < 0) return 0;
+  return value;
+};
+export {dollarStringToNumber};
 
 var parseSsaGovTable = function(lines) {
   let earningsRecords = [];
@@ -38,7 +38,8 @@ var parseSsaGovTable = function(lines) {
     earningsRecords.push(record);
   }
   return earningsRecords;
-}
+};
+
 var parseFormattedTable = function(lines) {
   let earningsRecords = [];
   for (let i = 0; i < lines.length; ++i) {
@@ -50,7 +51,7 @@ var parseFormattedTable = function(lines) {
     earningsRecords.push(record);
   }
   return earningsRecords;
-}
+};
 var parseThisSiteTable = function(lines) {
   let earningsRecords = [];
   for (let i = 0; i < lines.length; ++i) {
@@ -62,35 +63,31 @@ var parseThisSiteTable = function(lines) {
     earningsRecords.push(record);
   }
   return earningsRecords;
-}
+};
 
 function isYearString(maybeYearStr) {
   // If not an int, it's not a year.
   let maybeYear = Number.parseInt(maybeYearStr);
-  if (Number.isNaN(maybeYear))
-    return false;
+  if (Number.isNaN(maybeYear)) return false;
   // parseInt will ignore trailing garbage, so "1A" will be parsed as "1".
   // We don't want this as it could lead us to extract lines that aren't
   // valid.
-  if (maybeYear.toString().length !== maybeYearStr.length)
-    return false;
+  if (maybeYear.toString().length !== maybeYearStr.length) return false;
 
   // According to http://goo.gl/2HEj1H, the oldest person alive may have been
   // born as long back as 1887. This is debated, but it works for our simple
   // validation purposes here.
-  if (maybeYear < 1887)
-    return false;
+  if (maybeYear < 1887) return false;
 
   // If the pasted data is from ssa.gov, it won't have records greater than
   // last year, because the data comes from tax returns, which isn't processed
   // until the following year. However, some users would like to manufacture
   // data to paste into the tool, so we accept any year up to 70y in the future.
   // See https://github.com/Gregable/social-security-tools/issues/130
-  if (maybeYear > constants.CURRENT_YEAR + 70)
-    return false;
+  if (maybeYear > constants.CURRENT_YEAR + 70) return false;
 
   return true;
-}
+};
 
 var parsePaste = function(paste) {
   // We first collapse whitespace on each line as
@@ -98,27 +95,27 @@ var parsePaste = function(paste) {
   // separation.
 
   // Normalize and collapse whitespace.
-  let replacedStr = paste.replace(/[ \t]+/g, " ");
+  let replacedStr = paste.replace(/[ \t]+/g, ' ');
   // Normalize and collapse newlines.
-  replacedStr = replacedStr.replace(/[\r\n]+/g, "\n");
+  replacedStr = replacedStr.replace(/[\r\n]+/g, '\n');
   // Some columns will include the string "Not yet recorded" which breaks
   // columns on spaces in the string. We replace these with "NotYetRecorded".
-  replacedStr = replacedStr.replace(/not yet recorded+/gi, "NotYetRecorded");
+  replacedStr = replacedStr.replace(/not yet recorded+/gi, 'NotYetRecorded');
   // Similarly, for records in 1965, the Medicare column will include the
   // string "Medicare Began in 1966". We replace this with:
   // "MedicareBeganIn1966".
-  replacedStr = replacedStr.replace(/medicare began in 1966+/gi, "MedicareBeganIn1966");
+  replacedStr =
+      replacedStr.replace(/medicare began in 1966+/gi, 'MedicareBeganIn1966');
 
   // Split based on newlines.
-  let lines = replacedStr.split("\n");
+  let lines = replacedStr.split('\n');
 
   // All valid lines will start with a year indicator.
   let earningsLines = [];
   for (let i = 0; i < lines.length; ++i) {
     const line = lines[i].trim();
     const columns = line.split(' ');
-    if (!isYearString(columns[0]))
-      continue;
+    if (!isYearString(columns[0])) continue;
 
     // There must be at least a year and an earnings value.
     if (columns.length < 2) {
@@ -131,8 +128,7 @@ var parsePaste = function(paste) {
       let legitThreeLineValue = true;
       for (let j = 1; j < 3; ++j) {
         const colValue = lines[i + j].trim();
-        if (colValue === 'NotYetRecorded' ||
-            colValue[0] === '$') {
+        if (colValue === 'NotYetRecorded' || colValue[0] === '$') {
           constructedLine += ' ' + colValue;
         } else {
           legitThreeLineValue = false;
@@ -148,8 +144,7 @@ var parsePaste = function(paste) {
       earningsLines.push(line);
     }
   }
-  if (earningsLines.length === 0)
-    return [];
+  if (earningsLines.length === 0) return [];
 
   // There are several different formats we are interested in:
   // 1) The table at ssa.gov's website.
@@ -184,8 +179,10 @@ var parsePaste = function(paste) {
   // output so that it's in chronological order. This also lets us handle
   // errors in user formatted years or whatnot.
   if (out.length > 1)
-    out.sort(function(a, b) { return a.year - b.year });
+    out.sort(function(a, b) {
+      return a.year - b.year
+    });
 
   return out;
-}
-export { parsePaste };
+};
+export {parsePaste};


### PR DESCRIPTION
 User reported an input format that used `$-` to represent zero values, which were generating NaN errors that were not caught correctly. These are now being parsed correctly as $0.