### PR TITLE
Improve the data entry

### DIFF
--- a/src/lib/components/AgeRequest.svelte
+++ b/src/lib/components/AgeRequest.svelte
@@ -28,27 +28,48 @@
     });
   }
 
-  function parseDateInputValue(dateInputValue: string): Date {
+  function parseNumberString(input: string): number {
+    const parsed = parseInt(input);
+    if (isNaN(parsed)) return 0;
+    return parsed;
+  }
+
+  function parseDateInputValue(
+    day: string,
+    month: string,
+    year: string
+  ): Date | null {
+    let birthdateDay = parseNumberString(day);
+    let birthdateMonth = parseNumberString(month) - 1;
+    let birthdateYear = parseNumberString(year);
+
+    if (birthdateDay < 1 || birthdateDay > 31) return null;
+    if (birthdateMonth < 0 || birthdateMonth > 11) return null;
+    if (birthdateYear < 1900 || birthdateYear > 2100) return null;
+
     // Svelte binds the value of the input to a string, so we need to parse it
-    let localInput = new Date(dateInputValue);
-    // Javascript parses dates in UTC, but converts to local time.
-    // This can cause dates to add/subract a day from what's entered because
-    // of daylight savings. This normalizes that. Fun times.
-    const timeDiff = localInput.getTimezoneOffset() * 60000;
-    const adjusted = new Date(localInput.valueOf() + timeDiff);
-    return adjusted;
+    return new Date(
+      new Date(Date.UTC(birthdateYear, birthdateMonth, birthdateDay))
+    );
   }
 
   // Svelte binds the value of the input to a string, so we need to parse it
   // and store it in a Date object. If the date is invalid, we disable the
   // button.
   let parsedDate: Date;
-  let birthdateString = "";
+  let birthdateDayStr = "";
+  let birthdateMonthStr = "";
+  let birthdateYearStr = "";
   let disabled = true;
   $: disabled = (() => {
-    if (!birthdateString) return true;
-    parsedDate = parseDateInputValue(birthdateString);
-
+    parsedDate = parseDateInputValue(
+      birthdateDayStr,
+      birthdateMonthStr,
+      birthdateYearStr
+    );
+    if (parsedDate == null) console.log(null);
+    else console.log(parsedDate.toUTCString());
+    if (parsedDate == null) return true;
     // Date is in the future, can't be valid:
     if (parsedDate > new Date()) return true;
     // Date is too far in the past, can't be valid:
@@ -56,42 +77,125 @@
 
     return false;
   })();
+
+  function isTouchscreen(): boolean {
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  }
 </script>
 
 <div class="confirmation">
-  <div class="text">
-    <h3>Step 3 of 3: Select Birthdate</h3>
-    <p>
-      Birthdate is used to calculate when you can collect Social Security
-      benefits, as well as to determine the amount of your benefit.
-    </p>
-  </div>
-
-  <input
-    type="date"
-    class="birthdate-input"
-    placeholder="YYYY-MM-DD"
-    bind:value={birthdateString}
-  />
-
-  <button on:click={confirm} {disabled}>
-    <ico>&#10003;</ico> Next
-  </button>
+  <!-- Inspired by
+https://design-system.service.gov.uk/patterns/dates/#asking-for-memorable-dates
+-->
+  <fieldset>
+    <legend>
+      <h3>Step 2 of 2: When were you born?</h3>
+      <p>
+        Birthdate is used to calculate when you can collect Social Security
+        benefits, as well as to determine the amount of your benefit.
+      </p>
+    </legend>
+    <div class="hint">For example, 09 22 1975</div>
+    <div class="date-input-item">
+      <label class="date-input-label" for="bday-month">Month</label>
+      <input
+        class="input input-width-2"
+        id="bday-month"
+        name="bday-month"
+        type="text"
+        inputmode="numeric"
+        placeholder="MM"
+        maxlength="2"
+        bind:value={birthdateMonthStr}
+      />
+    </div>
+    <div class="date-input-item">
+      <label class="date-input-label" for="bday-day">Day</label>
+      <input
+        class="input input-width-2"
+        id="bday-day"
+        name="bday-day"
+        type="text"
+        inputmode="numeric"
+        placeholder="DD"
+        maxlength="2"
+        bind:value={birthdateDayStr}
+      />
+    </div>
+    <div class="date-input-item">
+      <label class="date-input-label" for="bday-year">Year</label>
+      <input
+        class="input input-width-4"
+        id="bday-year"
+        name="bday-year"
+        type="text"
+        inputmode="numeric"
+        placeholder="YYYY"
+        maxlength="4"
+        bind:value={birthdateYearStr}
+      />
+    </div>
+    <button on:click={confirm} {disabled}>
+      <ico>&#10003;</ico> Next
+    </button>
+  </fieldset>
 </div>
 
 <style>
   .confirmation {
-    text-align: center;
-    font-size: 18px;
+    font-size: 1.2em;
+    line-height: 1.3;
   }
-  .text {
+  fieldset {
     margin-bottom: 20px;
-    max-width: calc(min(700px, 100% - 20px));
+    max-width: calc(min(600px, 100% - 20px));
     margin: auto;
+    border: 0;
   }
-  input {
-    font-size: 26px;
-    vertical-align: middle;
+  .hint {
+    margin: -5px 0 15px 0;
+    font-weight: 400;
+    color: #505a5f;
+  }
+  .date-input-item {
+    display: inline-block;
+    margin-right: 20px;
+  }
+  .date-input-label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 400;
+    color: #0b0c0c;
+  }
+  @media (max-width: 640px) {
+    fieldset {
+      font-size: 16px;
+    }
+  }
+  @media (min-width: 641px) {
+    fieldset {
+      font-size: 19px;
+    }
+  }
+  .input {
+    font-size: 1.2em;
+    line-height: 1.3;
+    height: 2.5em;
+    padding: 5px;
+    border: 2px solid #0b0c0c;
+    border-radius: 0;
+    appearance: none;
+  }
+  .input:focus {
+    outline: 3px solid #fd0;
+    outline-offset: 0;
+    box-shadow: inset 0 0 0 2px;
+  }
+  .input-width-2 {
+    max-width: 2.75em;
+  }
+  .input-width-4 {
+    max-width: 4.5em;
   }
   button {
     background: #4ac15a;
@@ -100,7 +204,7 @@
     color: #fff;
     font-size: 18px;
     padding: 8px 26px;
-    margin: 4px 10px;
+    margin: 20px 0px;
     min-width: 110px;
     cursor: pointer;
   }

--- a/src/lib/components/DemoData.svelte
+++ b/src/lib/components/DemoData.svelte
@@ -74,6 +74,16 @@
 </script>
 
 <div class="demoPrompt">
+  <p>
+    To use the calculator, you must provide data from your Social Security
+    record. If you aren't ready for that yet, try the demo using sample data:
+
+    <button on:click={loadDemoData(0)}>&#x261b; Try the Demo</button>
+  </p>
+
+  <!--
+    Undecided if we want to keep the multiple demo option, so commenting out
+    for now.
   <h3>Try out some <u>demo</u> data instead:</h3>
   <ul class="demos">
     <li>
@@ -92,6 +102,7 @@
       <button on:click={loadDemoData(2)}>&#x261b; Try the Demo</button>
     </li>
   </ul>
+  -->
 </div>
 
 <style>

--- a/src/lib/components/DemoData.svelte
+++ b/src/lib/components/DemoData.svelte
@@ -107,7 +107,7 @@
 
 <style>
   .demoPrompt {
-    margin: auto;
+    margin: 0 auto 2em auto;
     max-width: min(660px, 80%);
   }
   button {
@@ -118,9 +118,6 @@
     margin: 2px 2px 0 0;
     cursor: pointer;
     background: #4ac15a;
-  }
-  li {
-    margin-bottom: 1em;
   }
 
   /** Desktop **/

--- a/src/lib/components/PasteConfirm.svelte
+++ b/src/lib/components/PasteConfirm.svelte
@@ -16,7 +16,7 @@
 <script lang="ts">
   import "$lib/global.css";
   import { createEventDispatcher } from "svelte";
-  import { EarningRecord } from "$lib/earning-record";
+  import type { EarningRecord } from "$lib/earning-record";
 
   const dispatch = createEventDispatcher();
 
@@ -42,7 +42,7 @@
 
 <div>
   <div class="confirmation">
-    <h3>Step 2 of 3: Confirm Earnings Record</h3>
+    <h3>Step 1 of 2: Confirm Earnings Record</h3>
     <p>Is this the same table you copied from ssa.gov?</p>
 
     <button on:click={confirm} class="success">

--- a/src/lib/components/PasteFlow.svelte
+++ b/src/lib/components/PasteFlow.svelte
@@ -155,18 +155,9 @@
   {/if}
   {#if mode === Mode.INITIAL}
     {#if isRecipient}
-      <div class="text">
-        <p>
-          To use the calculator, you must provide data from your Social Security
-          record. If you aren't ready for that yet, select a demo data set at
-          the bottom of the page.
-        </p>
-      </div>
-      <PastePrompt on:demo={handleDemo} on:paste={handlePaste} />
       <DemoData on:demo={handleDemo} />
-    {:else}
-      <PastePrompt on:demo={handleDemo} on:paste={handlePaste} />
     {/if}
+    <PastePrompt on:demo={handleDemo} on:paste={handlePaste} />
   {:else if mode === Mode.PASTE_CONFIRMATION}
     {#if isRecipient}
       <PasteConfirm

--- a/src/lib/components/PastePrompt.svelte
+++ b/src/lib/components/PastePrompt.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <div class="pastePrompt">
-  <h3>Step 1 of 3: Retrieve Social Security data</h3>
+  <h3>Step 1 of 2: Retrieve Social Security data</h3>
   <ol>
     <li>
       Sign in to

--- a/src/lib/components/PastePrompt.svelte
+++ b/src/lib/components/PastePrompt.svelte
@@ -103,13 +103,6 @@
       </p>
     </div>
   </div>
-
-  <p>
-    Alternatively, just paste any text formatted string with year and earnings
-    in the same line, for example:
-  </p>
-  <pre class="pasteableData">2000 $10,000
-2001 $15,000</pre>
 </div>
 
 <style>


### PR DESCRIPTION
Main change is the date picker. 

The browser native <input type=date> box has a poor mobile UX for picking non-recent dates.

It appears that the only affordance for navigating backwards from the current month is one month per tap. For someone in their 60s looking at retirement, that would indeed be hundreds of taps to select their birthday.

![Native Date Picker](https://github.com/Gregable/social-security-tools/assets/25519/08a508e0-aff6-4bc7-a444-acd9ffbca0ca)

I went with https://design-system.service.gov.uk/patterns/dates/#asking-for-memorable-dates after swapping month / day for a US audience:

![3 fields: month, day, year](https://github.com/Gregable/social-security-tools/assets/25519/4bcb4c1b-41e4-4378-b227-e1f061cb08cc)
