### PR TITLE
Fixes #306

### DIFF
--- a/src/lib/components/FutureEarningsSliders.svelte
+++ b/src/lib/components/FutureEarningsSliders.svelte
@@ -160,7 +160,9 @@
       <Slider
         bind:value={futureEarningWage}
         floor={1000}
-        ceiling={constants.MAXIMUM_EARNINGS[constants.CURRENT_YEAR].value()}
+        ceiling={constants.MAXIMUM_EARNINGS[
+          constants.MAX_MAXIMUM_EARNINGS_YEAR
+        ].value()}
         step={1000}
         translate={translateFutureEarnings}
       />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -186,7 +186,13 @@ export const MAXIMUM_EARNINGS: { [key: number]: Money } = {
 /**
  * Earliest Year for which we have data for the maximum earnings.
  */
-export const MIN_MAXIMUM_EARNINGS_YEAR = 1937;
+export const MIN_MAXIMUM_EARNINGS_YEAR: number = 1937;
+/**
+ * Latest Year for which we have data for the maximum earnings.
+ */
+export const MAX_MAXIMUM_EARNINGS_YEAR: number = Math.max(
+  ...Object.keys(MAXIMUM_EARNINGS).map(Number)
+);
 
 /**
  * Tax rates for social security contributions by year.

--- a/src/lib/recipient.ts
+++ b/src/lib/recipient.ts
@@ -188,11 +188,15 @@ export class Recipient {
 
     // Add the simulated records for the number of years requested.
     for (let i = 0; i < numYears; ++i) {
+      let cappedWage = wage;
+      if (startYear + i <= constants.MAX_MAXIMUM_EARNINGS_YEAR) {
+        cappedWage = Money.min(wage, constants.MAXIMUM_EARNINGS[startYear + i]);
+      }
       this.futureEarningsRecords_.push(
         new EarningRecord({
           year: startYear + i,
-          taxedEarnings: wage,
-          taxedMedicareEarnings: wage,
+          taxedEarnings: cappedWage,
+          taxedMedicareEarnings: cappedWage,
         })
       );
     }


### PR DESCRIPTION
If we know the maximum earnings for a future year, which happens late in the current year, allow the future wage slider to go up to that new value.

This also enforces capping future earnings wages to the maximum earnings for that year, if present. The result is that even if a user sets the slider to a value higher than the maximum earnings for the current year, the value will still be capped to the maximum earnings for that year.