### PR TITLE
Fix CSS for guides.

### DIFF
--- a/src/routes/guides/1st-and-2nd-of-month/+page.svelte
+++ b/src/routes/guides/1st-and-2nd-of-month/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
   import HeroImage from "./calendar.svg";
@@ -173,5 +172,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/covid-awi-drop/+page.svelte
+++ b/src/routes/guides/covid-awi-drop/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
 
@@ -98,29 +97,37 @@
     the multiplier year. So, for someone who turns 60 in year 2020:
   </p>
 
-  <table class="division">
+  <table style="margin: auto">
     <tr>
-      <td rowspan="2">Multiplier (year X) =</td>
-      <td style="border-bottom: 1px solid black;">AWI (year 2020)</td>
+      <td rowspan="2" style="padding: 6px; text-align: center;"
+        >Multiplier (year X) =</td
+      >
+      <td
+        style="border-bottom: 1px solid black; padding: 6px; text-align: center;"
+        >AWI (year 2020)</td
+      >
     </tr>
     <tr>
-      <td>AWI (year X)</td>
+      <td style="padding: 6px; text-align: center;">AWI (year X)</td>
     </tr>
   </table>
   <p>
     We can then multiply this by Taxed Earnings to see how AWI affects the
     Indexed Earnings in each year:
   </p>
-  <table class="division">
+  <table style="margin: auto">
     <tr>
-      <td rowspan="2">Indexed Earnings (year X) =</td>
-      <td style="border-bottom: 1px solid black;"
+      <td rowspan="2" style="padding: 6px; text-align: center;"
+        >Indexed Earnings (year X) =</td
+      >
+      <td
+        style="border-bottom: 1px solid black; padding: 6px; text-align: center;"
         >Taxed Earnings (year X) x
         <b>AWI (year 2020)</b>
       </td>
     </tr>
     <tr>
-      <td>AWI (year X)</td>
+      <td style="padding: 6px; text-align: center;">AWI (year X)</td>
     </tr>
   </table>
   <p>
@@ -186,12 +193,4 @@
   <GuideFooter />
 </div>
 
-<style>
-  .division td {
-    padding: 6px;
-    text-align: center;
-  }
-  .division {
-    margin: auto;
-  }
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/delayed-january-bump/+page.svelte
+++ b/src/routes/guides/delayed-january-bump/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
 
@@ -118,5 +117,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/earnings-cap/+page.svelte
+++ b/src/routes/guides/earnings-cap/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -25,7 +24,7 @@
   {@html schema.render()}
 </svelte:head>
 
-<div>
+<div class="earnings-cap-guide">
   <h1>{title}</h1>
   <p class="postdate">Published: {publishDate.toLocaleDateString()}</p>
   <p class="postdate">Updated: {updateDate.toLocaleDateString()}</p>
@@ -353,16 +352,4 @@
   <GuideFooter />
 </div>
 
-<style>
-  .css-column {
-    column-count: 4;
-    width: 90%;
-    column-rule: 1px solid lightblue;
-    margin: 2em;
-  }
-  .css-column span {
-    margin-right: 1.5em;
-    margin-left: 1.5em;
-    font-size: 14px;
-  }
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/earnings-record-paste/+page.svelte
+++ b/src/routes/guides/earnings-record-paste/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
   import { GuidesSchema } from "$lib/schema-org";
   import HeroImage from "./hero.svg";
   import ErrorMessageImage from "./error.png";
@@ -168,5 +167,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/federal-taxes/+page.svelte
+++ b/src/routes/guides/federal-taxes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -256,5 +255,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/filing-date-chart/+page.svelte
+++ b/src/routes/guides/filing-date-chart/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -200,5 +199,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/guide.css
+++ b/src/routes/guides/guide.css
@@ -24,6 +24,10 @@ figure {
   margin: 0;
   width: min-content;
 }
+figure.float-right {
+  float: right;
+  margin: 0 0 3vw 4vw;
+}
 img {
   border: 1px solid #ccc;
   max-width: 80vw;
@@ -46,4 +50,16 @@ figure:not(hero-image) {
 }
 div.indent {
   margin-left: 2em;
+}
+
+.earnings-cap-guide .css-column {
+  column-count: 4;
+  width: 90%;
+  column-rule: 1px solid lightblue;
+  margin: 2em;
+}
+.earnings-cap-guide .css-column span {
+  margin-right: 1.5em;
+  margin-left: 1.5em;
+  font-size: 14px;
 }

--- a/src/routes/guides/indexing-factors/+page.svelte
+++ b/src/routes/guides/indexing-factors/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -117,13 +116,18 @@
     (AWI) in the year she turned 60 divided by the AWI of the multiplier year:
   </p>
 
-  <table class="division">
+  <table style="margin: auto;">
     <tr>
-      <td rowspan="2">Multiplier (year X) =</td>
-      <td style="border-bottom: 1px solid black;">AWI (year 2030)</td>
+      <td rowspan="2" style="padding: 6px; text-align: center;"
+        >Multiplier (year X) =</td
+      >
+      <td
+        style="border-bottom: 1px solid black; padding: 6px; text-align: center;"
+        >AWI (year 2030)</td
+      >
     </tr>
     <tr>
-      <td>AWI (year X)</td>
+      <td style="padding: 6px; text-align: center;">AWI (year X)</td>
     </tr>
   </table>
 
@@ -205,12 +209,4 @@
   <GuideFooter />
 </div>
 
-<style>
-  .division td {
-    padding: 6px;
-    text-align: center;
-  }
-  .division {
-    margin: auto;
-  }
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/inflation/+page.svelte
+++ b/src/routes/guides/inflation/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -123,5 +122,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/international-agreements/+page.svelte
+++ b/src/routes/guides/international-agreements/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -59,5 +58,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/maximum/+page.svelte
+++ b/src/routes/guides/maximum/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -81,5 +80,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/spousal-benefit-filing-date/+page.svelte
+++ b/src/routes/guides/spousal-benefit-filing-date/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -75,7 +74,7 @@
 
     <br class="clear" />
 
-    <figure>
+    <figure class="float-right">
       <img
         src={EarlyFileImage}
         width="617"
@@ -110,7 +109,7 @@
 
   <br class="clear" />
 
-  <figure>
+  <figure class="float-right">
     <img
       src={LateFileImage}
       width="625"
@@ -140,7 +139,7 @@
 
   <h2>Personal and Spousal Benefits</h2>
 
-  <figure>
+  <figure class="float-right">
     <img
       src={HeroImage}
       width="628"
@@ -186,7 +185,7 @@
 
   <h3>Early Filing</h3>
 
-  <figure>
+  <figure class="float-right">
     <img
       src={EarlyFile100Image}
       width="621"
@@ -218,7 +217,7 @@
 
   <h3>Late Filing</h3>
 
-  <figure>
+  <figure class="float-right">
     <img
       src={LateFile100Image}
       width="620"
@@ -272,16 +271,4 @@
   <GuideFooter />
 </div>
 
-<style>
-  figure {
-    margin: 0;
-    width: min-content;
-    float: right;
-    margin: 0 0 3vw 4vw;
-  }
-  img {
-    border: 1px solid #ccc;
-    height: 40vw;
-    width: auto;
-  }
-</style>
+<style src="../guide.css"></style>

--- a/src/routes/guides/will-social-security-run-out/+page.svelte
+++ b/src/routes/guides/will-social-security-run-out/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import "$lib/global.css";
-  import "../guide.css";
 
   import { GuidesSchema } from "$lib/schema-org";
   import GuideFooter from "../guide-footer.svelte";
@@ -84,5 +83,4 @@
   <GuideFooter />
 </div>
 
-<style>
-</style>
+<style src="../guide.css"></style>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,24 +1,20 @@
-import adapter from '@sveltejs/adapter-vercel';
-import {vitePreprocess} from '@sveltejs/kit/vite';
+import adapter from "@sveltejs/adapter-vercel";
+import preprocess from "svelte-preprocess";
 
 /** @type {import('@sveltejs/kit').Config} */
 export default {
-  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
-  // for more information about preprocessors
-  preprocess: vitePreprocess(),
+  preprocess: preprocess(),
 
   kit: {
     adapter: adapter({
-      pages: 'build',
-      assets: 'build',
+      pages: "build",
+      assets: "build",
       fallback: undefined,
       precompress: false,
       strict: true,
     }),
     prerender: {
-      handleHttpError: 'warn',
-    }
+      handleHttpError: "warn",
+    },
   },
-
-
 };


### PR DESCRIPTION
Guide CSS was sticking around if the user navigated to another page. Preprocessing the guides fixes this issue.

Fixes https://github.com/Gregable/social-security-tools/issues/297