### PR TITLE
Add clickable strategy details view for single recipients

### DIFF
--- a/src/lib/strategy/calculations/alternative-strategies.ts
+++ b/src/lib/strategy/calculations/alternative-strategies.ts
@@ -1,0 +1,174 @@
+import { Money } from '$lib/money';
+import { MonthDate, MonthDuration } from '$lib/month-time';
+import type { Recipient } from '$lib/recipient';
+import { strategySumCentsSingle } from './strategy-calc';
+
+export interface AlternativeResult {
+  filingAge: MonthDuration;
+  npv: Money;
+  percentOfOptimal: number;
+  isOptimal: boolean;
+  isPlaceholder?: boolean;
+  placeholderReason?: string;
+}
+
+export interface YearGroup {
+  year: number;
+  results: AlternativeResult[];
+}
+
+/**
+ * Returns the color for a strategy box based on how close it is to optimal.
+ */
+export function getStrategyColor(
+  percentOfOptimal: number,
+  isOptimal: boolean
+): string {
+  if (isOptimal) return 'rgb(0, 100, 0)'; // Dark green for optimal
+  if (percentOfOptimal >= 99) return 'rgb(34, 139, 34)'; // Forest green (very close)
+  if (percentOfOptimal >= 95) return 'rgb(100, 170, 50)'; // Lime green
+  if (percentOfOptimal >= 90) return 'rgb(190, 210, 50)'; // Yellow-green (more yellow)
+  if (percentOfOptimal >= 85) return 'rgb(255, 215, 0)'; // Gold
+  if (percentOfOptimal >= 80) return 'rgb(255, 165, 0)'; // Orange
+  return 'rgb(220, 20, 60)'; // Red
+}
+
+/**
+ * Formats a filing age for display.
+ * @param filingAge The filing age as a MonthDuration
+ * @param displayAsAges If true, shows as "62y 3m", otherwise shows as date
+ * @param birthdate The recipient's birthdate (required when displayAsAges is false)
+ */
+export function formatFilingAgeDisplay(
+  filingAge: MonthDuration,
+  displayAsAges: boolean,
+  birthdate?: { dateAtSsaAge: (age: MonthDuration) => MonthDate }
+): string {
+  if (displayAsAges) {
+    const years = filingAge.years();
+    const months = filingAge.modMonths();
+    if (months === 0) {
+      return `${years}y`;
+    }
+    return `${years}y${months}m`;
+  } else {
+    if (!birthdate) {
+      throw new Error('birthdate required when displayAsAges is false');
+    }
+    const date = birthdate.dateAtSsaAge(filingAge);
+    const d = new Date(date.year(), date.monthIndex());
+    return d.toLocaleString('default', { month: 'short', year: '2-digit' });
+  }
+}
+
+/**
+ * Calculates alternative filing strategies grouped by year.
+ */
+export function calculateAlternativeStrategies(
+  recipient: Recipient,
+  deathAge: MonthDuration,
+  discountRate: number,
+  optimalNPV: Money,
+  optimalFilingAge: MonthDuration,
+  currentDate?: MonthDate
+): YearGroup[] {
+  const now = currentDate
+    ? currentDate
+    : MonthDate.initFromYearsMonths({
+        years: new Date().getFullYear(),
+        months: new Date().getMonth(),
+      });
+
+  const finalDate = recipient.birthdate.dateAtLayAge(deathAge);
+  const results: AlternativeResult[] = [];
+
+  // Calculate the recipient's current age in months
+  const currentAgeMonths = recipient.birthdate.ageAtSsaDate(now).asMonths();
+
+  // Generate all monthly filing ages from earliest eligible to 70
+  const earliestFilingMonths = recipient.birthdate
+    .earliestFilingMonth()
+    .asMonths();
+  const latestFilingMonths = 70 * 12; // Age 70
+
+  for (
+    let months = earliestFilingMonths;
+    months <= latestFilingMonths;
+    months++
+  ) {
+    const filingAge = new MonthDuration(months);
+
+    // Skip if filing age is after death
+    if (filingAge.greaterThan(deathAge)) continue;
+
+    // Check if this filing age is in the past
+    if (filingAge.asMonths() < currentAgeMonths) {
+      results.push({
+        filingAge,
+        npv: Money.fromCents(0),
+        percentOfOptimal: 0,
+        isOptimal: false,
+        isPlaceholder: true,
+        placeholderReason: 'Already passed',
+      });
+      continue;
+    }
+
+    const npvCents = strategySumCentsSingle(
+      recipient,
+      finalDate,
+      now,
+      discountRate,
+      filingAge
+    );
+    const npv = Money.fromCents(npvCents);
+    const percentOfOptimal =
+      optimalNPV.cents() > 0 ? (npvCents / optimalNPV.cents()) * 100 : 0;
+
+    results.push({
+      filingAge,
+      npv,
+      percentOfOptimal,
+      isOptimal: filingAge.asMonths() === optimalFilingAge.asMonths(),
+    });
+  }
+
+  // Group results by year
+  const groups = new Map<number, AlternativeResult[]>();
+  for (const result of results) {
+    const year = result.filingAge.years();
+    if (!groups.has(year)) {
+      groups.set(year, []);
+    }
+    groups.get(year)!.push(result);
+  }
+
+  // Convert to array sorted by year
+  const yearGroups = Array.from(groups.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([year, yearResults]) => ({ year, results: yearResults }));
+
+  // Add placeholders for unavailable months at the start of the first year
+  if (yearGroups.length > 0) {
+    const firstGroup = yearGroups[0];
+    const firstResult = firstGroup.results[0];
+    const firstMonth = firstResult.filingAge.modMonths();
+
+    if (firstMonth > 0) {
+      const placeholders: AlternativeResult[] = [];
+      for (let m = 0; m < firstMonth; m++) {
+        placeholders.push({
+          filingAge: new MonthDuration(firstGroup.year * 12 + m),
+          npv: Money.fromCents(0),
+          percentOfOptimal: 0,
+          isOptimal: false,
+          isPlaceholder: true,
+          placeholderReason: 'Not yet eligible',
+        });
+      }
+      firstGroup.results = [...placeholders, ...firstGroup.results];
+    }
+  }
+
+  return yearGroups;
+}

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -21,7 +21,9 @@
   import DiscountRateInput from "./components/DiscountRateInput.svelte";
   // Import components
   import RecipientInputs from "./components/RecipientInputs.svelte";
+  import AlternativeStrategiesRow from "./components/AlternativeStrategiesRow.svelte";
   import StrategyDetails from "./components/StrategyDetails.svelte";
+  import StrategyDetailsSingle from "./components/StrategyDetailsSingle.svelte";
   import StrategyMatrixDisplay from "./components/StrategyMatrixDisplay.svelte";
   import StrategyPlotSingle from "./components/StrategyPlotSingle.svelte";
 
@@ -276,6 +278,15 @@
     );
     calculationResultsStore.set(calculationResults);
   }
+
+  function handleSinglePointSelect(detail: { rowIndex: number } | null) {
+    if (detail === null) {
+      calculationResults.clearSelectedCell();
+    } else {
+      calculationResults.setSelectedCell(detail.rowIndex, 0);
+    }
+    calculationResultsStore.set(calculationResults);
+  }
 </script>
 
 <main>
@@ -341,6 +352,7 @@
           {calculationResults}
           deathProbDistribution={deathProbDistribution1}
           bind:displayAsAges
+          onselectpoint={handleSinglePointSelect}
         />
       {:else}
         <StrategyMatrixDisplay
@@ -366,6 +378,22 @@
           {recipients}
           result={calculationResults.getSelectedCellData()}
           {discountRate}
+          bind:displayAsAges
+        />
+      {/key}
+    {/if}
+    {#if calculationResults.getSelectedCellData() && isSingle}
+      {#key calculationResults.getSelectedCellData()}
+        <StrategyDetailsSingle
+          recipient={recipients[0]}
+          result={calculationResults.getSelectedCellData()}
+        />
+        <AlternativeStrategiesRow
+          recipient={recipients[0]}
+          deathAge={calculationResults.getSelectedCellData().bucket1.expectedAge}
+          {discountRate}
+          optimalNPV={calculationResults.getSelectedCellData().totalBenefit}
+          optimalFilingAge={calculationResults.getSelectedCellData().filingAge1}
           bind:displayAsAges
         />
       {/key}

--- a/src/routes/strategy/components/AlternativeStrategiesRow.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesRow.svelte
@@ -1,0 +1,303 @@
+<script lang="ts">
+  import { Money } from "$lib/money";
+  import { MonthDuration } from "$lib/month-time";
+  import type { Recipient } from "$lib/recipient";
+  import {
+    calculateAlternativeStrategies,
+    formatFilingAgeDisplay,
+    getStrategyColor,
+    type YearGroup,
+  } from "$lib/strategy/calculations/alternative-strategies";
+
+  export let recipient: Recipient;
+  export let deathAge: MonthDuration;
+  export let discountRate: number;
+  export let optimalNPV: Money;
+  export let optimalFilingAge: MonthDuration;
+  export let displayAsAges: boolean = false;
+
+  let groupedByYear: YearGroup[] = [];
+
+  // Calculate alternatives when inputs change
+  $: {
+    groupedByYear = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      discountRate,
+      optimalNPV,
+      optimalFilingAge
+    );
+  }
+
+  function getColor(percentOfOptimal: number, isOptimal: boolean): string {
+    return getStrategyColor(percentOfOptimal, isOptimal);
+  }
+
+  function formatFilingAge(filingAge: MonthDuration): string {
+    return formatFilingAgeDisplay(filingAge, displayAsAges, recipient.birthdate);
+  }
+</script>
+
+<div class="alternative-strategies-container">
+  <h3>
+    Alternative Filing {displayAsAges ? "Ages" : "Dates"}
+  </h3>
+  <p class="description">
+    Compare NPV outcomes for different filing ages given the selected death
+    scenario.
+  </p>
+
+  <div class="strategies-container">
+    {#each groupedByYear as yearGroup}
+      <div class="year-row">
+        <div class="year-label">Age {yearGroup.year}</div>
+        <div class="strategies-row">
+          {#each yearGroup.results as result}
+            {#if result.isPlaceholder}
+              <div class="strategy-box placeholder" title={result.placeholderReason}>
+                <div class="filing-label">{formatFilingAge(result.filingAge)}</div>
+                <div class="placeholder-text">N/A</div>
+              </div>
+            {:else}
+              <div
+                class="strategy-box"
+                class:optimal={result.isOptimal}
+                style="background-color: {getColor(
+                  result.percentOfOptimal,
+                  result.isOptimal
+                )};"
+              >
+                <div class="filing-label">{formatFilingAge(result.filingAge)}</div>
+                <div class="npv-value">{result.npv.wholeDollars()}</div>
+                <div class="percent-value">{result.percentOfOptimal.toFixed(1)}%</div>
+                {#if result.isOptimal}
+                  <div class="optimal-badge">Optimal</div>
+                {/if}
+              </div>
+            {/if}
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="legend">
+    <span class="legend-item">
+      <span class="color-box" style="background-color: rgb(0, 100, 0);"></span>
+      Optimal
+    </span>
+    <span class="legend-item">
+      <span class="color-box" style="background-color: rgb(34, 139, 34);"></span>
+      99%+
+    </span>
+    <span class="legend-item">
+      <span class="color-box" style="background-color: rgb(100, 170, 50);"></span>
+      95-99%
+    </span>
+    <span class="legend-item">
+      <span
+        class="color-box"
+        style="background-color: rgb(190, 210, 50);"
+      ></span>
+      90-95%
+    </span>
+    <span class="legend-item">
+      <span class="color-box" style="background-color: rgb(255, 215, 0);"></span>
+      85-90%
+    </span>
+    <span class="legend-item">
+      <span class="color-box" style="background-color: rgb(255, 165, 0);"></span>
+      80-85%
+    </span>
+    <span class="legend-item">
+      <span class="color-box" style="background-color: rgb(220, 20, 60);"></span>
+      &lt;80%
+    </span>
+  </div>
+</div>
+
+<style>
+  .alternative-strategies-container {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #fff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  }
+
+  .alternative-strategies-container h3 {
+    color: #333;
+    margin: 0 0 0.5rem 0;
+    font-size: 1.2rem;
+  }
+
+  .description {
+    color: #666;
+    font-size: 0.9rem;
+    margin: 0 0 1.5rem 0;
+  }
+
+  .strategies-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .year-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .year-label {
+    min-width: 55px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #555;
+  }
+
+  .strategies-row {
+    display: grid;
+    grid-template-columns: repeat(12, 70px);
+    gap: 0.25rem;
+  }
+
+  .strategy-box {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.5rem;
+    border-radius: 4px;
+    width: 70px;
+    box-sizing: border-box;
+    color: white;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    transition: transform 0.1s ease;
+    cursor: default;
+  }
+
+  .strategy-box:hover {
+    transform: scale(1.1);
+    z-index: 1;
+  }
+
+  .strategy-box.optimal {
+    border: 2px solid #ffd700;
+    box-shadow: 0 0 6px rgba(255, 215, 0, 0.6);
+  }
+
+  .strategy-box.placeholder {
+    background-color: #e0e0e0;
+    color: #999;
+    text-shadow: none;
+    cursor: help;
+  }
+
+  .strategy-box.placeholder:hover {
+    transform: none;
+  }
+
+  .placeholder-text {
+    font-size: 0.65rem;
+    font-style: italic;
+  }
+
+  .filing-label {
+    font-weight: bold;
+    font-size: 0.75rem;
+    margin-bottom: 0.1rem;
+  }
+
+  .npv-value {
+    font-size: 0.7rem;
+    margin-bottom: 0.05rem;
+  }
+
+  .percent-value {
+    font-size: 0.65rem;
+    opacity: 0.9;
+  }
+
+  .optimal-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    background-color: #ffd700;
+    color: #333;
+    font-size: 0.55rem;
+    font-weight: bold;
+    padding: 1px 4px;
+    border-radius: 8px;
+    text-shadow: none;
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    font-size: 0.8rem;
+    color: #666;
+    border-top: 1px solid #eee;
+    padding-top: 1rem;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .color-box {
+    width: 14px;
+    height: 14px;
+    border-radius: 2px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  @media (max-width: 768px) {
+    .strategies-container {
+      gap: 0.4rem;
+    }
+
+    .year-row {
+      gap: 0.3rem;
+    }
+
+    .year-label {
+      min-width: 45px;
+      font-size: 0.75rem;
+    }
+
+    .strategies-row {
+      grid-template-columns: repeat(12, 55px);
+      gap: 0.2rem;
+    }
+
+    .strategy-box {
+      width: 55px;
+      padding: 0.25rem 0.4rem;
+    }
+
+    .filing-label {
+      font-size: 0.65rem;
+    }
+
+    .npv-value {
+      font-size: 0.6rem;
+    }
+
+    .percent-value {
+      font-size: 0.55rem;
+    }
+
+    .legend {
+      gap: 0.5rem;
+      font-size: 0.7rem;
+    }
+  }
+</style>

--- a/src/routes/strategy/components/StrategyDetails.svelte
+++ b/src/routes/strategy/components/StrategyDetails.svelte
@@ -109,38 +109,28 @@
       </thead>
       <tbody>
         <tr>
-          <td class="row-label">Filing Age</td>
-          <td>{result.filingAge1Years}y {result.filingAge1Months}m</td>
-          <td>{result.filingAge2Years}y {result.filingAge2Months}m</td>
+          <td class="row-label">Filing</td>
+          <td>{filingDate1.toString()} ({result.filingAge1Years}y {result.filingAge1Months}m)</td>
+          <td>{filingDate2.toString()} ({result.filingAge2Years}y {result.filingAge2Months}m)</td>
         </tr>
         <tr>
-          <td class="row-label">Filing Date</td>
-          <td>{filingDate1.toString()}</td>
-          <td>{filingDate2.toString()}</td>
-        </tr>
-        <tr>
-          <td class="row-label">Death Age</td>
+          <td class="row-label">Death</td>
           <td>
-            {expectedAge1.toAgeString()}
+            {deathDate1.monthName()} {deathDate1.year()} ({expectedAge1.toAgeString()})
             {#if result.deathProb1 !== undefined}
               <span class="probability"
-                >({formatProbability(result.deathProb1 ?? null)})</span
+                >{formatProbability(result.deathProb1 ?? null)}</span
               >
             {/if}
           </td>
           <td>
-            {expectedAge2.toAgeString()}
+            {deathDate2.monthName()} {deathDate2.year()} ({expectedAge2.toAgeString()})
             {#if result.deathProb2 !== undefined}
               <span class="probability"
-                >({formatProbability(result.deathProb2 ?? null)})</span
+                >{formatProbability(result.deathProb2 ?? null)}</span
               >
             {/if}
           </td>
-        </tr>
-        <tr>
-          <td class="row-label">Death Date</td>
-          <td>{deathDate1.monthName()} {deathDate1.year()}</td>
-          <td>{deathDate2.monthName()} {deathDate2.year()}</td>
         </tr>
       </tbody>
     </table>

--- a/src/routes/strategy/components/StrategyDetailsSingle.svelte
+++ b/src/routes/strategy/components/StrategyDetailsSingle.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import { MonthDuration } from "$lib/month-time";
+  import type { Recipient } from "$lib/recipient";
+  import { strategySumPeriodsSingle } from "$lib/strategy/calculations/strategy-calc";
+  import type { StrategyResult } from "$lib/strategy/ui";
+
+  export let result: StrategyResult;
+  export let recipient: Recipient;
+
+  // Compute filing date from filing age
+  $: filingDate = recipient.birthdate.dateAtLayAge(result.filingAge1);
+
+  // Expected death age (probability-weighted modeled midpoint)
+  $: expectedAge = result.bucket1.expectedAge;
+  $: deathDate = recipient.birthdate.dateAtLayAge(expectedAge);
+
+  // Calculate the benefit periods for the selected strategy
+  $: finalDate = recipient.birthdate.dateAtLayAge(
+    new MonthDuration(result.bucket1.midAge * 12)
+  );
+
+  $: benefitPeriods = strategySumPeriodsSingle(
+    recipient,
+    finalDate,
+    result.filingAge1
+  );
+
+  $: formattedPeriods = benefitPeriods.map((period) => ({
+    startFormatted: period.startDate.toString(),
+    endFormatted: period.endDate.toString(),
+    amount: period.amount.string(),
+    annualAmount: period.amount.times(12).string(),
+  }));
+</script>
+
+<div class="strategy-overview-container">
+  <h3>Selected Strategy Overview</h3>
+
+  <div class="strategy-summary">
+    <table class="summary-table">
+      <tbody>
+        <tr>
+          <td class="row-label">Filing</td>
+          <td>{filingDate.toString()} ({result.filingAge1Years}y {result.filingAge1Months}m)</td>
+        </tr>
+        <tr>
+          <td class="row-label">Death</td>
+          <td>{deathDate.monthName()} {deathDate.year()} ({expectedAge.toAgeString()})</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="npv-display">
+      <strong>Net Present Value: {result.totalBenefit.string()}</strong>
+    </div>
+  </div>
+
+  <div class="payment-timeline">
+    <h4>Payment Timeline</h4>
+
+    {#if formattedPeriods.length === 0}
+      <div class="no-benefits">No benefits</div>
+    {:else}
+      <div class="payment-periods">
+        {#each formattedPeriods as period}
+          <div class="payment-period">
+            <div class="period-dates">
+              {period.startFormatted} — {period.endFormatted}
+            </div>
+            <div class="benefit-amounts">
+              <span class="monthly-amount">{period.amount}/mo</span>
+              <span class="annual-amount">{period.annualAmount}/yr</span>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .strategy-overview-container {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border: 1px solid #007bff;
+    border-radius: 8px;
+    background-color: #f8fbff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    max-width: 600px;
+  }
+
+  .strategy-overview-container h3 {
+    color: #0056b3;
+    margin: 0 0 1.5rem 0;
+    text-align: center;
+    font-size: 1.3rem;
+  }
+
+  .strategy-summary {
+    margin-bottom: 2rem;
+  }
+
+  .summary-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    font-size: 0.95rem;
+  }
+
+  .summary-table td {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid #e0e0e0;
+  }
+
+  .summary-table .row-label {
+    font-weight: 600;
+    color: #0056b3;
+    background-color: #f8f9fa;
+    border-right: 1px solid #e0e0e0;
+    width: 40%;
+  }
+
+  .npv-display {
+    text-align: center;
+    padding: 1rem;
+    background-color: #e7f3ff;
+    border: 1px solid #b3d9ff;
+    border-radius: 6px;
+    font-size: 1.1rem;
+    color: #0056b3;
+  }
+
+  .payment-timeline h4 {
+    color: #0056b3;
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+    border-bottom: 1px solid #d0d0d0;
+    padding-bottom: 0.5rem;
+  }
+
+  .payment-periods {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .payment-period {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    border-left: 3px solid #007bff;
+    background-color: #f0f8ff;
+    font-size: 0.9rem;
+  }
+
+  .period-dates {
+    font-weight: 500;
+    color: #333;
+  }
+
+  .benefit-amounts {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    text-align: right;
+  }
+
+  .monthly-amount {
+    font-weight: 600;
+    color: #0056b3;
+  }
+
+  .annual-amount {
+    font-size: 0.8rem;
+    color: #6c757d;
+  }
+
+  .no-benefits {
+    text-align: center;
+    color: #6c757d;
+    font-style: italic;
+    padding: 1rem;
+    border: 1px dashed #dee2e6;
+    border-radius: 4px;
+    background-color: #f8f9fa;
+  }
+
+  @media (max-width: 768px) {
+    .summary-table {
+      font-size: 0.85rem;
+    }
+
+    .summary-table td {
+      padding: 0.4rem 0.5rem;
+    }
+
+    .payment-period {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.5rem;
+    }
+
+    .benefit-amounts {
+      align-items: flex-start;
+      text-align: left;
+    }
+  }
+</style>

--- a/src/stories/AlternativeStrategiesRow.stories.ts
+++ b/src/stories/AlternativeStrategiesRow.stories.ts
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
+import { MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+import AlternativeStrategiesRow from '../routes/strategy/components/AlternativeStrategiesRow.svelte';
+
+const meta: Meta<AlternativeStrategiesRow> = {
+  title: 'Strategy/AlternativeStrategiesRow',
+  component: AlternativeStrategiesRow,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Creates a recipient with the given birthdate and PIA.
+ */
+function createRecipient(
+  birthYear: number,
+  birthMonth: number,
+  birthDay: number,
+  piaAmount: number
+): Recipient {
+  const recipient = new Recipient();
+  recipient.birthdate = Birthdate.FromYMD(birthYear, birthMonth, birthDay);
+  recipient.setPia(Money.from(piaAmount));
+  recipient.name = 'Alex';
+  recipient.markFirst();
+  return recipient;
+}
+
+// Default story: typical recipient born mid-month
+// Birthdate Feb 15, 1962 means earliest filing is 62y 1m (March 2024)
+export const Default: Story = {
+  args: {
+    recipient: createRecipient(1962, 1, 15, 2000),
+    deathAge: new MonthDuration(85 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(450000),
+    optimalFilingAge: new MonthDuration(67 * 12),
+    displayAsAges: false,
+  },
+};
+
+// Recipient who can file right at 62y 0m (born on the 1st or 2nd of the month)
+export const EarlyEligible: Story = {
+  args: {
+    recipient: createRecipient(1962, 5, 2, 1800),
+    deathAge: new MonthDuration(90 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(520000),
+    optimalFilingAge: new MonthDuration(70 * 12),
+    displayAsAges: false,
+  },
+};
+
+// Recipient born late in the month, can't file until 62y 1m
+// Born Dec 25, 1960 - earliest filing is 62y 1m (Jan 2023)
+export const LateMonthBirthday: Story = {
+  args: {
+    recipient: createRecipient(1960, 11, 25, 2500),
+    deathAge: new MonthDuration(88 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(580000),
+    optimalFilingAge: new MonthDuration(68 * 12 + 6),
+    displayAsAges: false,
+  },
+};
+
+// Display as ages instead of dates
+export const DisplayAsAges: Story = {
+  args: {
+    recipient: createRecipient(1962, 1, 15, 2000),
+    deathAge: new MonthDuration(85 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(450000),
+    optimalFilingAge: new MonthDuration(67 * 12),
+    displayAsAges: true,
+  },
+};
+
+// Recipient with early optimal filing age
+export const EarlyOptimal: Story = {
+  args: {
+    recipient: createRecipient(1965, 3, 10, 1500),
+    deathAge: new MonthDuration(75 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(280000),
+    optimalFilingAge: new MonthDuration(62 * 12 + 1),
+    displayAsAges: false,
+  },
+};
+
+// Recipient with late optimal filing age (age 70)
+export const LateOptimal: Story = {
+  args: {
+    recipient: createRecipient(1965, 3, 10, 3000),
+    deathAge: new MonthDuration(95 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(850000),
+    optimalFilingAge: new MonthDuration(70 * 12),
+    displayAsAges: false,
+  },
+};
+
+// Shorter life expectancy - shows truncated grid
+export const ShortLifeExpectancy: Story = {
+  args: {
+    recipient: createRecipient(1962, 5, 15, 2200),
+    deathAge: new MonthDuration(68 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(180000),
+    optimalFilingAge: new MonthDuration(62 * 12 + 1),
+    displayAsAges: false,
+  },
+};
+
+// With discount rate applied
+export const WithDiscountRate: Story = {
+  args: {
+    recipient: createRecipient(1962, 1, 15, 2000),
+    deathAge: new MonthDuration(85 * 12),
+    discountRate: 3,
+    optimalNPV: Money.from(320000),
+    optimalFilingAge: new MonthDuration(65 * 12),
+    displayAsAges: false,
+  },
+};
+
+// Higher PIA recipient
+export const HighEarner: Story = {
+  args: {
+    recipient: createRecipient(1963, 7, 20, 4000),
+    deathAge: new MonthDuration(90 * 12),
+    discountRate: 0,
+    optimalNPV: Money.from(1100000),
+    optimalFilingAge: new MonthDuration(70 * 12),
+    displayAsAges: false,
+  },
+};

--- a/src/test/strategy/alternative-strategies.test.ts
+++ b/src/test/strategy/alternative-strategies.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
+import { MonthDate, MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+import {
+  calculateAlternativeStrategies,
+  formatFilingAgeDisplay,
+  getStrategyColor,
+} from '$lib/strategy/calculations/alternative-strategies';
+
+describe('getStrategyColor', () => {
+  it('returns dark green for optimal', () => {
+    expect(getStrategyColor(100, true)).toBe('rgb(0, 100, 0)');
+  });
+
+  it('returns dark green for optimal even with lower percentage', () => {
+    // The optimal flag takes precedence
+    expect(getStrategyColor(50, true)).toBe('rgb(0, 100, 0)');
+  });
+
+  it('returns forest green for 99%+ non-optimal', () => {
+    expect(getStrategyColor(99, false)).toBe('rgb(34, 139, 34)');
+    expect(getStrategyColor(99.5, false)).toBe('rgb(34, 139, 34)');
+    expect(getStrategyColor(100, false)).toBe('rgb(34, 139, 34)');
+  });
+
+  it('returns lime green for 95-99%', () => {
+    expect(getStrategyColor(95, false)).toBe('rgb(100, 170, 50)');
+    expect(getStrategyColor(97, false)).toBe('rgb(100, 170, 50)');
+    expect(getStrategyColor(98.9, false)).toBe('rgb(100, 170, 50)');
+  });
+
+  it('returns yellow-green for 90-95%', () => {
+    expect(getStrategyColor(90, false)).toBe('rgb(190, 210, 50)');
+    expect(getStrategyColor(92, false)).toBe('rgb(190, 210, 50)');
+    expect(getStrategyColor(94.9, false)).toBe('rgb(190, 210, 50)');
+  });
+
+  it('returns gold for 85-90%', () => {
+    expect(getStrategyColor(85, false)).toBe('rgb(255, 215, 0)');
+    expect(getStrategyColor(87, false)).toBe('rgb(255, 215, 0)');
+    expect(getStrategyColor(89.9, false)).toBe('rgb(255, 215, 0)');
+  });
+
+  it('returns orange for 80-85%', () => {
+    expect(getStrategyColor(80, false)).toBe('rgb(255, 165, 0)');
+    expect(getStrategyColor(82, false)).toBe('rgb(255, 165, 0)');
+    expect(getStrategyColor(84.9, false)).toBe('rgb(255, 165, 0)');
+  });
+
+  it('returns red for below 80%', () => {
+    expect(getStrategyColor(79.9, false)).toBe('rgb(220, 20, 60)');
+    expect(getStrategyColor(50, false)).toBe('rgb(220, 20, 60)');
+    expect(getStrategyColor(0, false)).toBe('rgb(220, 20, 60)');
+  });
+});
+
+describe('formatFilingAgeDisplay', () => {
+  it('formats age with just years when months is 0', () => {
+    const age = new MonthDuration(62 * 12);
+    expect(formatFilingAgeDisplay(age, true)).toBe('62y');
+  });
+
+  it('formats age with years and months', () => {
+    const age = new MonthDuration(62 * 12 + 3);
+    expect(formatFilingAgeDisplay(age, true)).toBe('62y3m');
+  });
+
+  it('formats age 70', () => {
+    const age = new MonthDuration(70 * 12);
+    expect(formatFilingAgeDisplay(age, true)).toBe('70y');
+  });
+
+  it('formats age 67 and 6 months', () => {
+    const age = new MonthDuration(67 * 12 + 6);
+    expect(formatFilingAgeDisplay(age, true)).toBe('67y6m');
+  });
+
+  it('throws error when displayAsAges is false and no birthdate', () => {
+    const age = new MonthDuration(62 * 12);
+    expect(() => formatFilingAgeDisplay(age, false)).toThrow(
+      'birthdate required when displayAsAges is false'
+    );
+  });
+
+  it('formats as date when displayAsAges is false', () => {
+    const age = new MonthDuration(62 * 12);
+    const birthdate = Birthdate.FromYMD(1962, 0, 15); // Jan 15, 1962
+    const result = formatFilingAgeDisplay(age, false, birthdate);
+    // Age 62 for Jan 1962 birthday means filing in Jan 2024
+    // Date format may vary by locale, just check it contains Jan and 24
+    expect(result).toContain('Jan');
+    expect(result).toContain('24');
+  });
+});
+
+describe('calculateAlternativeStrategies', () => {
+  function createRecipient(
+    birthYear: number,
+    birthMonth: number,
+    birthDay: number,
+    piaAmount: number
+  ): Recipient {
+    const recipient = new Recipient();
+    recipient.birthdate = Birthdate.FromYMD(birthYear, birthMonth, birthDay);
+    recipient.setPia(Money.from(piaAmount));
+    return recipient;
+  }
+
+  it('groups results by year', () => {
+    // Use a birthdate far in the future so no ages are "already passed"
+    const recipient = createRecipient(2000, 0, 15, 2000);
+    const deathAge = new MonthDuration(85 * 12);
+    const optimalNPV = Money.from(500000);
+    const optimalFilingAge = new MonthDuration(67 * 12);
+    // Use a current date before the recipient turns 62
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2050,
+      months: 0,
+    });
+
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // Should have groups for ages 62 through 70 (9 years)
+    expect(result.length).toBe(9);
+    expect(result[0].year).toBe(62);
+    expect(result[8].year).toBe(70);
+  });
+
+  it('adds placeholders for unavailable months at start of first year', () => {
+    // Born mid-month, so earliest filing is 62y 1m
+    const recipient = createRecipient(2000, 5, 15, 2000); // June 15
+    const deathAge = new MonthDuration(85 * 12);
+    const optimalNPV = Money.from(500000);
+    const optimalFilingAge = new MonthDuration(67 * 12);
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2050,
+      months: 0,
+    });
+
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // First year should have 12 entries (including placeholder)
+    const firstYear = result[0];
+    expect(firstYear.year).toBe(62);
+    // First entry should be a placeholder
+    expect(firstYear.results[0].isPlaceholder).toBe(true);
+    expect(firstYear.results[0].placeholderReason).toBe('Not yet eligible');
+  });
+
+  it('marks past filing ages as already passed', () => {
+    // Born Jan 2, 1960 so they can file at exactly 62y 0m, avoiding "Not yet eligible" placeholders
+    const recipient = createRecipient(1960, 0, 2, 2000);
+    const deathAge = new MonthDuration(85 * 12);
+    const optimalNPV = Money.from(500000);
+    const optimalFilingAge = new MonthDuration(67 * 12);
+    // Current date when recipient is 64 years old
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2024,
+      months: 6,
+    });
+
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // Ages 62 and 63 should be marked as already passed
+    const age62Group = result.find((g) => g.year === 62);
+    expect(age62Group).toBeDefined();
+    // All entries in age 62 should be "Already passed" (no eligibility placeholders
+    // since this recipient can file at exactly 62y 0m)
+    for (const r of age62Group!.results) {
+      expect(r.isPlaceholder).toBe(true);
+      expect(r.placeholderReason).toBe('Already passed');
+    }
+
+    const age63Group = result.find((g) => g.year === 63);
+    expect(age63Group).toBeDefined();
+    for (const r of age63Group!.results) {
+      expect(r.isPlaceholder).toBe(true);
+      expect(r.placeholderReason).toBe('Already passed');
+    }
+  });
+
+  it('truncates results at death age', () => {
+    const recipient = createRecipient(2000, 0, 2, 2000);
+    // Death at age 65 means no filing ages after 65
+    const deathAge = new MonthDuration(65 * 12);
+    const optimalNPV = Money.from(300000);
+    const optimalFilingAge = new MonthDuration(62 * 12);
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2050,
+      months: 0,
+    });
+
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // Should only have ages 62 through 65 (4 years)
+    expect(result.length).toBe(4);
+    expect(result[result.length - 1].year).toBe(65);
+  });
+
+  it('marks the optimal filing age correctly', () => {
+    const recipient = createRecipient(2000, 0, 2, 2000);
+    const deathAge = new MonthDuration(85 * 12);
+    const optimalNPV = Money.from(500000);
+    const optimalFilingAge = new MonthDuration(67 * 12);
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2050,
+      months: 0,
+    });
+
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // Find the age 67 group and check the first entry (67y 0m)
+    const age67Group = result.find((g) => g.year === 67);
+    expect(age67Group).toBeDefined();
+    const optimalResult = age67Group!.results.find(
+      (r) => r.filingAge.asMonths() === 67 * 12
+    );
+    expect(optimalResult).toBeDefined();
+    expect(optimalResult!.isOptimal).toBe(true);
+
+    // Other results should not be marked as optimal
+    const age62Group = result.find((g) => g.year === 62);
+    for (const r of age62Group!.results) {
+      if (!r.isPlaceholder) {
+        expect(r.isOptimal).toBe(false);
+      }
+    }
+  });
+
+  it('calculates percentage of optimal correctly', () => {
+    const recipient = createRecipient(2000, 0, 2, 2000);
+    const deathAge = new MonthDuration(85 * 12);
+    const optimalNPV = Money.from(500000);
+    const optimalFilingAge = new MonthDuration(67 * 12);
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2050,
+      months: 0,
+    });
+
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // All non-placeholder results should have a percentage calculated
+    for (const group of result) {
+      for (const r of group.results) {
+        if (!r.isPlaceholder) {
+          // Percentage should be positive and reasonable
+          expect(r.percentOfOptimal).toBeGreaterThan(0);
+          expect(r.percentOfOptimal).toBeLessThanOrEqual(101); // Allow slight floating point variance
+        }
+      }
+    }
+  });
+
+  it('handles zero optimal NPV without division errors', () => {
+    const recipient = createRecipient(2000, 0, 2, 0); // Zero PIA
+    const deathAge = new MonthDuration(85 * 12);
+    const optimalNPV = Money.from(0);
+    const optimalFilingAge = new MonthDuration(67 * 12);
+    const currentDate = MonthDate.initFromYearsMonths({
+      years: 2050,
+      months: 0,
+    });
+
+    // Should not throw
+    const result = calculateAlternativeStrategies(
+      recipient,
+      deathAge,
+      0,
+      optimalNPV,
+      optimalFilingAge,
+      currentDate
+    );
+
+    // All percentages should be 0 when optimal is 0
+    for (const group of result) {
+      for (const r of group.results) {
+        if (!r.isPlaceholder) {
+          expect(r.percentOfOptimal).toBe(0);
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds click-to-pin functionality to the single recipient strategy chart (StrategyPlotSingle)
- Creates StrategyDetailsSingle component showing selected strategy overview (filing age/date, death age/date, NPV, payment timeline)
- Creates AlternativeStrategiesRow component displaying all monthly filing ages (62-70) with color-coded NPV performance
- Extracts shared strategy calculation logic into `alternative-strategies.ts`

## Test plan

- [ ] Navigate to `/strategy` page
- [ ] Check "Single Recipient" checkbox
- [ ] Fill in birthdate and PIA, click Calculate
- [ ] Verify chart renders and hover behavior still works
- [ ] Click on a point on the chart - verify:
  - Point shows golden "pinned" styling
  - Strategy details panel appears below
  - Alternative strategies grid shows all filing ages 62-70 with NPV
- [ ] Toggle "Display as Ages" checkbox and verify labels update
- [ ] Click same point again to deselect
- [ ] Run `npm test` - all tests pass
- [ ] Run `npm run check` - no type errors