### PR TITLE
Add comprehensive PostHog analytics tracking

### DIFF
--- a/src/lib/components/DemoData.svelte
+++ b/src/lib/components/DemoData.svelte
@@ -27,8 +27,10 @@ import { parsePaste } from '$lib/ssa-parse';
 
 // Callback prop for demo event
 export let ondemo:
-  | ((detail: { recipient: Recipient; spouse: Recipient | null }) => void)
+  | ((detail: { recipient: Recipient; spouse: Recipient | null; demoType?: string }) => void)
   | undefined = undefined;
+
+const DEMO_TYPES = ['average_earner_couple', 'high_earner_single', 'young_earner_couple'] as const;
 
 function loadDemoData(demoId: number) {
   return () => {
@@ -68,6 +70,7 @@ function loadDemoData(demoId: number) {
     ondemo?.({
       recipient: recipient,
       spouse: spouse,
+      demoType: DEMO_TYPES[demoId],
     });
   };
 }

--- a/src/lib/components/Sponsor.svelte
+++ b/src/lib/components/Sponsor.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import posthog from 'posthog-js';
 import { onMount } from 'svelte';
+import { browser } from '$app/environment';
 import ProjectionLabImage from '$lib/images/projection-lab.png';
 import { Recipient } from '$lib/recipient';
 
@@ -8,12 +10,26 @@ export let recipient: Recipient = new Recipient();
 let sponsorElement: HTMLElement;
 let isVisible = false;
 
+function handleSponsorClick() {
+  if (browser) {
+    posthog.capture('Sponsor: Clicked', {
+      sponsor_name: 'ProjectionLab',
+    });
+  }
+}
+
 onMount(() => {
   const observer = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           isVisible = true;
+          // Track sponsor visibility
+          if (browser) {
+            posthog.capture('Sponsor: Visible', {
+              sponsor_name: 'ProjectionLab',
+            });
+          }
           observer.unobserve(entry.target);
         }
       });
@@ -41,6 +57,7 @@ onMount(() => {
   class="spon-anchor"
   target="_blank"
   rel="noopener noreferrer"
+  on:click={handleSponsorClick}
 >
   <div class="transition-section">
     <h2>Beyond Social Security: Complete Retirement Planning</h2>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,18 +1,54 @@
 <script lang="ts">
 import posthog from 'posthog-js';
 import { onMount } from 'svelte';
+import { afterNavigate } from '$app/navigation';
 import { browser } from '$app/environment';
-import { initializeIntegration } from '$lib/integrations/context';
+import { page } from '$app/stores';
+import { initializeIntegration, activeIntegration } from '$lib/integrations/context';
 import '../app.css';
-
-// These imports are available for use but may not be directly referenced
-// They're kept for potential future use
-const _browser = browser;
-const _posthog = posthog;
 
 onMount(() => {
   // Initialize integration to preserve session state across all pages
   initializeIntegration();
+
+  // Register integration_id as a super property if present in URL hash
+  if (browser) {
+    const hashParams = new URLSearchParams(window.location.hash.slice(1));
+    const integrationId = hashParams.get('integration');
+    if (integrationId) {
+      posthog.register({ integration_id: integrationId });
+    }
+  }
+});
+
+// Track page views on navigation
+afterNavigate(({ to }) => {
+  if (browser && to?.url) {
+    const pathname = to.url.pathname;
+    let eventName = 'Page View';
+    let properties: Record<string, string | undefined> = {};
+
+    // Determine the page type and event name
+    if (pathname === '/') {
+      eventName = 'Page View: Home';
+    } else if (pathname === '/calculator') {
+      eventName = 'Page View: Calculator';
+      properties.integration_id = $activeIntegration?.id;
+    } else if (pathname === '/guides') {
+      eventName = 'Page View: Guides Index';
+    } else if (pathname.startsWith('/guides/')) {
+      eventName = 'Page View: Guide';
+      properties.guide_slug = pathname.replace('/guides/', '');
+    } else if (pathname === '/strategy') {
+      eventName = 'Page View: Strategy';
+    } else if (pathname === '/about') {
+      eventName = 'Page View: About';
+    } else if (pathname === '/contact') {
+      eventName = 'Page View: Contact';
+    }
+
+    posthog.capture(eventName, properties);
+  }
 });
 </script>
 

--- a/src/routes/guides/guide-footer.svelte
+++ b/src/routes/guides/guide-footer.svelte
@@ -1,3 +1,19 @@
+<script lang="ts">
+import posthog from 'posthog-js';
+import { browser } from '$app/environment';
+import { page } from '$app/stores';
+
+function handleCtaClick() {
+  if (browser) {
+    const guideSlug = $page.url.pathname.replace('/guides/', '');
+    posthog.capture('Guide: CTA Clicked', {
+      guide_slug: guideSlug,
+      cta_type: 'calculate_my_benefits',
+    });
+  }
+}
+</script>
+
 <div class="footer">
   <div class="footer-content">
     <div class="footer-icon">📊</div>
@@ -21,7 +37,7 @@
       </div>
     </div>
     <div class="cta-container">
-      <a href="/calculator" class="cta-button" role="button">
+      <a href="/calculator" class="cta-button" role="button" on:click={handleCtaClick}>
         <span class="cta-text">Calculate My Benefits</span>
       </a>
       <div class="trust-indicators">


### PR DESCRIPTION
## Summary
- Add paste flow funnel events to track user progression through data entry
- Add page view tracking for all key routes
- Add integration activation tracking with preloaded data detection
- Add sponsor visibility and click tracking
- Add guide CTA engagement tracking
- Enhance existing events (Demo Loaded, Hash Pasted, Pasted) with additional properties

## New Events

### Paste Flow Funnel
- `Paste Flow: Started` - with `is_spouse_entry`
- `Paste Flow: Parse Success` - with `record_count`, `is_pia_only`
- `Paste Flow: Data Confirmed` / `Data Rejected`
- `Paste Flow: Zero Earnings Check`
- `Paste Flow: Birthdate Entered`
- `Paste Flow: Spouse Question Shown`
- `Paste Flow: Single Selected` / `Couple Selected`

### Page Views
- `Page View: Home`, `Calculator`, `Guides Index`, `Guide`, `Strategy`, `About`, `Contact`
- Guide pages include `guide_slug` property

### Integration & Sponsor
- `Integration: Activated` - with `integration_id`, `has_preloaded_data`
- `Sponsor: Visible` / `Sponsor: Clicked`

### Guide Engagement
- `Guide: CTA Clicked` - with `guide_slug`, `cta_type`

## Test plan
- [ ] Deploy to preview and walk through paste flow, verify events in PostHog
- [ ] Test demo button and verify `Demo Loaded` event with `demo_type`
- [ ] Navigate between pages and verify page view events
- [ ] Test sponsor visibility and click tracking
- [ ] Test guide CTA click tracking
- [ ] Verify integration parameter tracking with `#integration=opensocialsecurity.com`