### PR TITLE
Reduce the amount of color.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,9 +28,10 @@
   {:else}
     <Sidebar>
       {#if context.spouse}
-        <SidebarSection label={context.recipient.shortName(15)} heading={true}>
-          <h1><RecipientName r={context.recipient} /></h1>
-        </SidebarSection>
+        <SidebarSection
+          label={context.recipient.shortName(15)}
+          heading={true}
+        />
       {/if}
       <SidebarSection label="Earnings Record">
         <EarningsReport recipient={context.recipient} />
@@ -48,10 +49,7 @@
         <FilingDateReport recipient={context.recipient} />
       </SidebarSection>
       {#if context.spouse}
-        <SidebarSection label={context.spouse.shortName(15)} heading={true}>
-          <h1><RecipientName r={context.spouse} /></h1>
-        </SidebarSection>
-
+        <SidebarSection label={context.spouse.shortName(15)} heading={true} />
         <SidebarSection label="Earnings Record">
           <EarningsReport recipient={context.spouse} />
         </SidebarSection>

--- a/src/components/EarningsReport.svelte
+++ b/src/components/EarningsReport.svelte
@@ -2,13 +2,14 @@
   import "../global.css";
   import EarningsTable from "./EarningsTable.svelte";
   import FutureEarningsSliders from "./FutureEarningsSliders.svelte";
+  import RecipientName from "./RecipientName.svelte";
   import { Recipient } from "../lib/recipient";
 
   export let recipient: Recipient = new Recipient();
 </script>
 
 <div>
-  <h2>Earnings Record</h2>
+  <h2><RecipientName r={$recipient} apos noColor /> Earnings Record</h2>
 
   <EarningsTable earningsRecords={$recipient.earningsRecords} />
   <FutureEarningsSliders recipient={$recipient} />

--- a/src/components/EligibilityReport.svelte
+++ b/src/components/EligibilityReport.svelte
@@ -180,7 +180,7 @@
     letter-spacing: 0.04rem;
   }
   .eligible {
-    color: green;
+    color: black;
   }
   .ineligible {
     color: red;


### PR DESCRIPTION
With two users, the colors on names gets a little busy.

This change removes the username headers, instead folding them into the heading for the "Earnings Record", and removing the color.

This also removes the green color from the big "Eligible" text, though the red is still maintained for ineligibile users.

Overall, this makes the page a little less busy, and a little more readable.