### PR TITLE
Use the recipient store less frequently

### DIFF
--- a/src/lib/components/CombinedChart.svelte
+++ b/src/lib/components/CombinedChart.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import "$lib/global.css";
-  import { Birthdate } from "$lib/birthday";
   import { Recipient } from "$lib/recipient";
   import { Money } from "$lib/money";
   import Slider from "./Slider.svelte";
   import RecipientName from "./RecipientName.svelte";
 
   import { MonthDate, MonthDuration } from "$lib/month-time";
-  import { PrimaryInsuranceAmount } from "$lib/pia";
 
   export let recipient: Recipient = new Recipient();
   export let spouse: Recipient = new Recipient();
@@ -776,23 +774,21 @@
   function YoungerOlder(): [Recipient, Recipient] {
     // If the recipients are the same age, arbitrarily pick the recipient
     // as the younger one.
-    if (
-      $recipient.birthdate.ssaBirthdate() == $spouse.birthdate.ssaBirthdate()
-    ) {
-      return [$recipient, $spouse];
+    if (recipient.birthdate.ssaBirthdate() == spouse.birthdate.ssaBirthdate()) {
+      return [recipient, spouse];
     }
 
     // Determine which recipient is older / younger.
     // Slight point of confusion: The younger recipient is the
     // one who has the *higher* birthdate.
     const youngerRecipient: Recipient =
-      $recipient.birthdate.ssaBirthdate() < $spouse.birthdate.ssaBirthdate()
-        ? $spouse
-        : $recipient;
+      recipient.birthdate.ssaBirthdate() < spouse.birthdate.ssaBirthdate()
+        ? spouse
+        : recipient;
     const olderRecipient: Recipient =
-      $recipient.birthdate.ssaBirthdate() < $spouse.birthdate.ssaBirthdate()
-        ? $recipient
-        : $spouse;
+      recipient.birthdate.ssaBirthdate() < spouse.birthdate.ssaBirthdate()
+        ? recipient
+        : spouse;
 
     return [youngerRecipient, olderRecipient];
   }
@@ -917,8 +913,8 @@
   {/if}
   <p>
     The following <i class="noprint">interactive</i> tool visualizes how
-    different filing dates for both <RecipientName r={$recipient} /> and <RecipientName
-      r={$spouse}
+    different filing dates for both <RecipientName r={recipient} /> and <RecipientName
+      r={spouse}
     /> affect total benefits, including the spousal benefit.
     <span class="noprint"
       >Move the slider to select a filing date for each person and hover over
@@ -944,14 +940,14 @@
     <p class="sliderLabel">
       <span class="noprint">
         Select the age that <RecipientName
-          r={$recipient}
+          r={recipient}
           suffix="
   files">you file</RecipientName
         > for benefits:
       </span>
       <span class="onlyprint">
         Age that <RecipientName
-          r={$recipient}
+          r={recipient}
           suffix="
   files">you file</RecipientName
         > for benefits:
@@ -984,14 +980,14 @@
     <p class="sliderLabel">
       <span class="noprint">
         Select the age that <RecipientName
-          r={$spouse}
+          r={spouse}
           suffix="
   files">you file</RecipientName
         > for benefits:
       </span>
       <span class="onlyprint">
         Age that <RecipientName
-          r={$spouse}
+          r={spouse}
           suffix="
   files">you file</RecipientName
         > for benefits:

--- a/src/lib/components/EligibilityReport.svelte
+++ b/src/lib/components/EligibilityReport.svelte
@@ -6,7 +6,7 @@
   import RName from "./RecipientName.svelte";
 
   export let recipient: Recipient = new Recipient();
-  let r = $recipient;
+  let r = recipient;
 </script>
 
 <div class="pageBreakAvoid">

--- a/src/lib/components/FilingDateChart.svelte
+++ b/src/lib/components/FilingDateChart.svelte
@@ -44,7 +44,7 @@
   let blueish_ = "#337ab7";
 
   onMount(() => {
-    sliderMonths_ = $recipient.normalRetirementAge().asMonths();
+    sliderMonths_ = recipient.normalRetirementAge().asMonths();
     updateCanvas();
     mounted_ = true;
     media_query_list = window.matchMedia("print");
@@ -125,19 +125,19 @@
    */
   function maxRenderedYDollars(): Money {
     const maxAge = MonthDuration.initFromYearsMonths({ years: 70, months: 0 });
-    return $recipient.benefitAtAge(maxAge);
+    return recipient.benefitAtAge(maxAge);
   }
 
   /**
    * Compute the canvas x-coordinate for a date.
    */
   function canvasX(date: MonthDate): number {
-    const startDate: MonthDate = $recipient.birthdate.dateAtSsaAge(
+    const startDate: MonthDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
     );
     // Allow the canvas to show all of the way to age 71, so that there is
     // some rendered space if the user slides the slider all of the way to 70.
-    const endDate = $recipient.birthdate.dateAtSsaAge(
+    const endDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
     );
     const xValue =
@@ -152,10 +152,10 @@
    * @param x The x-coordinate in canvas pixels.
    */
   function dateX(x: number): MonthDate {
-    const startDate: MonthDate = $recipient.birthdate.dateAtSsaAge(
+    const startDate: MonthDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
     );
-    const endDate = $recipient.birthdate.dateAtSsaAge(
+    const endDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
     );
 
@@ -256,10 +256,10 @@
     ctx_.strokeStyle = "#666";
     ctx_.setLineDash([2, 2]);
 
-    let startDate: MonthDate = $recipient.birthdate.dateAtSsaAge(
+    let startDate: MonthDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
     );
-    let endDate = $recipient.birthdate.dateAtSsaAge(
+    let endDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
     );
 
@@ -312,7 +312,7 @@
     // We don't want users to select a start date earlier than is allowed.
     // For those born on the 1st/2nd, that's 62y0m. For everyone else, it's
     // 62y1m.
-    if ($recipient.birthdate.layBirthDayOfMonth() <= 2) {
+    if (recipient.birthdate.layBirthDayOfMonth() <= 2) {
       userFloor_ = 62 * 12;
     } else {
       userFloor_ = 62 * 12 + 1;
@@ -327,7 +327,7 @@
       age.lessThanOrEqual(endAge);
       age = age.add(MonthDuration.initFromYearsMonths({ years: 1, months: 0 }))
     ) {
-      const monthsUntilNRA: number = $recipient
+      const monthsUntilNRA: number = recipient
         .normalRetirementAge()
         .subtract(age)
         .asMonths();
@@ -337,7 +337,7 @@
           value: age.asMonths(),
           label: translateSliderLabel(age.asMonths(), "tick-value"),
           legend: "NRA",
-          color: $recipient.colors().dark,
+          color: recipient.colors().dark,
         });
       } else {
         // Not an NRA tick, so just add it normally.
@@ -350,10 +350,10 @@
       if (monthsUntilNRA > 0 && monthsUntilNRA < 12) {
         // The NRA is between this and the next tick: add a special tick for it.
         customTicks_.push({
-          value: $recipient.normalRetirementAge().asMonths(),
+          value: recipient.normalRetirementAge().asMonths(),
           label: "",
           legend: "NRA",
-          color: $recipient.colors().dark,
+          color: recipient.colors().dark,
         });
       }
     }
@@ -362,7 +362,7 @@
 
   function userSelectedDate() {
     let selectedAge = new MonthDuration(sliderMonths_);
-    let selectedDate = $recipient.birthdate.dateAtSsaAge(selectedAge);
+    let selectedDate = recipient.birthdate.dateAtSsaAge(selectedAge);
     return selectedDate;
   }
 
@@ -382,7 +382,7 @@
     let selectedDate = userSelectedDate();
 
     let boxes = [];
-    let benefit = $recipient.benefitOnDate(selectedDate, selectedDate);
+    let benefit = recipient.benefitOnDate(selectedDate, selectedDate);
     boxes.push([canvasX(selectedDate), canvasY(benefit), benefit]);
 
     for (
@@ -390,10 +390,8 @@
       i.lessThanOrEqual(dateX(canvasEl_.width));
       i = i.addDuration(new MonthDuration(1))
     ) {
-      if (
-        $recipient.benefitOnDate(selectedDate, i).value() != benefit.value()
-      ) {
-        benefit = $recipient.benefitOnDate(selectedDate, i);
+      if (recipient.benefitOnDate(selectedDate, i).value() != benefit.value()) {
+        benefit = recipient.benefitOnDate(selectedDate, i);
         boxes.push([canvasX(i), canvasY(benefit), benefit]);
       }
     }
@@ -407,7 +405,7 @@
   function renderFilingDateBenefitBoxes(boxes: Array<[number, number, Money]>) {
     ctx_.save();
 
-    ctx_.strokeStyle = $recipient.colors().medium;
+    ctx_.strokeStyle = recipient.colors().medium;
     ctx_.lineWidth = 2;
     ctx_.beginPath();
 
@@ -428,7 +426,7 @@
     // Draw all of the way to the right edge of the chart.
     ctx_.lineTo(canvasEl_.width, boxes[boxes.length - 1][1]);
 
-    ctx_.fillStyle = $recipient.colors().light;
+    ctx_.fillStyle = recipient.colors().light;
     ctx_.fill();
     ctx_.stroke();
     ctx_.restore();
@@ -449,7 +447,7 @@
    */
   function renderBenefitLabels(boxes: Array<[number, number, Money]>) {
     ctx_.save();
-    ctx_.fillStyle = $recipient.colors().dark;
+    ctx_.fillStyle = recipient.colors().dark;
     ctx_.font = "14px Helvetica";
     let font_height = 12;
 
@@ -516,15 +514,15 @@
    */
   function renderTrendline() {
     ctx_.save();
-    ctx_.strokeStyle = $recipient.colors().medium;
+    ctx_.strokeStyle = recipient.colors().medium;
     ctx_.lineWidth = 2;
     ctx_.globalAlpha = 0.4;
     ctx_.beginPath();
 
-    const startDate: MonthDate = $recipient.birthdate.dateAtSsaAge(
+    const startDate: MonthDate = recipient.birthdate.dateAtSsaAge(
       new MonthDuration(userFloor_)
     );
-    const endDate = $recipient.birthdate.dateAtSsaAge(
+    const endDate = recipient.birthdate.dateAtSsaAge(
       MonthDuration.initFromYearsMonths({ years: 70, months: 0 })
     );
 
@@ -535,7 +533,7 @@
     ) {
       let thisX = canvasX(i);
       // Determine the maximum eventual benefit for a filing date of i.
-      let yDollars = $recipient.benefitOnDate(i, i);
+      let yDollars = recipient.benefitOnDate(i, i);
       let thisY = canvasY(yDollars);
       if (i.monthsSinceEpoch() == startDate.monthsSinceEpoch()) {
         ctx_.moveTo(thisX, thisY);
@@ -646,7 +644,7 @@
   }
   let filingDateString_: string = "";
   $: filingDateString_ = updateFilingDateString(
-    $recipient.birthdate,
+    recipient.birthdate,
     sliderMonths_
   );
 </script>
@@ -655,14 +653,14 @@
 <div class="chart-container">
   <p class="noprint">
     Select the age that <RecipientName
-      r={$recipient}
+      r={recipient}
       suffix="
   files">you file</RecipientName
     > for benefits:
   </p>
   <p class="onlyprint">
     Age that <RecipientName
-      r={$recipient}
+      r={recipient}
       suffix="
   files">you file</RecipientName
     > for benefits:
@@ -682,13 +680,13 @@
       translate={translateSliderLabel}
       showTicks={true}
       ticksArray={customTicks_}
-      barLeftColor={$recipient.colors().light}
-      barRightColor={$recipient.colors().medium}
-      tickLeftColor={$recipient.colors().light}
-      tickRightColor={$recipient.colors().medium}
-      handleColor={$recipient.colors().medium}
-      handleSelectedColor={$recipient.colors().dark}
-      tickLegendColor={$recipient.colors().dark}
+      barLeftColor={recipient.colors().light}
+      barRightColor={recipient.colors().medium}
+      tickLeftColor={recipient.colors().light}
+      tickRightColor={recipient.colors().medium}
+      handleColor={recipient.colors().medium}
+      handleSelectedColor={recipient.colors().dark}
+      tickLegendColor={recipient.colors().dark}
     />
   </div>
   <canvas
@@ -704,7 +702,7 @@
     class="selectedDateBox"
     style:--selected-date-border-color={blueish_}
     style:--selected-date-text-color={blueish_}
-    style:--filing-date-text-color={$recipient.colors().dark}
+    style:--filing-date-text-color={recipient.colors().dark}
     class:hidden={lastMouseX_ <= 0}
   >
     {#if lastMouseX_ > 0}
@@ -716,7 +714,7 @@
       <span class="selectedDate"
         >{dateX(lastMouseX_).monthName()}
         {dateX(lastMouseX_).year()}</span
-      >, <RecipientName r={$recipient} apos noColor={true} shortenTo={30}
+      >, <RecipientName r={recipient} apos noColor={true} shortenTo={30}
         >your</RecipientName
       > benefit will be:
 

--- a/src/lib/components/FilingDateReport.svelte
+++ b/src/lib/components/FilingDateReport.svelte
@@ -8,15 +8,13 @@
   import Expando from "./Expando.svelte";
 
   export let recipient: Recipient = new Recipient();
-  let r: Recipient = $recipient;
+  let r: Recipient = recipient;
 
-  let exampleAge: { age: number; day: number; month: string; year: number };
-  $: exampleAge = $recipient.birthdate.exampleSsaAge(constants.CURRENT_YEAR);
+  let exampleAge = recipient.birthdate.exampleSsaAge(constants.CURRENT_YEAR);
 
-  let followingMonth: MonthDate;
-  $: followingMonth = MonthDate.initFromYearsMonths({
+  let followingMonth = MonthDate.initFromYearsMonths({
     years: constants.CURRENT_YEAR,
-    months: $recipient.birthdate.ssaBirthMonthDate().monthIndex(),
+    months: recipient.birthdate.ssaBirthMonthDate().monthIndex(),
   }).addDuration(new MonthDuration(1));
 
   function twoSignificantDigits(n: number) {
@@ -45,14 +43,14 @@
       {:else}
         <p>
           <RName {r}>You</RName> can begin taking benefits as early as
-          {#if $recipient.birthdate.layBirthDayOfMonth() == 2}
+          {#if recipient.birthdate.layBirthDayOfMonth() == 2}
             62 years old (<b
-              >{$recipient.birthdate
+              >{recipient.birthdate
                 .dateAtSsaAge(
                   MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
                 )
                 .monthFullName()}
-              {$recipient.birthdate
+              {recipient.birthdate
                 .dateAtSsaAge(
                   MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
                 )
@@ -60,12 +58,12 @@
             >),
           {:else}
             62 years and 1 month old (<b
-              >{$recipient.birthdate
+              >{recipient.birthdate
                 .dateAtSsaAge(
                   MonthDuration.initFromYearsMonths({ years: 62, months: 1 })
                 )
                 .monthFullName()}
-              {$recipient.birthdate
+              {recipient.birthdate
                 .dateAtSsaAge(
                   MonthDuration.initFromYearsMonths({ years: 62, months: 1 })
                 )
@@ -73,18 +71,18 @@
             >),
           {/if}
           wait until as late as 70 years old (<b
-            >{$recipient.birthdate
+            >{recipient.birthdate
               .dateAtSsaAge(
                 MonthDuration.initFromYearsMonths({ years: 70, months: 0 })
               )
               .monthFullName()}
-            {$recipient.birthdate
+            {recipient.birthdate
               .dateAtSsaAge(
                 MonthDuration.initFromYearsMonths({ years: 70, months: 0 })
               )
               .year()}</b
           >), or start any month in between. The longer <RName
-            r={$recipient}
+            r={recipient}
             suffix=" waits">you wait</RName
           >, the higher the benefit.
         </p>
@@ -97,7 +95,7 @@
       collapsedText="Expand to learn about the effect of Filing before or after Normal Retirement Age"
       expandedText="Show Less"
     >
-      {#if $recipient.birthdate.layBirthDayOfMonth() != 2}
+      {#if recipient.birthdate.layBirthDayOfMonth() != 2}
         <div class="insetTextBox">
           <h4>Special Rule</h4>
           <p>
@@ -110,9 +108,9 @@
             attaining age 62.
           </p>
           <p>
-            {#if $recipient.birthdate.layBirthDayOfMonth() == 1}
+            {#if recipient.birthdate.layBirthDayOfMonth() == 1}
               For example, <RName {r} suffix=" was">you were</RName> born on
-              <b>{$recipient.birthdate.layBirthdateString()}</b>. <RName
+              <b>{recipient.birthdate.layBirthdateString()}</b>. <RName
                 {r}
                 suffix=" attains">You attain</RName
               > age <b>{exampleAge.age}</b>
@@ -126,7 +124,7 @@
               >.
             {:else}
               For example, <RName {r} suffix=" was">you were</RName> born on
-              <b>{$recipient.birthdate.layBirthdateString()}</b>, so the first
+              <b>{recipient.birthdate.layBirthdateString()}</b>, so the first
               month that <RName {r} suffix=" is">you are</RName>
               <b>{exampleAge.age}</b>
               throughout the <u>entire</u> month is
@@ -150,8 +148,8 @@
           If <RName {r} suffix=" chooses">you choose</RName> to take benefits
           <i>earlier</i>
           than normal retirement age (<b
-            >{$recipient.normalRetirementDate().monthFullName()}
-            {$recipient.normalRetirementDate().year()}</b
+            >{recipient.normalRetirementDate().monthFullName()}
+            {recipient.normalRetirementDate().year()}</b
           >), <RName {r} apos>your</RName> benefit amount will be
           <u>permanently</u> <i>reduced</i>:
         </p>
@@ -168,15 +166,15 @@
         <p>
           The 36 month mark before normal retirement age is age
           <b
-            >{$recipient.earlyRetirementInflectionAge().years()} years
-            {#if $recipient.earlyRetirementInflectionAge().modMonths() != 0}
+            >{recipient.earlyRetirementInflectionAge().years()} years
+            {#if recipient.earlyRetirementInflectionAge().modMonths() != 0}
               and
-              {$recipient.earlyRetirementInflectionAge().modMonths()} months >
+              {recipient.earlyRetirementInflectionAge().modMonths()} months >
             {/if}</b
           >
           (<b
-            >{$recipient.earlyRetirementInflectionDate().monthName()}
-            {$recipient.earlyRetirementInflectionDate().year()}</b
+            >{recipient.earlyRetirementInflectionDate().monthName()}
+            {recipient.earlyRetirementInflectionDate().year()}</b
           >).
         </p>
       </div>
@@ -187,14 +185,14 @@
           If <RName {r} suffix=" chooses">you choose</RName> to delay until
           <i>later</i>
           than normal retirement age (<b
-            >{$recipient.normalRetirementDate().monthFullName()}
-            {$recipient.normalRetirementDate().year()}</b
+            >{recipient.normalRetirementDate().monthFullName()}
+            {recipient.normalRetirementDate().year()}</b
           >) to start <RName {r} apos>your</RName> benefit, the amount will be
           <u>permanently</u>
           <i>increased</i>:
         </p>
         <ul>
-          {#if $recipient.delayedRetirementIncrease() == 0.08}
+          {#if recipient.delayedRetirementIncrease() == 0.08}
             <li>
               <b>2 / 3</b> of one percent per month (<b>8%</b> per year) for each
               month after normal retirement age, up age 70.
@@ -203,10 +201,10 @@
             <li>
               <b
                 >{twoSignificantDigits(
-                  ($recipient.delayedRetirementIncrease() * 100) / 12
+                  (recipient.delayedRetirementIncrease() * 100) / 12
                 )}%</b
               >
-              per month (<b>{$recipient.delayedRetirementIncrease() * 100}%</b>
+              per month (<b>{recipient.delayedRetirementIncrease() * 100}%</b>
               per year) for each month after normal retirement age, up age 70.
             </li>
           {/if}
@@ -237,7 +235,7 @@
           >
         </p>
       </div>
-      <FilingDateChart recipient={$recipient} />
+      <FilingDateChart {recipient} />
     </div>
   {/if}
 </div>

--- a/src/lib/components/FutureEarningsSliders.svelte
+++ b/src/lib/components/FutureEarningsSliders.svelte
@@ -36,14 +36,14 @@
   function remainingEarningYears(recipient: Recipient): number {
     if (!recipient) return 0;
     let years =
-      $recipient.normalRetirementDate().year() - constants.CURRENT_YEAR + 1;
+      recipient.normalRetirementDate().year() - constants.CURRENT_YEAR + 1;
     // The slider can go from 0 to 35 years.
     return Math.min(35, Math.max(0, years));
   }
   function mostRecentEarningWage(recipient: Recipient): Money {
-    const numEarningsYears = $recipient.earningsRecords.length;
+    const numEarningsYears = recipient.earningsRecords.length;
     if (numEarningsYears == 0) return Money.from(1000);
-    let earningRecord = $recipient.earningsRecords[numEarningsYears - 1];
+    let earningRecord = recipient.earningsRecords[numEarningsYears - 1];
     if (
       earningRecord.year == constants.CURRENT_YEAR ||
       earningRecord.year == constants.CURRENT_YEAR - 1 ||
@@ -58,13 +58,13 @@
   // the year of the normal retirement age. We want the sliders to start
   // in the same place as ssa.gov, but the user can of course move them from
   // there.
-  let futureEarningYears: number = remainingEarningYears($recipient);
-  let futureEarningWage: number = mostRecentEarningWage($recipient)
+  let futureEarningYears: number = remainingEarningYears(recipient);
+  let futureEarningWage: number = mostRecentEarningWage(recipient)
     .roundToDollar()
     .value();
 
   function update(futureEarningYears: number, futureEarningWage: Money) {
-    $recipient.simulateFutureEarningsYears(
+    recipient.simulateFutureEarningsYears(
       futureEarningYears,
       futureEarningWage
     );
@@ -140,7 +140,7 @@
 <div class="sliders" bind:this={slidersEl}>
   <div class="grid">
     <div class="item left">
-      <RecipientName r={$recipient} shortenTo={15} suffix=" plans"
+      <RecipientName r={recipient} shortenTo={15} suffix=" plans"
         >I plan</RecipientName
       > to work for
     </div>

--- a/src/lib/components/IndexedEarningsReport.svelte
+++ b/src/lib/components/IndexedEarningsReport.svelte
@@ -25,9 +25,8 @@
         Social Security Benefits are based on the <u
           >Averaged Indexed Monthly Earnings</u
         >
-        (AIME). This is the monthly average of <RecipientName
-          r={$recipient}
-          apos>your</RecipientName
+        (AIME). This is the monthly average of <RecipientName r={recipient} apos
+          >your</RecipientName
         > highest 35 years of earnings, adjusted over time by wage growth.
       </p>
 
@@ -39,7 +38,7 @@
     </div>
 
     <p class="noprint">
-      To understand how <RecipientName r={$recipient} apos>your</RecipientName> AIME
+      To understand how <RecipientName r={recipient} apos>your</RecipientName> AIME
       is calculated, expand the box below:
     </p>
 
@@ -51,7 +50,7 @@
       <div class="expando">
         <div class="pageBreakAvoid">
           <p>
-            <RecipientName r={$recipient} suffix=" has">You have</RecipientName>
+            <RecipientName r={recipient} suffix=" has">You have</RecipientName>
             <b>{totalRecords}</b> total years of lifetime Social Security earnings,
             shown in the table below.
           </p>
@@ -59,7 +58,7 @@
           <p>
             The multipliers and indexed earnings in the table below will
             increase every year until <RecipientName
-              r={$recipient}
+              r={recipient}
               suffix=" reaches">you reach</RecipientName
             > age 60, after which point they are fixed. Years after age 60 will be
             a 1.0 multiplier. The increase in the multipliers is determined by US
@@ -70,9 +69,9 @@
           {#if totalRecords >= 35}
             <p>
               For
-              <RecipientName r={$recipient}>you</RecipientName>, this means that
+              <RecipientName r={recipient}>you</RecipientName>, this means that
               years where the indexed earnings value falls below
-              <b>{$recipient.cutoffIndexedEarnings().wholeDollars()}</b>
+              <b>{recipient.cutoffIndexedEarnings().wholeDollars()}</b>
               do not affect the benefit calculation because they are not among the
               top 35.
             </p>
@@ -86,20 +85,20 @@
           {/if}
 
           <p>
-            To calculate <RecipientName r={$recipient} apos>your</RecipientName>
+            To calculate <RecipientName r={recipient} apos>your</RecipientName>
             total indexed earnings, simply sum the top 35 values in the indexed earnings
             column in the earnings record table below.
           </p>
 
           <p class="indent">
-            <RecipientName r={$recipient} apos>Your</RecipientName>
+            <RecipientName r={recipient} apos>Your</RecipientName>
             total indexed earnings:
             <b>{$recipient.totalIndexedEarnings().wholeDollars()}</b>
           </p>
 
           {#if totalRecords >= 35}
             <p>
-              <RecipientName r={$recipient} apos>Your</RecipientName>
+              <RecipientName r={recipient} apos>Your</RecipientName>
               <u>Averaged Indexed Monthly Earnings</u> (AIME) is simply the total
               indexed earnings divided by 35 years divided by 12 months, as follows:
             </p>
@@ -122,12 +121,12 @@
           </p>
         </div>
         <p>
-          Here is a table of <RecipientName r={$recipient} apos
+          Here is a table of <RecipientName r={recipient} apos
             >your</RecipientName
           >
           earnings, with wage indexing multipliers applied:
         </p>
-        <IndexedEarningsTable recipient={$recipient} />
+        <IndexedEarningsTable {recipient} />
       </div>
     </Expando>
   </div>

--- a/src/lib/components/NormalRetirementAgeReport.svelte
+++ b/src/lib/components/NormalRetirementAgeReport.svelte
@@ -6,10 +6,9 @@
   import { Money } from "$lib/money";
 
   export let recipient: Recipient = new Recipient();
-  let r: Recipient = $recipient;
+  const r: Recipient = recipient;
 
-  let exampleAge: { age: number; day: number; month: string; year: number };
-  $: exampleAge = $recipient.birthdate.exampleSsaAge(constants.CURRENT_YEAR);
+  const exampleAge = recipient.birthdate.exampleSsaAge(constants.CURRENT_YEAR);
 
   /**
    * The benefit amount at normal retirement age.
@@ -33,25 +32,25 @@
     <p>
       Normal Retirement Age is between 65 and 67, depending on when you were
       born. For <RName {r} suffix=" who was">those</RName>
-      born in <b>{$recipient.birthdate.ssaBirthYear()}</b>, normal retirement
-      age is
-      {#if $recipient.normalRetirementAge().modMonths() == 0}
-        <b>{$recipient.normalRetirementAge().years()}</b> years.
+      born in <b>{recipient.birthdate.ssaBirthYear()}</b>, normal retirement age
+      is
+      {#if recipient.normalRetirementAge().modMonths() == 0}
+        <b>{recipient.normalRetirementAge().years()}</b> years.
       {:else}
         <b
-          >{$recipient.normalRetirementAge().years()} years and {$recipient
+          >{recipient.normalRetirementAge().years()} years and {recipient
             .normalRetirementAge()
             .modMonths()} months</b
         >.
       {/if}
       This is in
       <b
-        >{$recipient.normalRetirementDate().monthFullName()},
-        {$recipient.normalRetirementDate().year()}</b
+        >{recipient.normalRetirementDate().monthFullName()},
+        {recipient.normalRetirementDate().year()}</b
       >.
     </p>
 
-    {#if $recipient.birthdate.isFirstOfMonth()}
+    {#if recipient.birthdate.isFirstOfMonth()}
       <div class="insetTextBox pageBreakAvoid">
         <h4>Special Rule</h4>
         <p>

--- a/src/lib/components/PiaReport.svelte
+++ b/src/lib/components/PiaReport.svelte
@@ -7,7 +7,7 @@
   import RName from "./RecipientName.svelte";
 
   export let recipient: Recipient = new Recipient();
-  let r: Recipient = $recipient;
+  const r: Recipient = recipient;
 
   function oneSignificantDigit(n: number) {
     return n.toLocaleString(undefined, {
@@ -37,7 +37,7 @@
         > / month
       </div>
 
-      {#if $recipient.isPiaOnly}
+      {#if recipient.isPiaOnly}
         <p>The amount above is the value you provided.</p>
       {:else if !$recipient.isEligible()}
         <p>
@@ -82,12 +82,12 @@
               <tr>
                 <td>
                   Any amount less than
-                  {$recipient.pia().firstBendPoint().wholeDollars()}
+                  {recipient.pia().firstBendPoint().wholeDollars()}
                   is multiplied by 90%:
                 </td>
                 <td>
                   <b
-                    >{$recipient
+                    >{recipient
                       .pia()
                       .primaryInsuranceAmountByBracket(0)
                       .string()}</b
@@ -98,9 +98,9 @@
               <tr>
                 <td>
                   The amount more than
-                  {$recipient.pia().firstBendPoint().wholeDollars()}
+                  {recipient.pia().firstBendPoint().wholeDollars()}
                   and less than
-                  {$recipient.pia().secondBendPoint().wholeDollars()}
+                  {recipient.pia().secondBendPoint().wholeDollars()}
                   is multiplied by 32%:
                 </td>
                 <td>
@@ -117,7 +117,7 @@
                 <td>
                   Any <span class="onlydisplay600">remaining</span> amount more
                   than
-                  {$recipient.pia().secondBendPoint().wholeDollars()}
+                  {recipient.pia().secondBendPoint().wholeDollars()}
                   is multiplied by 15%:
                 </td>
                 <td>
@@ -205,7 +205,7 @@
     </div>
   </div>
 
-  {#if !$recipient.isPiaOnly && $recipient.isEligible()}
+  {#if !recipient.isPiaOnly && $recipient.isEligible()}
     <div class="text pageBreakAvoid">
       <p style="margin-top: 1em">
         In the following chart, you can see what <RName {r} apos>your</RName>
@@ -215,7 +215,7 @@
           Amount changes.</span
         >
       </p>
-      <BendpointChart recipient={$recipient} />
+      <BendpointChart {recipient} />
     </div>
   {/if}
 </div>

--- a/src/lib/components/RecipientName.svelte
+++ b/src/lib/components/RecipientName.svelte
@@ -11,7 +11,7 @@
     with styling to help visually identify the user.
 
   @example
-    <RecipientName r={$recipient}/ suffix="'s">your</RecipientName>
+    <RecipientName r={recipient}/ suffix="'s">your</RecipientName>
     This will display as "your" if the recipient is the only user, or as
     "Alex's" for example if the recipient is not the only user.
 -->
@@ -58,11 +58,11 @@
 </script>
 
 <span
-  >{#if $r.only}<slot />{:else}<span
+  >{#if r.only}<slot />{:else}<span
       class="name"
       class:noColor
-      class:first={$r.first}
-      >{#if shortenTo}{$r.shortName(shortenTo)}{:else}{$r.name}{/if}</span
+      class:first={r.first}
+      >{#if shortenTo}{r.shortName(shortenTo)}{:else}{r.name}{/if}</span
     >{finalSuffix()}{/if}
 </span>
 

--- a/src/lib/components/SpousalBenefit.svelte
+++ b/src/lib/components/SpousalBenefit.svelte
@@ -12,13 +12,17 @@
 
   export let recipient: Recipient = new Recipient();
   export let spouse: Recipient = new Recipient();
-  let r: Recipient = $recipient;
-  let s: Recipient = $spouse;
+  const r: Recipient = recipient;
+  const s: Recipient = spouse;
 
   let higherEarner: Recipient;
   let lowerEarner: Recipient;
-  $: higherEarner = $r.higherEarningsThan($s) ? $r : $s;
-  $: lowerEarner = $r.higherEarningsThan($s) ? $s : $r;
+  $: higherEarner = $recipient.higherEarningsThan($spouse)
+    ? $recipient
+    : $spouse;
+  $: lowerEarner = $recipient.higherEarningsThan($spouse)
+    ? $spouse
+    : $recipient;
 
   function spousalBenefitCalc(higher: Recipient, lower: Recipient): Money {
     let maxSpousal = higher.pia().primaryInsuranceAmount().div(2);
@@ -64,52 +68,52 @@
 </script>
 
 <div>
-  <h3><RName r={$r} noColor /></h3>
+  <h3><RName {r} noColor /></h3>
   <div class="text">
-    {#if $r.higherEarningsThan($s)}
+    {#if $recipient.higherEarningsThan($spouse)}
       <p>
-        Because <RName r={$r} /> has higher earnings than <RName r={$s} />, <RName
-          r={$r}
+        Because <RName {r} /> has higher earnings than <RName r={s} />, <RName
+          {r}
         /> is not eligible to receive a spousal benefit.
       </p>
-    {:else if $r.pia().primaryInsuranceAmount().value() === $s
+    {:else if $recipient.pia().primaryInsuranceAmount().value() === $spouse
         .pia()
         .primaryInsuranceAmount()
         .value()}
       <p>
-        <RName r={$r} /> and <RName r={$s} /> have the same Primary Insurance Amount.
-        Therefore, <RName r={$r} /> is not eligible to receive a spousal benefit.
+        <RName {r} /> and <RName r={s} /> have the same Primary Insurance Amount.
+        Therefore, <RName {r} /> is not eligible to receive a spousal benefit.
       </p>
     {:else if spousalBenefit.value() == 0}
       <p>
-        <RName r={$r} /> has lower earnings than <RName r={$s} />. However <RName
-          r={$r}
+        <RName {r} /> has lower earnings than <RName r={s} />. However <RName
+          {r}
           apos
         /> Primary Insurance Amount is greater than half of
         <RName r={s} apos /> Primary Insurance Amount, so there is no spousal benefit
         payable.
       </p>
     {:else}
-      {#if $r.pia().primaryInsuranceAmount().value() == 0}
-        <RName r={$r} /> is eligible to receive a <u>spousal benefit</u> on <RName
-          r={$s}
+      {#if $recipient.pia().primaryInsuranceAmount().value() == 0}
+        <RName {r} /> is eligible to receive a <u>spousal benefit</u> on <RName
+          r={s}
           apos
-        /> record equal to half of <RName r={$s} apos /> Primary Insurance Amount.
+        /> record equal to half of <RName r={s} apos /> Primary Insurance Amount.
       {:else}
-        <RName r={$r} /> is eligible to receive a <u>spousal benefit</u> on <RName
-          r={$s}
+        <RName {r} /> is eligible to receive a <u>spousal benefit</u> on <RName
+          r={s}
           apos
         /> record. A spousal benefit is the amount at normal retirement age that
-        <RName r={$r} /> recieves in addition to <RName r={$r} apos />
+        <RName {r} /> recieves in addition to <RName {r} apos />
         own benefit of
-        <b>{$r.pia().primaryInsuranceAmount().string()}</b>
+        <b>{$recipient.pia().primaryInsuranceAmount().string()}</b>
         / month.
       {/if}
       <div class="banner">
         Spousal Benefit: <b>{spousalBenefit.string()}</b> / month
       </div>
 
-      {#if $r.pia().primaryInsuranceAmount().value() > 0}
+      {#if $recipient.pia().primaryInsuranceAmount().value() > 0}
         <Expando
           collapsedText="Expand for a detailed look at the Spousal Benefit"
           expandedText="Show Less"
@@ -117,34 +121,35 @@
         >
           <div class="expando">
             <p>
-              <RName r={$r} apos /> spousal benefit at normal retirement age is calculated
-              as 50% of <RName r={$s} apos /> Primary Insurance Amount minus <RName
-                r={$r}
+              <RName {r} apos /> spousal benefit at normal retirement age is calculated
+              as 50% of <RName r={s} apos /> Primary Insurance Amount minus <RName
+                {r}
                 apos
               /> own Primary Insurance Amount.
             </p>
             <ul class="pialist">
               <li>
-                <RName r={$s} apos /> Primary Insurance Amount:
+                <RName r={s} apos /> Primary Insurance Amount:
                 <span class="nowrap">
-                  <b>{$s.pia().primaryInsuranceAmount().string()}</b>
+                  <b>{$spouse.pia().primaryInsuranceAmount().string()}</b>
                   / month.</span
                 >
               </li>
               <li>
-                <RName r={$r} apos /> Primary Insurance Amount:
+                <RName {r} apos /> Primary Insurance Amount:
                 <span class="nowrap">
-                  <b>{$r.pia().primaryInsuranceAmount().string()}</b>
+                  <b>{$recipient.pia().primaryInsuranceAmount().string()}</b>
                   / month.</span
                 >
               </li>
             </ul>
             <p>
-              <RName r={$r} apos /> Spousal Benefit:
+              <RName {r} apos /> Spousal Benefit:
               <span class="nowrap"
                 >(
-                <b>{$s.pia().primaryInsuranceAmount().string()}</b> x 50% ) -
-                <b>{$r.pia().primaryInsuranceAmount().string()}</b> =
+                <b>{$spouse.pia().primaryInsuranceAmount().string()}</b> x 50% )
+                -
+                <b>{$recipient.pia().primaryInsuranceAmount().string()}</b> =
                 <b>{spousalBenefit.string()}</b></span
               >
             </p>
@@ -152,7 +157,9 @@
             <div class="curlyvisualization">
               <div style="width: 100%">
                 <div class="curlyText" style="width: {spousalBenefitFraction}%">
-                  Personal (<b>{$r.pia().primaryInsuranceAmount().string()}</b>)
+                  Personal (<b
+                    >{$recipient.pia().primaryInsuranceAmount().string()}</b
+                  >)
                 </div>
                 <div
                   class="curlyText"
@@ -164,13 +171,13 @@
               <br style="clear: both" />
               <div
                 class="fullCurlyBar"
-                class:firstRecipient={$r.first}
-                class:secondRecipient={!$r.first}
+                class:firstRecipient={r.first}
+                class:secondRecipient={!r.first}
               >
                 <div
                   class="leftCurlyBar"
-                  class:firstRecipient={!$r.first}
-                  class:secondRecipient={$r.first}
+                  class:firstRecipient={!r.first}
+                  class:secondRecipient={r.first}
                   style="width: {spousalBenefitFraction}%"
                 />
               </div>
@@ -182,7 +189,7 @@
               />
               <div style="width: 100%; text-align: center;">
                 Total: <b
-                  >{$r
+                  >{$recipient
                     .pia()
                     .primaryInsuranceAmount()
                     .plus(spousalBenefit)
@@ -195,20 +202,20 @@
       {/if}
       <h4>Filing Date</h4>
       <p>
-        <RName r={$r} /> will begin receiving spousal benefits at the latter of either
-        the date that <RName r={$r} /> or <RName r={$s} /> files for benefits.
+        <RName {r} /> will begin receiving spousal benefits at the latter of either
+        the date that <RName {r} /> or <RName r={s} /> files for benefits.
       </p>
       <Expando
         collapsedText="Expand for detail about the effect of Filing Date on Spousal Benefits"
         expandedText="Show Less"
       >
         <div class="expando">
-          {#if $r.pia().primaryInsuranceAmount().value() == 0}
+          {#if $recipient.pia().primaryInsuranceAmount().value() == 0}
             <p>
-              <RName r={$r} /> can choose the filing date to begin receiving spousal
+              <RName {r} /> can choose the filing date to begin receiving spousal
               benefits. However,
-              <RName r={$r} /> is not eligible to begin spousal benefits until
-              <RName r={$s} /> begins primary benefits. (If applicable, see
+              <RName {r} /> is not eligible to begin spousal benefits until
+              <RName r={s} /> begins primary benefits. (If applicable, see
               <a
                 href="https://www.ssa.gov/benefits/retirement/planner/applying7.html#h4"
                 target="_blank">divorced spouses</a
@@ -222,34 +229,34 @@
 
             <ul>
               <li>
-                <RName r={$r} /> is not eligible to begin spousal benefits until
-                <RName r={$s} /> begins primary benefits. (If applicable, see
+                <RName {r} /> is not eligible to begin spousal benefits until
+                <RName r={s} /> begins primary benefits. (If applicable, see
                 <a
                   href="https://www.ssa.gov/benefits/retirement/planner/applying7.html#h4"
                   target="_blank">divorced spouses</a
                 >.)
               </li>
               <li>
-                <RName r={$r} /> must elect to collect all or none of the benefits
-                <RName r={$r} /> is eligible for. This is known as the
+                <RName {r} /> must elect to collect all or none of the benefits
+                <RName {r} /> is eligible for. This is known as the
                 <u>deeming</u> rule; you are deemed to be filing for all
                 benefits you are eligible for. Examples:
                 <ul>
                   <li>
-                    <RName r={$r} /> cannot choose to delay personal benefits while
+                    <RName {r} /> cannot choose to delay personal benefits while
                     collecting spousal benefits.
                   </li>
                   <li>
-                    Once <RName r={$r} />
-                    begins personal benefits, <RName r={$r} /> cannot delay spousal
-                    benefits beyond when <RName r={$s} /> begins primary benefits.
+                    Once <RName {r} />
+                    begins personal benefits, <RName {r} /> cannot delay spousal
+                    benefits beyond when <RName r={s} /> begins primary benefits.
                   </li>
                 </ul>
               </li>
             </ul>
             <p>
-              Since <RName r={$r} apos /> personal and spousal benefits may begin
-              on different dates, the reduction factors for early filing may applied
+              Since <RName {r} apos /> personal and spousal benefits may begin on
+              different dates, the reduction factors for early filing may applied
               from different starting dates for each of the two benefits.
             </p>
           {/if}
@@ -258,8 +265,8 @@
             If <RName {r} /> chooses to file for spousal benefits
             <i>earlier</i>
             than <RName {r} apos /> normal retirement age (<b
-              >{$r.normalRetirementDate().monthFullName()}
-              {$r.normalRetirementDate().year()}</b
+              >{recipient.normalRetirementDate().monthFullName()}
+              {recipient.normalRetirementDate().year()}</b
             >), the spousal benefit amount will be
             <u>permanently</u> <i>reduced</i>:
           </p>
@@ -276,15 +283,15 @@
           <p>
             The 36 month mark before normal retirement age is age
             <b
-              >{$recipient.earlyRetirementInflectionAge().years()} years
-              {#if $recipient.earlyRetirementInflectionAge().modMonths() != 0}
+              >{recipient.earlyRetirementInflectionAge().years()} years
+              {#if recipient.earlyRetirementInflectionAge().modMonths() != 0}
                 and
-                {$recipient.earlyRetirementInflectionAge().modMonths()} months >
+                {recipient.earlyRetirementInflectionAge().modMonths()} months >
               {/if}</b
             >
             (<b
-              >{$recipient.earlyRetirementInflectionDate().monthName()}
-              {$recipient.earlyRetirementInflectionDate().year()}</b
+              >{recipient.earlyRetirementInflectionDate().monthName()}
+              {recipient.earlyRetirementInflectionDate().year()}</b
             >).
           </p>
           <h4>Delayed Filing for Spousal Benefits</h4>

--- a/src/lib/components/SpousalReport.svelte
+++ b/src/lib/components/SpousalReport.svelte
@@ -14,8 +14,8 @@
       In addition to your own <u>primary</u> benefit, married couples may earn
       <u>spousal</u> Social Security benefits based on each other's records.
     </p>
-    <SpousalBenefit recipient={$recipient} spouse={$spouse} />
-    <SpousalBenefit recipient={$spouse} spouse={$recipient} />
+    <SpousalBenefit {recipient} {spouse} />
+    <SpousalBenefit recipient={spouse} spouse={recipient} />
   </div>
 </div>
 


### PR DESCRIPTION
Now that I better understand the `$` syntax's behavior, I can see that in a number of places, we are subscribing to updates when they are not relevant. Most of these are for the recipient names, which don't change after the initial flow.

This change reduces the number of subscriptions, which should have the effect of reducing some CPU from callbacks. It's probably minimal, but at least it's a little cleaner.