### PR TITLE
Improve spouse question page styling

### DIFF
--- a/src/lib/components/SpouseQuestion.svelte
+++ b/src/lib/components/SpouseQuestion.svelte
@@ -142,19 +142,12 @@
     margin: 0;
   }
   .benefits-list li {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.75em;
     margin-bottom: 0.6em;
     line-height: 1.4;
     color: #4a5568;
   }
   .benefits-list li:last-child {
     margin-bottom: 0;
-  }
-  .benefits-list .icon {
-    flex-shrink: 0;
-    font-size: 1.1em;
   }
   .question {
     font-weight: 500;


### PR DESCRIPTION
## Summary
- Add styled info card container with subtle gradient background
- Convert bullet points to a styled list with better visual hierarchy
- Improve spacing and typography for the call-to-action question

## Test plan
- [ ] View the SpouseQuestion story in Storybook
- [ ] Verify the info card displays correctly with gradient background
- [ ] Confirm text is readable and well-spaced