### PR TITLE
Improve spacing between integration banner and progress indicator

### DIFF
--- a/src/lib/components/ProgressIndicator.svelte
+++ b/src/lib/components/ProgressIndicator.svelte
@@ -108,7 +108,7 @@ const steps = [
 
 <style>
   .progress-container {
-    margin: 0 auto 1.5em auto;
+    margin: 1.5em auto;
     max-width: min(600px, 95%);
     padding: 0 10px;
   }

--- a/src/lib/components/integrations/IntegrationBanner.svelte
+++ b/src/lib/components/integrations/IntegrationBanner.svelte
@@ -65,7 +65,7 @@
   .intro-banner {
     background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
     border-left: 4px solid #1976d2;
-    margin: 1em auto 0;
+    margin: 1.5em auto 0;
     padding: 0.75em 1em;
     max-width: 1080px;
     border-radius: 4px 4px 0 0;
@@ -160,7 +160,7 @@
 
   @media screen and (max-width: 600px) {
     .intro-banner {
-      margin: 0.5em;
+      margin: 1em 0.5em 0;
       padding: 0.5em 0.75em;
     }
     .banner-content {


### PR DESCRIPTION
## Summary
- Increase top margin on IntegrationBanner from `1em` to `1.5em`
- Add top margin to ProgressIndicator container (`1.5em auto` instead of `0 auto 1.5em auto`)
- Update mobile responsive styles for consistent spacing

This provides better visual separation when the integration banner is displayed above the new progress indicator in the paste flow.

## Test plan
- [ ] Visit `/calculator` with an integration parameter (e.g., `#integration=cfiresim.com`)
- [ ] Verify adequate spacing between the integration banner and the progress indicator
- [ ] Test on mobile viewport sizes to ensure responsive spacing is consistent