### PR TITLE
Fix survivor benefit crash when higher/lower earner swaps

### DIFF
--- a/src/lib/components/SurvivorReport.svelte
+++ b/src/lib/components/SurvivorReport.svelte
@@ -274,6 +274,8 @@ $: fileVsDeath &&
   beforeDeathSliderMonths_ &&
   afterDeathSliderMonths_ &&
   survivorSliderMonths_ &&
+  higherEarner &&
+  lowerEarner &&
   minCapSlider();
 </script>
 


### PR DESCRIPTION
## Summary
- Fix crash in SurvivorReport when birthdates like 10/22/1982 and 9/3/1982 are entered
- Add `higherEarner` and `lowerEarner` as reactive dependencies to the `minCapSlider` reactive statement
- Ensures `survivorActualFilingDate` is recalculated when earnings data changes cause the higher/lower earner designation to swap

## Problem
When the higher/lower earner designation changed (e.g., due to earnings data updates), the `minCapSlider()` function was not re-running because it only tracked slider values as dependencies. This left `survivorActualFilingDate` stale, potentially equal to the death date, causing:

```
Uncaught Error: Cannot file for survivor benefits before spouse died: Oct 2052 <= Oct 2052
```

## Test plan
- [x] `npm run check` passes (0 errors, 0 warnings)
- [x] All 707 tests pass
- [ ] Manual test: Enter birthdates 10/22/1982 and 9/3/1982, verify survivor report loads without error