### PR TITLE
Improve StrategyPlotSingle chart UX and add tests

### DIFF
--- a/src/routes/strategy/components/StrategyPlotSingle.svelte
+++ b/src/routes/strategy/components/StrategyPlotSingle.svelte
@@ -38,7 +38,7 @@
   $: rowBuckets = calculationResults.rowBuckets();
 
   // X-axis padding in years on each side of the interesting range
-  const xAxisPadding = 2;
+  const xAxisPadding = 5;
 
   /**
    * The data points to plot. Each point represents a death age bucket and the

--- a/src/stories/StrategyPlotSingle.stories.ts
+++ b/src/stories/StrategyPlotSingle.stories.ts
@@ -200,7 +200,7 @@ function createDeathProbDistribution(
 
 export const Default: Story = {
   args: {
-    recipient: createRecipient(1962, 3, 15, 2500),
+    recipient: createRecipient(1962, 3, 1, 2500),
     calculationResults: createTypicalCalculationResults(),
     deathProbDistribution: createDeathProbDistribution(),
     displayAsAges: true,
@@ -209,7 +209,7 @@ export const Default: Story = {
 
 export const DisplayAsDates: Story = {
   args: {
-    recipient: createRecipient(1962, 3, 15, 2500),
+    recipient: createRecipient(1962, 3, 1, 2500),
     calculationResults: createTypicalCalculationResults(),
     deathProbDistribution: createDeathProbDistribution(),
     displayAsAges: false,
@@ -219,7 +219,7 @@ export const DisplayAsDates: Story = {
 export const FlatEarlyFiling: Story = {
   name: 'Flat Line - Early Filing (High Interest Rate)',
   args: {
-    recipient: createRecipient(1962, 3, 15, 2500),
+    recipient: createRecipient(1962, 3, 1, 2500),
     calculationResults: createFlatEarlyFilingResults(),
     deathProbDistribution: createDeathProbDistribution(),
     displayAsAges: true,
@@ -229,7 +229,7 @@ export const FlatEarlyFiling: Story = {
 export const FlatLateFiling: Story = {
   name: 'Flat Line - Late Filing (Low Interest Rate)',
   args: {
-    recipient: createRecipient(1962, 3, 15, 2500),
+    recipient: createRecipient(1962, 3, 1, 2500),
     calculationResults: createFlatLateFilingResults(),
     deathProbDistribution: createDeathProbDistribution(),
     displayAsAges: true,
@@ -239,7 +239,7 @@ export const FlatLateFiling: Story = {
 export const SharpTransition: Story = {
   name: 'Sharp Filing Age Transition',
   args: {
-    recipient: createRecipient(1962, 3, 15, 2500),
+    recipient: createRecipient(1962, 3, 1, 2500),
     calculationResults: createSharpTransitionResults(),
     deathProbDistribution: createDeathProbDistribution(),
     displayAsAges: true,

--- a/src/test/routes/strategy/components/StrategyPlotSingle.test.ts
+++ b/src/test/routes/strategy/components/StrategyPlotSingle.test.ts
@@ -49,7 +49,7 @@ function createCalculationResults(
 function calculateXAxisRange(
   results: CalculationResults,
   earliestFilingAge: number,
-  xAxisPadding: number = 2
+  xAxisPadding: number = 5
 ): { min: number; max: number } {
   const rowBuckets = results.rowBuckets();
   const bucketMin = rowBuckets[0]?.startAge ?? 62;
@@ -150,9 +150,9 @@ describe('StrategyPlotSingle', () => {
 
       // Last death age with minimum filing age is 75
       // First death age with maximum filing age is 85
-      // With padding of 2: min = 73, max = 87
-      expect(range.min).toBe(73);
-      expect(range.max).toBe(87);
+      // With padding of 5: min = 70, max = 90
+      expect(range.min).toBe(70);
+      expect(range.max).toBe(90);
     });
 
     it('should respect bucket boundaries when applying padding', () => {
@@ -169,7 +169,7 @@ describe('StrategyPlotSingle', () => {
 
       // Last death age with min filing (62) is 63
       // First death age with max filing (70) is 65
-      // With padding of 2: min = max(62, 63-2) = 62, max = min(66, 65+2) = 66
+      // With padding of 5: min = max(62, 63-5) = 62, max = min(66, 65+5) = 66
       expect(range.min).toBe(62); // Clamped to bucket min
       expect(range.max).toBe(66); // Clamped to bucket max
     });
@@ -186,9 +186,9 @@ describe('StrategyPlotSingle', () => {
 
       // Last death age with min filing (62) is 79
       // First death age with max filing (70) is 80
-      // With padding of 2: min = 77, max = 82
-      expect(range.min).toBe(77);
-      expect(range.max).toBe(82);
+      // With padding of 5: min = 74, max = 85
+      expect(range.min).toBe(74);
+      expect(range.max).toBe(85);
     });
   });
 


### PR DESCRIPTION
## Summary
- Color y-axis labels to match their corresponding chart lines (blue for filing age, red for cumulative mortality)
- Fix click crosshairs to match hover behavior with split horizontal lines reaching both y-axes
- Add dynamic x-axis range that focuses on the transition region where filing age varies
- Add y-axis padding for visual breathing room
- Handle flat line edge case (e.g., high interest rate scenarios)

## Test plan
- [x] Run `npm run check` - passes with no errors
- [x] Run `npm run test` - all 8 new tests pass
- [x] Run `npm run storybook` and verify all 6 new stories render correctly
- [x] Manual testing: verify hover and click crosshairs match on the strategy page
- [x] Manual testing: verify x-axis narrows to interesting range with default settings
- [x] Manual testing: verify flat line case (high interest rate) shows full x-axis range