### PR TITLE
Match ssa.gov more closely.

### DIFF
--- a/src/lib/components/FutureEarningsSliders.svelte
+++ b/src/lib/components/FutureEarningsSliders.svelte
@@ -29,15 +29,44 @@
     }
     return "";
   }
-  let futureEarningYears: number = 0;
-  let futureEarningWage: number = 1000;
+
+  // Computes the remaining years of earnings until the normal retirement age.
+  function remainingEarningYears(recipient: Recipient): number {
+    if (!recipient) return 0;
+    let years =
+      $recipient.normalRetirementDate().year() - constants.CURRENT_YEAR + 1;
+    // The slider can go from 0 to 35 years.
+    return Math.min(35, Math.max(0, years));
+  }
+  function mostRecentEarningWage(recipient: Recipient): Money {
+    const numEarningsYears = $recipient.earningsRecords.length;
+    if (numEarningsYears == 0) return Money.from(1000);
+    let earningRecord = $recipient.earningsRecords[numEarningsYears - 1];
+    if (
+      earningRecord.year == constants.CURRENT_YEAR ||
+      earningRecord.year == constants.CURRENT_YEAR - 1 ||
+      earningRecord.year == constants.CURRENT_YEAR - 2
+    ) {
+      return earningRecord.taxedEarnings;
+    }
+    return Money.from(1000);
+  }
+  // ssa.gov by default shows a projection for someone who earns the same
+  // amount every year going forward as last year up until, and inluding,
+  // the year of the normal retirement age. We want the sliders to start
+  // in the same place as ssa.gov, but the user can of course move them from
+  // there.
+  let futureEarningYears: number = remainingEarningYears($recipient);
+  let futureEarningWage: number = mostRecentEarningWage($recipient)
+    .roundToDollar()
+    .value();
+
   function update(futureEarningYears: number, futureEarningWage: Money) {
     $recipient.simulateFutureEarningsYears(
       futureEarningYears,
       futureEarningWage
     );
   }
-
   $: update(futureEarningYears, Money.from(futureEarningWage));
 </script>
 

--- a/src/lib/earning-record.ts
+++ b/src/lib/earning-record.ts
@@ -1,5 +1,5 @@
-import * as constants from './constants'
-import {Money} from './money';
+import * as constants from '$lib/constants'
+import {Money} from '$lib/money';
 
 /**
  * EarningRecord class

--- a/src/lib/recipient.ts
+++ b/src/lib/recipient.ts
@@ -1,9 +1,9 @@
-import {Birthdate} from './birthday';
-import * as constants from './constants';
-import {EarningRecord} from './earning-record';
-import {Money} from './money';
-import {MonthDate, MonthDuration} from './month-time';
-import {PrimaryInsuranceAmount} from './pia';
+import {Birthdate} from '$lib/birthday';
+import * as constants from '$lib/constants';
+import {EarningRecord} from '$lib/earning-record';
+import {Money} from '$lib/money';
+import {MonthDate, MonthDuration} from '$lib/month-time';
+import {PrimaryInsuranceAmount} from '$lib/pia';
 
 export class RecipientColors {
   constructor(dark: string, medium: string, light: string) {

--- a/src/stories/FutureEarningsSliders.stories.ts
+++ b/src/stories/FutureEarningsSliders.stories.ts
@@ -1,6 +1,10 @@
 import type {Meta} from '@storybook/svelte';
 import FutureEarningsSliders from '../lib/components/FutureEarningsSliders.svelte';
 import {Recipient} from '$lib/recipient';
+import * as constants from '$lib/constants'
+import {Birthdate} from '$lib/birthday';
+import {EarningRecord} from '$lib/earning-record';
+import {Money} from '$lib/money';
 
 const meta: Meta<FutureEarningsSliders> = {
   component: FutureEarningsSliders,
@@ -15,6 +19,15 @@ export default meta;
 let recipient = new Recipient();
 recipient.name = 'Alex';
 recipient.markFirst();
+recipient.birthdate = Birthdate.FromYMD(constants.CURRENT_YEAR - 47, 3, 4)
+const earnings = [
+  new EarningRecord({
+    year: constants.CURRENT_YEAR - 1,
+    taxedEarnings: Money.from(50100.23),
+    taxedMedicareEarnings: Money.from(0)
+  }),
+]
+recipient.earningsRecords = earnings;
 
 const Template = ({...args}) => ({
   Component: FutureEarningsSliders,


### PR DESCRIPTION
Fixes #113.

By default, ssa.gov assumes the user will continue earning the same as the previous year's earnings until and including the year of normal retirement age. We want to set the sliders to the same initial value so we get the same "answer".