### PR TITLE
Attempt to get vercel to emit correct headers.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
To use SharedArrayBuffer, we must emit the following headers:

```
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
```

Vercel is not emitting these headers in production. This commit adds a `vercel.json` file to the root of the project, as per instructions here:

https://vercel.com/guides/fix-shared-array-buffer-not-defined-nextjs-react