### PR TITLE
Improve spouse data entry flow with skip option and clearer messaging

### DIFF
--- a/src/lib/components/AgeRequest.svelte
+++ b/src/lib/components/AgeRequest.svelte
@@ -23,6 +23,7 @@ import BirthdateInput from './BirthdateInput.svelte';
 // Props
 export let birthdate: Birthdate = null;
 export let inputId = 'birthdate';
+export let name: string = '';
 
 // Callback prop for submit event
 export let onsubmit: ((detail: { birthdate: Birthdate }) => void) | undefined =
@@ -51,10 +52,10 @@ function checkEnter(event) {
 <div class="confirmation">
   <fieldset>
     <legend>
-      <h3>Step 2 of 2: When were you born?</h3>
+      <h3>Step 2 of 2: When {name ? `was ${name}` : 'were you'} born?</h3>
       <p>
-        Birthdate is used to calculate when you can collect Social Security
-        benefits, as well as to determine the amount of your benefit.
+        Birthdate is used to calculate when {name || 'you'} can collect Social Security
+        benefits, as well as to determine the amount of {name ? 'their' : 'your'} benefit.
       </p>
     </legend>
     <div class="hint">For example, 09 22 1975</div>

--- a/src/lib/components/PasteFlow.svelte
+++ b/src/lib/components/PasteFlow.svelte
@@ -341,7 +341,7 @@ function handleSpouseQuestion(detail: {
     {#if isRecipient}
       <DemoData ondemo={handleDemo} />
     {/if}
-    <PastePrompt onpaste={handlePaste} />
+    <PastePrompt onpaste={handlePaste} isSpouse={!isRecipient} />
   {:else if mode === Mode.PASTE_CONFIRMATION}
     {#if isRecipient}
       <PasteConfirm
@@ -363,6 +363,7 @@ function handleSpouseQuestion(detail: {
       birthdate={isRecipient
         ? recipientBirthdateFromHash
         : spouseBirthdateFromHash}
+      name={isRecipient ? '' : spouseName}
       onsubmit={handleAgeSubmit}
     />
   {:else if allowSpouseFlow && mode === Mode.SPOUSE_QUESTION}

--- a/src/lib/components/PastePrompt.svelte
+++ b/src/lib/components/PastePrompt.svelte
@@ -25,6 +25,9 @@ import CopyPasteDemoPoster from '$lib/videos/copy-paste-demo-poster.jpg';
 export let onpaste: ((detail: { recipient: Recipient }) => void) | undefined =
   undefined;
 
+// Whether we're entering data for a spouse (shows skip option)
+export let isSpouse: boolean = false;
+
 let pasteContents: string = '';
 let pasteError: boolean = false;
 
@@ -63,6 +66,12 @@ $: piaDisabled = (() => {
   if (piaInput === null) return true;
   return piaInput < 0;
 })();
+
+function skipEarnings() {
+  let recipient: Recipient = new Recipient();
+  recipient.setPia(Money.from(0));
+  onpaste?.({ recipient: recipient });
+}
 </script>
 
 <div class="pastePrompt">
@@ -143,6 +152,19 @@ $: piaDisabled = (() => {
       </div>
     </div>
   </div>
+
+  {#if isSpouse}
+    <div class="skipEarnings">
+      <p>
+        If your spouse has no earnings history, or you just want to get a quick
+        estimate for now, you can skip this step and assume no earnings. You can
+        always come back later to enter more accurate data.
+      </p>
+      <button class="skipButton" on:click={skipEarnings}>
+        Skip - Assume No Earnings
+      </button>
+    </div>
+  {/if}
 
   <div class="subheading">Alternative Options</div>
   <Expando
@@ -333,6 +355,28 @@ $: piaDisabled = (() => {
     font-weight: bold;
     font-size: 22px;
     vertical-align: middle;
+  }
+
+  .skipEarnings {
+    max-width: 480px;
+    margin: 0 auto 30px auto;
+    padding: 15px 20px;
+    background: #f5f5f5;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    text-align: center;
+  }
+  .skipEarnings p {
+    margin: 0 0 12px 0;
+    color: #555;
+    font-size: 14px;
+  }
+  .skipButton {
+    background: #6b8e9f;
+    padding: 8px 20px;
+  }
+  .skipButton:hover {
+    background: #4a6d7e;
   }
 
   /** Desktop **/

--- a/src/lib/components/SpouseQuestion.svelte
+++ b/src/lib/components/SpouseQuestion.svelte
@@ -50,6 +50,11 @@ function confirmSpouse() {
     {#if initial}
       <div>
         <p>This site can calculate the Social Security spousal benefit.</p>
+        <p>
+          Even if your spouse has little or no work history, they may still be
+          eligible for spousal benefits based on your earnings record.
+        </p>
+        <p>You don't need your spouse's ssa.gov login to get started.</p>
         <p>Would you like to also enter data for a spouse?</p>
 
         <button on:click={nospouse}>

--- a/src/stories/PastePrompt.stories.ts
+++ b/src/stories/PastePrompt.stories.ts
@@ -14,8 +14,9 @@ const meta: Meta<PastePrompt> = {
 };
 export default meta;
 
-const Template = ({ ..._args }) => ({
+const Template = ({ ...args }) => ({
   Component: PastePrompt,
+  props: args,
   on: {
     paste: action('paste'),
   },
@@ -23,3 +24,8 @@ const Template = ({ ..._args }) => ({
 
 export const Default = Template.bind({});
 Default.args = {};
+
+export const SpouseMode = Template.bind({});
+SpouseMode.args = {
+  isSpouse: true,
+};


### PR DESCRIPTION
## Summary

- Add explanatory text in SpouseQuestion clarifying that spouses with little or no work history may still be eligible for spousal benefits
- Add "Skip - Assume No Earnings" button in PastePrompt when entering spouse data, allowing users to get a quick estimate without needing the spouse's SSA.gov login
- Update AgeRequest to show spouse's name instead of "you" when entering spouse birthdate
- Add Storybook story for spouse mode in PastePrompt

## Test plan

- [ ] Run `npm test` to verify all tests pass
- [ ] Run `npm run build` to verify build succeeds
- [ ] Manual test: Go through paste flow, select "Yes" at spouse question, verify skip button appears
- [ ] Manual test: Click skip button, verify flow continues to spouse birthdate entry
- [ ] Manual test: Verify birthdate page shows "When was {SpouseName} born?" for spouse
- [ ] Manual test: Complete flow and verify spousal benefits are calculated correctly