### PR TITLE
Fix survivor filing age restriction when death slider is at floor

### DIFF
--- a/src/lib/components/SurvivorReport.svelte
+++ b/src/lib/components/SurvivorReport.svelte
@@ -234,8 +234,14 @@ function minCapSlider() {
     // (matching the hardcoded value in the survivor benefit calculation below)
     deathAgeMonths = 70 * 12;
   } else if (fileVsDeath === 'fileAfterDeath') {
-    // When dying before filing, the death date is the slider value
-    deathAgeMonths = afterDeathSliderMonths_;
+    // When dying before filing, the death date is the slider value.
+    // But if slider is at floor (<=66), don't restrict survivor filing age
+    // since "<=66" means death could have occurred earlier.
+    if (afterDeathSliderMonths_ === 66 * 12) {
+      deathAgeMonths = 0;
+    } else {
+      deathAgeMonths = afterDeathSliderMonths_;
+    }
   } else {
     throw new Error(`fileVsDeath toggle unexpected value: ${fileVsDeath}`);
   }


### PR DESCRIPTION
## Summary
- When "dies before filing" is selected and the death age slider is at its minimum ("≤66"), the survivor filing slider was incorrectly restricted to 66+1 month minimum
- The "≤66" label implies death could occur at age 66 *or earlier*, but the code was treating it as exactly 66
- Now when the slider is at its floor value, the survivor can file as early as age 60, honoring the "≤" semantics