### PR TITLE
Add Storybook stories for BirthdateInput, SpousalBenefitToggle, and integrations

### DIFF
--- a/src/stories/BirthdateInput.stories.ts
+++ b/src/stories/BirthdateInput.stories.ts
@@ -1,0 +1,119 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import BirthdateInput from '$lib/components/BirthdateInput.svelte';
+
+const meta: Meta<BirthdateInput> = {
+  component: BirthdateInput,
+  title: 'Input/BirthdateInput',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A date input component that allows users to enter a birthdate using separate month, day, and year fields with validation.',
+      },
+    },
+  },
+  argTypes: {
+    birthdate: {
+      control: 'object',
+      description: 'Initial birthdate value (Birthdate object or null)',
+    },
+    inputId: {
+      control: 'text',
+      description: 'ID prefix for input elements',
+    },
+    autoFocus: {
+      control: 'boolean',
+      description: 'Whether to auto-focus the month input on mount',
+    },
+    isValid: {
+      control: 'boolean',
+      description: 'Bound validation state (output)',
+    },
+  },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: BirthdateInput,
+  props: args,
+  on: {
+    change: action('change'),
+  },
+});
+
+// Empty state - no initial birthdate
+export const Empty = Template.bind({});
+Empty.args = {
+  birthdate: null,
+  inputId: 'birthdate-empty',
+};
+Empty.parameters = {
+  docs: {
+    description: {
+      story: 'Initial empty state with no pre-filled date.',
+    },
+  },
+};
+
+// Pre-filled with valid date
+export const WithValidDate = Template.bind({});
+WithValidDate.args = {
+  birthdate: Birthdate.FromYMD(1960, 5, 15),
+  inputId: 'birthdate-valid',
+};
+WithValidDate.parameters = {
+  docs: {
+    description: {
+      story: 'Pre-filled with a valid birthdate (June 15, 1960).',
+    },
+  },
+};
+
+// With autoFocus enabled
+export const AutoFocused = Template.bind({});
+AutoFocused.args = {
+  birthdate: null,
+  inputId: 'birthdate-focus',
+  autoFocus: true,
+};
+AutoFocused.parameters = {
+  docs: {
+    description: {
+      story:
+        'Empty input with autoFocus enabled - month field receives focus on mount.',
+    },
+  },
+};
+
+// Early birthdate (older person near SS eligibility)
+export const EarlyBirthdate = Template.bind({});
+EarlyBirthdate.args = {
+  birthdate: Birthdate.FromYMD(1955, 0, 1),
+  inputId: 'birthdate-early',
+};
+EarlyBirthdate.parameters = {
+  docs: {
+    description: {
+      story:
+        'Pre-filled with January 1, 1955 - an older person approaching Social Security eligibility.',
+    },
+  },
+};
+
+// Younger person
+export const RecentBirthdate = Template.bind({});
+RecentBirthdate.args = {
+  birthdate: Birthdate.FromYMD(1985, 6, 4),
+  inputId: 'birthdate-recent',
+};
+RecentBirthdate.parameters = {
+  docs: {
+    description: {
+      story: 'Pre-filled with July 4, 1985 - a younger person planning ahead.',
+    },
+  },
+};

--- a/src/stories/Integrations.demo.svelte
+++ b/src/stories/Integrations.demo.svelte
@@ -1,0 +1,120 @@
+<!--
+  @component
+  Demo wrapper for displaying all IntroBanner integration variants.
+  Used only in Storybook stories to show consolidated view of all integrations.
+-->
+<script lang="ts">
+// IntroBanners for each integration
+import FiCalcIntroBanner from '$lib/components/integrations/ficalc.app/IntroBanner.svelte';
+import CFireSimIntroBanner from '$lib/components/integrations/cfiresim.com/IntroBanner.svelte';
+import FireCalcIntroBanner from '$lib/components/integrations/firecalc.com/IntroBanner.svelte';
+import LinoptIntroBanner from '$lib/components/integrations/linopt.com/IntroBanner.svelte';
+import OpenSSIntroBanner from '$lib/components/integrations/opensocialsecurity.com/IntroBanner.svelte';
+import OwlPlannerIntroBanner from '$lib/components/integrations/owlplanner.streamlit.app/IntroBanner.svelte';
+import FinPodsIntroBanner from '$lib/components/integrations/finpodsai.com/IntroBanner.svelte';
+
+export let isReportView: boolean = false;
+</script>
+
+<div class="integrations-demo">
+  <div class="demo-header">
+    <h2>Integration IntroBanners</h2>
+    <p>
+      <code>isReportView: {isReportView}</code>
+      {#if isReportView}
+        - Shows "Scroll to see results" badge
+      {:else}
+        - No badge (paste flow view)
+      {/if}
+    </p>
+  </div>
+
+  <div class="banner-list">
+    <div class="banner-item">
+      <h3>FI Calc</h3>
+      <FiCalcIntroBanner {isReportView} />
+    </div>
+
+    <div class="banner-item">
+      <h3>cFIREsim</h3>
+      <CFireSimIntroBanner {isReportView} />
+    </div>
+
+    <div class="banner-item">
+      <h3>FIRECalc</h3>
+      <FireCalcIntroBanner {isReportView} />
+    </div>
+
+    <div class="banner-item">
+      <h3>Linopt</h3>
+      <LinoptIntroBanner {isReportView} />
+    </div>
+
+    <div class="banner-item">
+      <h3>Open Social Security</h3>
+      <OpenSSIntroBanner {isReportView} />
+    </div>
+
+    <div class="banner-item">
+      <h3>Owl Retirement Planner</h3>
+      <OwlPlannerIntroBanner {isReportView} />
+    </div>
+
+    <div class="banner-item">
+      <h3>Fin Pods AI</h3>
+      <FinPodsIntroBanner {isReportView} />
+    </div>
+  </div>
+</div>
+
+<style>
+  .integrations-demo {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1em;
+  }
+
+  .demo-header {
+    margin-bottom: 1.5em;
+    padding-bottom: 1em;
+    border-bottom: 1px solid #dee2e6;
+  }
+
+  .demo-header h2 {
+    margin: 0 0 0.5em 0;
+    color: #212529;
+  }
+
+  .demo-header p {
+    margin: 0;
+    color: #6c757d;
+  }
+
+  .demo-header code {
+    background: #e9ecef;
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+
+  .banner-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+  }
+
+  .banner-item {
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .banner-item h3 {
+    margin: 0;
+    padding: 0.75em 1em;
+    background: #f8f9fa;
+    font-size: 0.95em;
+    color: #495057;
+    border-bottom: 1px solid #e9ecef;
+  }
+</style>

--- a/src/stories/Integrations.stories.ts
+++ b/src/stories/Integrations.stories.ts
@@ -1,0 +1,58 @@
+import type { Meta } from '@storybook/svelte';
+import IntegrationsDemo from './Integrations.demo.svelte';
+
+const meta: Meta<IntegrationsDemo> = {
+  component: IntegrationsDemo,
+  title: 'Integrations/AllIntroBanners',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Consolidated view of all IntroBanner components used across different financial tool integrations. Each integration has its own branded banner that explains how Social Security data will be used with that tool.',
+      },
+    },
+  },
+  argTypes: {
+    isReportView: {
+      control: 'boolean',
+      description:
+        'When true, shows a "Scroll to see results" badge. When false (paste flow), no badge is shown.',
+    },
+  },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: IntegrationsDemo,
+  props: args,
+});
+
+// All IntroBanners in paste flow view (default - no badge)
+export const PasteFlowView = Template.bind({});
+PasteFlowView.args = {
+  isReportView: false,
+};
+PasteFlowView.parameters = {
+  docs: {
+    description: {
+      story:
+        'IntroBanners as they appear during the paste flow (before report is generated). No badge is shown.',
+    },
+  },
+};
+
+// All IntroBanners in report view (with scroll badge)
+export const ReportView = Template.bind({});
+ReportView.args = {
+  isReportView: true,
+};
+ReportView.parameters = {
+  docs: {
+    description: {
+      story:
+        'IntroBanners as they appear in the report view. Shows a "Scroll to see results" badge to guide users.',
+    },
+  },
+};

--- a/src/stories/SpousalBenefitToggle.demo.svelte
+++ b/src/stories/SpousalBenefitToggle.demo.svelte
@@ -1,0 +1,99 @@
+<!--
+  @component
+  Demo wrapper for SpousalBenefitToggle that sets up required context and stores.
+  Used only in Storybook stories.
+-->
+<script lang="ts">
+import { onMount } from 'svelte';
+import SpousalBenefitToggle from '$lib/components/integrations/SpousalBenefitToggle.svelte';
+import { recipientFilingDate, spouseFilingDate } from '$lib/context';
+import { Money } from '$lib/money';
+import type { MonthDate } from '$lib/month-time';
+import type { Recipient } from '$lib/recipient';
+import { IntegrationContext } from '$lib/components/integrations/integration-context';
+
+export let recipient: Recipient;
+export let spouse: Recipient;
+export let toolName: string = 'Demo Tool';
+export let includeSpousalBenefit: boolean = false;
+export let recipientFilingDateValue: MonthDate;
+export let spouseFilingDateValue: MonthDate;
+
+// Set up stores on mount
+onMount(() => {
+  if (recipientFilingDateValue) {
+    recipientFilingDate.set(recipientFilingDateValue);
+  }
+  if (spouseFilingDateValue) {
+    spouseFilingDate.set(spouseFilingDateValue);
+  }
+});
+
+// Also react to prop changes
+$: if (recipientFilingDateValue) {
+  recipientFilingDate.set(recipientFilingDateValue);
+}
+$: if (spouseFilingDateValue) {
+  spouseFilingDate.set(spouseFilingDateValue);
+}
+
+$: context = new IntegrationContext(recipient, spouse);
+
+// Bound values from toggle
+let recipientBenefitCalculationDate: MonthDate;
+let spouseBenefitCalculationDate: MonthDate;
+let recipientAnnualBenefit: Money;
+let spouseAnnualBenefit: Money;
+</script>
+
+<div class="demo-container">
+  <SpousalBenefitToggle
+    {context}
+    bind:includeSpousalBenefit
+    bind:recipientBenefitCalculationDate
+    bind:spouseBenefitCalculationDate
+    bind:recipientAnnualBenefit
+    bind:spouseAnnualBenefit
+    {toolName}
+  />
+
+  <div class="demo-output">
+    <h4>Current Selection</h4>
+    <p>Include Spousal Benefit: <strong>{includeSpousalBenefit ? 'Yes' : 'No'}</strong></p>
+    {#if recipientAnnualBenefit}
+      <p>{recipient.name} Annual Benefit: <strong>{recipientAnnualBenefit.wholeDollars()}</strong></p>
+    {/if}
+    {#if spouseAnnualBenefit && spouse}
+      <p>{spouse.name} Annual Benefit: <strong>{spouseAnnualBenefit.wholeDollars()}</strong></p>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .demo-container {
+    max-width: 800px;
+    padding: 1em;
+  }
+
+  .demo-output {
+    margin-top: 1.5em;
+    padding: 1em;
+    background: #f0f4f8;
+    border-radius: 8px;
+    border: 1px solid #dee2e6;
+  }
+
+  .demo-output h4 {
+    margin: 0 0 0.5em 0;
+    color: #495057;
+  }
+
+  .demo-output p {
+    margin: 0.25em 0;
+    font-size: 0.95em;
+  }
+
+  .demo-output strong {
+    color: #1976d2;
+  }
+</style>

--- a/src/stories/SpousalBenefitToggle.stories.ts
+++ b/src/stories/SpousalBenefitToggle.stories.ts
@@ -1,0 +1,122 @@
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import { MonthDate } from '$lib/month-time';
+import demo from '$lib/pastes/averagepaste.txt?raw';
+import demo_spouse_low from '$lib/pastes/averagepaste-spouse.txt?raw';
+import demo_spouse_high from '$lib/pastes/averagepaste-spouse-2.txt?raw';
+import { Recipient } from '$lib/recipient';
+import { parsePaste } from '$lib/ssa-parse';
+import SpousalBenefitToggleDemo from './SpousalBenefitToggle.demo.svelte';
+
+// Set up test recipients
+const recipient = new Recipient();
+recipient.name = 'Alex';
+recipient.markFirst();
+recipient.earningsRecords = parsePaste(demo);
+recipient.birthdate = Birthdate.FromYMD(1960, 5, 15);
+
+// Lower earner spouse - eligible for spousal benefits
+const spouseLowEarner = new Recipient();
+spouseLowEarner.name = 'Chris';
+spouseLowEarner.markSecond();
+spouseLowEarner.earningsRecords = parsePaste(demo_spouse_low);
+spouseLowEarner.birthdate = Birthdate.FromYMD(1962, 3, 10);
+
+// Higher earner spouse - not eligible for spousal benefits
+const spouseHighEarner = new Recipient();
+spouseHighEarner.name = 'Jordan';
+spouseHighEarner.markSecond();
+spouseHighEarner.earningsRecords = parsePaste(demo_spouse_high);
+spouseHighEarner.birthdate = Birthdate.FromYMD(1958, 8, 20);
+
+// Filing dates (at age 67 - typical full retirement age)
+const recipientFilingAt67 = MonthDate.initFromYearsMonths({
+  years: 2027,
+  months: 5,
+});
+const spouseLowFilingAt67 = MonthDate.initFromYearsMonths({
+  years: 2029,
+  months: 3,
+});
+const spouseHighFilingAt67 = MonthDate.initFromYearsMonths({
+  years: 2025,
+  months: 8,
+});
+
+const meta: Meta<SpousalBenefitToggleDemo> = {
+  component: SpousalBenefitToggleDemo,
+  title: 'Integrations/SpousalBenefitToggle',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A toggle component for choosing between personal benefit only vs combined personal + spousal benefit for the lower earner. Used by integration tools that only accept a single filing date per person.',
+      },
+    },
+  },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: SpousalBenefitToggleDemo,
+  props: args,
+});
+
+// Lower earner spouse (spousal benefit applies)
+export const LowerEarnerSpouse = Template.bind({});
+LowerEarnerSpouse.args = {
+  recipient: recipient,
+  spouse: spouseLowEarner,
+  toolName: 'FIRECalc',
+  includeSpousalBenefit: false,
+  recipientFilingDateValue: recipientFilingAt67,
+  spouseFilingDateValue: spouseLowFilingAt67,
+};
+LowerEarnerSpouse.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the spouse has lower earnings, they may be eligible for spousal benefits. The user can choose between personal-only or combined benefit calculation.',
+    },
+  },
+};
+
+// Higher earner spouse (no spousal benefit - recipient is lower earner)
+export const RecipientIsLowerEarner = Template.bind({});
+RecipientIsLowerEarner.args = {
+  recipient: recipient,
+  spouse: spouseHighEarner,
+  toolName: 'Linopt',
+  includeSpousalBenefit: false,
+  recipientFilingDateValue: recipientFilingAt67,
+  spouseFilingDateValue: spouseHighFilingAt67,
+};
+RecipientIsLowerEarner.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the recipient is the lower earner, they may be eligible for spousal benefits from their spouse.',
+    },
+  },
+};
+
+// With spousal benefit pre-selected
+export const SpousalSelected = Template.bind({});
+SpousalSelected.args = {
+  recipient: recipient,
+  spouse: spouseLowEarner,
+  toolName: 'cFIREsim',
+  includeSpousalBenefit: true,
+  recipientFilingDateValue: recipientFilingAt67,
+  spouseFilingDateValue: spouseLowFilingAt67,
+};
+SpousalSelected.parameters = {
+  docs: {
+    description: {
+      story:
+        'Shows the toggle with "Combined Personal + Spousal Benefit" pre-selected.',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Add Storybook stories for `BirthdateInput` component with validation state variants
- Add Storybook stories for `SpousalBenefitToggle` with demo wrapper for context setup
- Add consolidated Storybook stories for all 7 integration IntroBanner variants

## Test plan
- [x] Run `npm run storybook` and verify new stories render correctly
- [ ] Check BirthdateInput stories: Empty, WithValidDate, AutoFocused, EarlyBirthdate, RecentBirthdate
- [ ] Check SpousalBenefitToggle stories: LowerEarnerSpouse, RecipientIsLowerEarner, SpousalSelected
- [ ] Check Integrations stories: PasteFlowView, ReportView (all 7 banners visible)