### PR TITLE
Add variant styling to Expando component

### DIFF
--- a/src/lib/components/Expando.svelte
+++ b/src/lib/components/Expando.svelte
@@ -2,6 +2,14 @@
 import { onMount } from 'svelte';
 
 /**
+ * Visual style variant for the expando.
+ * - 'default': Box style with gray background (backwards compatible)
+ * - 'inline': Link-like style, lightweight for helper content
+ * - 'section': Full-width section divider style
+ */
+export let variant: 'default' | 'inline' | 'section' = 'default';
+
+/**
  * If true, the expando will be expanded when the page loads.
  *
  * Modifications to this variable will not be reflected in the
@@ -71,10 +79,17 @@ function toggle() {
     contentsEl.style.maxHeight = null;
   }
 }
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    toggle();
+  }
+}
 </script>
 
 <section
-  class="expando"
+  class="expando variant-{variant}"
   class:expanded
   style:--collapsed-background-color={collapsed_background_color}
   style:--collapsed-hover-color={collapsed_hover_color}
@@ -87,9 +102,10 @@ function toggle() {
   <div
     class="label noprint"
     on:click={toggle}
-    on:keydown={toggle}
+    on:keydown={handleKeydown}
     role="button"
     tabindex="0"
+    aria-expanded={expanded}
   >
     {expanded ? expandedText : collapsedText}
   </div>
@@ -104,69 +120,202 @@ function toggle() {
     position: relative;
     margin: 10px 0 20px 0;
   }
-  .label {
-    font-size: 16px;
+
+  /* ========================================
+   * DEFAULT VARIANT (modernized)
+   * ======================================== */
+  .variant-default .label {
+    font-size: 15px;
     display: block;
     position: relative;
-    /* 20px + 7x2 padding + 1x2 border = 36px */
     height: auto;
-    padding: 7px 10px;
-    font-weight: bold;
-    background-color: var(--collapsed-background-color);
-    border: 1px solid var(--collapsed-tab-color);
-    border-left: 3px solid var(--collapsed-border-color);
+    padding: 10px 14px;
+    padding-right: 36px;
+    font-weight: 600;
+    background: linear-gradient(to bottom, #f8f9fa, #f1f3f4);
+    border: 1px solid #d0d4d8;
+    border-radius: 6px;
+    color: #495057;
     cursor: pointer;
-    transition: all 0.25s ease-out;
-    /* Leave some space for the right arrow */
-    padding-right: 35px;
+    transition: all 0.2s ease;
     max-width: max-content;
   }
-  .label:hover {
-    background: var(--collapsed-hover-color);
+  .variant-default .label:hover {
+    background: linear-gradient(to bottom, #fff, #f8f9fa);
+    border-color: #b8bdc2;
   }
-  /* Prevent the label from being selected */
-  .label::selection {
+  .variant-default .label::selection {
     background: none;
   }
-  /* Create a right pointing triangle by making only the left border
-   * visible. Since the border is 6px wide, the triangle is 6px wide
-   * and 12px tall.
-   */
-  .label::before {
+  .variant-default .label::before {
     content: '';
     position: absolute;
-    right: 4px;
+    right: 12px;
     top: 50%;
-    margin-top: -6px;
-    border: 6px solid transparent;
-    border-left-color: var(--collapsed-border-color);
+    margin-top: -5px;
+    border: 5px solid transparent;
+    border-left-color: #6c757d;
+    border-left-width: 6px;
   }
-  /**
-   * When the input is checked upon the label being clicked, change the border
-   * colors to make it look like it's selected.
-   */
-  .expanded .label {
-    border: 1px solid var(--expanded-border-color);
-    border-left: 3px solid var(--expanded-tab-color);
-    background: var(--expanded-background-color);
+  .variant-default.expanded .label {
+    background: linear-gradient(to bottom, #e8f0fe, #dbe6f6);
+    border-color: #a8c7f5;
+    border-bottom-color: transparent;
+    color: #1a4d8c;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
-  /* Update the right arrow to a down arrow when checked */
-  .expanded .label::before {
-    border: 6px solid transparent;
-    border-top-color: var(--expanded-tab-color);
+  .variant-default.expanded .label::before {
+    border: 5px solid transparent;
+    border-top-color: #1a4d8c;
+    border-top-width: 6px;
     margin-top: -3px;
-    right: 10px;
+    right: 14px;
   }
-  .expandContents {
+  .variant-default .expandContents {
     overflow: hidden;
-    margin-left: 6px;
-    border-left: 2px solid #a6a6f5;
-    margin-bottom: 4px;
-    border-image: linear-gradient(to bottom, #a6a6f5, 90%, #fff) 1 100%;
-    padding: 0px;
-    transition: all 0.25s ease-in;
-
-    /* This will be modified by javascript upon toggling. */
+    margin: 0;
+    padding: 0;
+    background: #f8fafc;
+    border-radius: 0 0 6px 6px;
+    box-shadow: inset 0 0 0 1px transparent;
+    transition: max-height 0.25s ease-in-out, box-shadow 0.15s ease;
     max-height: 0;
+  }
+  .variant-default.expanded .expandContents {
+    box-shadow:
+      inset 1px 0 0 #a8c7f5,
+      inset -1px 0 0 #a8c7f5,
+      inset 0 -1px 0 #a8c7f5,
+      inset 0 1px 0 #a8c7f5;
+  }
+
+  /* ========================================
+   * INLINE VARIANT (link-like, lightweight)
+   * ======================================== */
+  .variant-inline {
+    margin: 4px 0;
+    display: inline-block;
+  }
+  .variant-inline .label {
+    display: inline;
+    background: transparent;
+    border: none;
+    padding: 0;
+    padding-left: 1em;
+    font-weight: normal;
+    font-size: inherit;
+    color: #4a90a4;
+    text-decoration: underline;
+    cursor: pointer;
+    position: relative;
+  }
+  .variant-inline .label:hover {
+    background: transparent;
+    color: #2c5f72;
+  }
+  .variant-inline .label::selection {
+    background: none;
+  }
+  .variant-inline .label::before {
+    content: '\25B6';
+    font-size: 0.6em;
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    color: #4a90a4;
+    transition: transform 0.2s ease;
+  }
+  .variant-inline.expanded .label {
+    background: transparent;
+    border: none;
+    color: #2c5f72;
+  }
+  .variant-inline.expanded .label::before {
+    transform: translateY(-50%) rotate(90deg);
+    border: none;
+    color: #2c5f72;
+  }
+  .variant-inline .expandContents {
+    overflow: hidden;
+    margin-left: 1em;
+    margin-top: 0.5em;
+    border-left: none;
+    border-image: none;
+    padding: 0;
+    transition: all 0.2s ease-in;
+    max-height: 0;
+  }
+
+  /* ========================================
+   * SECTION VARIANT (full-width divider)
+   * ======================================== */
+  .variant-section {
+    margin: 1.5em 0;
+  }
+  .variant-section .label {
+    display: block;
+    position: relative;
+    width: 100%;
+    padding: 12px 40px 12px 16px;
+    font-size: 15px;
+    font-weight: 600;
+    background: linear-gradient(to bottom, #f8f9fa, #e9ecef);
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    color: #495057;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: left;
+  }
+  .variant-section .label:hover {
+    background: linear-gradient(to bottom, #ffffff, #f8f9fa);
+    border-color: #adb5bd;
+  }
+  .variant-section .label::selection {
+    background: none;
+  }
+  .variant-section .label::before {
+    content: '';
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    margin-top: -5px;
+    border: 5px solid transparent;
+    border-left-color: #6c757d;
+    border-left-width: 6px;
+  }
+  .variant-section.expanded .label {
+    background: linear-gradient(to bottom, #e7f1ff, #d6e6ff);
+    border-color: #a6c8ff;
+    border-bottom-color: transparent;
+    color: #2c5282;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  .variant-section.expanded .label::before {
+    border: 5px solid transparent;
+    border-top-color: #2c5282;
+    border-top-width: 6px;
+    margin-top: -3px;
+    right: 18px;
+  }
+  .variant-section .expandContents {
+    overflow: hidden;
+    border-radius: 0 0 4px 4px;
+    background: #fafbfc;
+    margin: 0;
+    box-shadow: inset 0 0 0 1px transparent;
+    transition: max-height 0.25s ease-in-out, box-shadow 0.15s ease;
+    max-height: 0;
+  }
+  .variant-section.expanded .expandContents {
+    box-shadow:
+      inset 1px 0 0 #a6c8ff,
+      inset -1px 0 0 #a6c8ff,
+      inset 0 -1px 0 #a6c8ff,
+      inset 0 1px 0 #a6c8ff;
   }
 </style>

--- a/src/lib/components/PastePrompt.svelte
+++ b/src/lib/components/PastePrompt.svelte
@@ -100,6 +100,7 @@ function skipEarnings() {
         target="_blank">direct link</a
       >
       <Expando
+        variant="inline"
         collapsedText="or find it manually"
         expandedText="Hide"
       >
@@ -116,6 +117,7 @@ function skipEarnings() {
     <li>
       <strong>Copy the table</strong> &mdash; Select All ({selectAllShortcut}) works great
       <Expando
+        variant="inline"
         collapsedText="See example"
         expandedText="Hide"
       >
@@ -176,6 +178,7 @@ function skipEarnings() {
   {/if}
 
   <Expando
+    variant="section"
     collapsedText="Alternative data entry options"
     expandedText="Alternative data entry options"
   >

--- a/src/stories/Expando.demo.svelte
+++ b/src/stories/Expando.demo.svelte
@@ -5,10 +5,14 @@
  * component that is only used in the demo.
  */
 import Expando from '$lib/components/Expando.svelte';
+
+export let variant: 'default' | 'inline' | 'section' = 'default';
+export let collapsedText: string = 'Cat Ipsum';
+export let expandedText: string = 'Collapse Me';
 </script>
 
 <div>
-  <Expando collapsedText="Cat Ipsum" expandedText="Collapse Me">
+  <Expando {variant} {collapsedText} {expandedText}>
     <!-- https://ipsum-community.github.io/catipsum.com/ -->
     <p>
       Present belly, scratch hand when stroked man running from cops stops to

--- a/src/stories/Expando.stories.ts
+++ b/src/stories/Expando.stories.ts
@@ -8,6 +8,13 @@ const meta: Meta<Expando> = {
   parameters: {
     layout: 'fullscreen',
   },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'inline', 'section'],
+      description: 'Visual style variant',
+    },
+  },
 };
 export default meta;
 
@@ -17,4 +24,22 @@ const Template = ({ ...args }) => ({
 });
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  variant: 'default',
+  collapsedText: 'Expand for details',
+  expandedText: 'Collapse',
+};
+
+export const Inline = Template.bind({});
+Inline.args = {
+  variant: 'inline',
+  collapsedText: 'Show example',
+  expandedText: 'Hide',
+};
+
+export const Section = Template.bind({});
+Section.args = {
+  variant: 'section',
+  collapsedText: 'Alternative options',
+  expandedText: 'Alternative options',
+};


### PR DESCRIPTION
## Summary

- Adds a `variant` prop to the Expando component with three visual styles optimized for different use cases
- **inline**: Link-style appearance for lightweight helper content (no background, underlined text)
- **section**: Full-width divider style for major expandable sections (gradient background, rounded corners)
- **default**: Modernized box style with gradients and softer colors (backwards compatible)
- Improves accessibility with `aria-expanded` attribute and proper keyboard handling (Enter/Space only)
- Updates PastePrompt to use appropriate variants for each expando

## Test plan

- [ ] Run `npm run storybook` and verify all three variants render correctly
- [ ] Check expand/collapse animations are smooth on all variants
- [ ] Test keyboard navigation (Tab, Enter, Space) on each variant
- [ ] Visit paste prompt page and verify inline/section variants look correct
- [ ] Verify report pages still use default styling correctly