### PR TITLE
Add basic analytics event tracking.

### DIFF
--- a/src/lib/components/PasteFlow.svelte
+++ b/src/lib/components/PasteFlow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import "$lib/global.css";
   import { createEventDispatcher, onMount } from "svelte";
+  import va from "@vercel/analytics";
   import { context } from "$lib/context";
   import AgeRequest from "./AgeRequest.svelte";
   import DemoData from "./DemoData.svelte";
@@ -8,7 +9,6 @@
   import PastePrompt from "./PastePrompt.svelte";
   import PasteApology from "./PasteApology.svelte";
   import SpouseQuestion from "./SpouseQuestion.svelte";
-  import RecipientName from "./RecipientName.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -65,6 +65,7 @@
     }
 
     // Let the app know we're done.
+    va.track("Demo Loaded");
     dispatch("done");
   }
 
@@ -116,6 +117,7 @@
       context.recipient.birthdate = event.detail.birthdate;
     } else {
       context.spouse.birthdate = event.detail.birthdate;
+      va.track("Pasted with spousal");
       // Let the app know we're done.
       dispatch("done");
     }
@@ -134,6 +136,7 @@
       spouseName = event.detail.spousename;
       mode = Mode.INITIAL;
     } else {
+      va.track("Pasted");
       // Let the app know we're done.
       dispatch("done");
     }


### PR DESCRIPTION
This tracks the following events:
 - Clicked a "load demo" link, but not which one.
 - Successfully pasted data for a single user, but not the data.
 - Successfully pasted data for a user and spouse, but not the data.

In none of these cases are we tracking anything sensitive, such as income, name, birthdate, etc.