### PR TITLE
Rename PostHog proxy path to avoid ad blocker detection

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -6,7 +6,7 @@ export const prerender = true;
 export const load = async () => {
   if (browser) {
     posthog.init('phc_hCY7L2NR1CymU5BYBsvZOQ7eblUWH1eOrKX8jQ3ZcUK', {
-      api_host: 'https://ssa.tools/ingest',
+      api_host: 'https://ssa.tools/api/v1',
       ui_host: 'https://app.posthog.com',
       autocapture: false,
       disable_session_recording: true,

--- a/vercel.json
+++ b/vercel.json
@@ -29,7 +29,7 @@
   ],
   "rewrites": [
     {
-      "source": "/ingest/:path(.*)",
+      "source": "/api/v1/:path(.*)",
       "destination": "https://app.posthog.com/:path*"
     }
   ]


### PR DESCRIPTION
## Summary
Change the PostHog proxy path from `/ingest` to `/api/v1` to reduce ad blocker detection.

The `/ingest` path is a well-known PostHog proxy pattern that many ad blockers specifically target. Using `/api/v1` looks like a generic API endpoint and is much less likely to be blocked.

## Changes
- `vercel.json`: Update rewrite rule from `/ingest/*` to `/api/v1/*`
- `src/routes/+layout.ts`: Update `api_host` to use new path

## Test plan
- [ ] Deploy to preview
- [ ] Verify analytics events are captured in PostHog dashboard
- [ ] Test with common ad blockers (uBlock Origin, etc.) to confirm reduced blocking