### PR TITLE
Bug Fix for COLA of recipient currenly 62 years.

### DIFF
--- a/src/lib/pia.ts
+++ b/src/lib/pia.ts
@@ -173,7 +173,7 @@ export class PrimaryInsuranceAmount {
    */
   shouldAdjustForCOLA(): boolean {
     return (
-      this.recipient_.birthdate.yearTurningSsaAge(62) < constants.CURRENT_YEAR
+      this.recipient_.birthdate.yearTurningSsaAge(62) <= constants.MAX_COLA_YEAR
     );
   }
 


### PR DESCRIPTION
If a recipient turned 62 in the current year, no COLA should be applied yet, since the COLA is applied in January of the following year.

However, when the COLA adjustment is known in October, we can still show the COLA adjustment to those 62 year old recipients who will in fact be eligible for the COLA in January but we were not doing so.