### PR TITLE
Fix Chromatic showing stories as new on every PR

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -40,3 +40,5 @@ jobs:
           onlyChanged: true
           # Skip unchanged stories entirely (saves snapshots)
           skip: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+          # Auto-accept changes on main branch to establish baselines
+          autoAcceptChanges: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary
- Add `autoAcceptChanges` for main branch builds so story snapshots are automatically accepted as baselines when merged to main

## Problem
Every PR was showing the same stories as "new" (BirthdateInput, AllIntroBanners, AllReportEnd, SpousalBenefit, SpousalBenefitToggle) even when they weren't modified. This happened because new stories merged to main were recorded but never accepted as baselines, so PRs had nothing to compare against.

## Test plan
- [ ] Merge this PR to main
- [ ] Verify the next main branch Chromatic build auto-accepts the baselines
- [ ] Open a new PR and confirm those stories no longer appear as "new"