### PR TITLE
Add serialize/deserialize methods to domain classes

### DIFF
--- a/src/lib/birthday.ts
+++ b/src/lib/birthday.ts
@@ -239,4 +239,31 @@ export class Birthdate {
     };
     return example;
   }
+
+  /**
+   * Serializes this birthdate to a plain object for storage.
+   */
+  serialize(): SerializedBirthdate {
+    return {
+      year: this.layBirthYear(),
+      month: this.layBirthMonth(),
+      day: this.layBirthDayOfMonth(),
+    };
+  }
+
+  /**
+   * Deserializes a plain object back to a Birthdate.
+   */
+  static deserialize(data: SerializedBirthdate): Birthdate {
+    return Birthdate.FromYMD(data.year, data.month, data.day);
+  }
+}
+
+/**
+ * Serialized format for session storage.
+ */
+export interface SerializedBirthdate {
+  year: number;
+  month: number;
+  day: number;
 }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,9 +1,22 @@
 /**
  * Global context for the application.
  */
+
 import { derived, writable } from 'svelte/store';
+import { browser } from '$app/environment';
 import type { MonthDate } from './month-time';
-import type { Recipient } from './recipient';
+import { Recipient, type SerializedRecipient } from './recipient';
+
+const SESSION_KEY = 'ssa-tools-session';
+
+interface SerializedSession {
+  recipient: SerializedRecipient | null;
+  spouse: SerializedRecipient | null;
+  isDemo: boolean;
+  version: number;
+}
+
+const SESSION_VERSION = 1;
 
 class Context {
   recipient: Recipient | null = null;
@@ -11,6 +24,102 @@ class Context {
 }
 
 export const context = new Context();
+
+/**
+ * Flag to track if current data is demo data.
+ */
+export const isDemo = writable<boolean>(false);
+
+/**
+ * Save the current session to sessionStorage.
+ * Call this after paste flow completes.
+ */
+export function saveSession(demo: boolean = false): void {
+  if (!browser) return;
+
+  const session: SerializedSession = {
+    recipient: context.recipient ? context.recipient.serialize() : null,
+    spouse: context.spouse ? context.spouse.serialize() : null,
+    isDemo: demo,
+    version: SESSION_VERSION,
+  };
+
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+    isDemo.set(demo);
+  } catch (e) {
+    console.error('Failed to save session:', e);
+  }
+}
+
+/**
+ * Restore session from sessionStorage.
+ * Returns true if a session was restored, false otherwise.
+ */
+export function restoreSession(): boolean {
+  if (!browser) return false;
+
+  try {
+    const stored = sessionStorage.getItem(SESSION_KEY);
+    if (!stored) return false;
+
+    const session: SerializedSession = JSON.parse(stored);
+    if (session.version !== SESSION_VERSION) {
+      // Incompatible version, clear and return
+      clearSession();
+      return false;
+    }
+
+    if (session.recipient) {
+      context.recipient = Recipient.deserialize(session.recipient);
+      if (session.spouse) {
+        context.recipient.markFirst();
+      }
+    }
+
+    if (session.spouse) {
+      context.spouse = Recipient.deserialize(session.spouse);
+      context.spouse.markSecond();
+    }
+
+    isDemo.set(session.isDemo);
+    return context.recipient !== null;
+  } catch (e) {
+    console.error('Failed to restore session:', e);
+    clearSession();
+    return false;
+  }
+}
+
+/**
+ * Clear the session from sessionStorage.
+ */
+export function clearSession(): void {
+  if (!browser) return;
+
+  try {
+    sessionStorage.removeItem(SESSION_KEY);
+  } catch (e) {
+    console.error('Failed to clear session:', e);
+  }
+
+  context.recipient = null;
+  context.spouse = null;
+  isDemo.set(false);
+}
+
+/**
+ * Check if a session exists in sessionStorage.
+ */
+export function hasSession(): boolean {
+  if (!browser) return false;
+
+  try {
+    return sessionStorage.getItem(SESSION_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
 
 // The filing date sliders track themselves to see if they are currently
 // visible and stuck to the top of the screen. This is used to determine

--- a/src/lib/earning-record.ts
+++ b/src/lib/earning-record.ts
@@ -144,6 +144,31 @@ export class EarningRecord {
     const factor: number = this.indexFactor();
     return cappedEarning.times(factor);
   }
+
+  /**
+   * Serializes this record to a plain object for storage.
+   */
+  serialize(): SerializedEarningRecord {
+    return {
+      year: this.year,
+      taxedEarningsCents: this.taxedEarnings.cents(),
+      taxedMedicareEarningsCents: this.taxedMedicareEarnings.cents(),
+      incomplete: this.incomplete,
+    };
+  }
+
+  /**
+   * Deserializes a plain object back to an EarningRecord.
+   */
+  static deserialize(data: SerializedEarningRecord): EarningRecord {
+    const record = new EarningRecord({
+      year: data.year,
+      taxedEarnings: Money.fromCents(data.taxedEarningsCents),
+      taxedMedicareEarnings: Money.fromCents(data.taxedMedicareEarningsCents),
+    });
+    record.incomplete = data.incomplete;
+    return record;
+  }
 }
 
 /**
@@ -153,4 +178,14 @@ interface EarningRecordInput {
   year: number;
   taxedEarnings: Money;
   taxedMedicareEarnings: Money;
+}
+
+/**
+ * Serialized format for session storage.
+ */
+export interface SerializedEarningRecord {
+  year: number;
+  taxedEarningsCents: number;
+  taxedMedicareEarningsCents: number;
+  incomplete: boolean;
 }

--- a/src/test/birthday.test.ts
+++ b/src/test/birthday.test.ts
@@ -131,3 +131,48 @@ describe('currentAge', () => {
     expect(bd.currentAge(asOf)).toBe(25);
   });
 });
+
+describe('Birthdate serialization', () => {
+  it('serializes to plain object', () => {
+    const bd = Birthdate.FromYMD(1965, 5, 15); // Jun 15, 1965
+
+    const serialized = bd.serialize();
+
+    expect(serialized).toEqual({
+      year: 1965,
+      month: 5,
+      day: 15,
+    });
+  });
+
+  it('deserializes back to Birthdate', () => {
+    const serialized = { year: 1965, month: 5, day: 15 };
+
+    const bd = Birthdate.deserialize(serialized);
+
+    expect(bd.layBirthYear()).toBe(1965);
+    expect(bd.layBirthMonth()).toBe(5);
+    expect(bd.layBirthDayOfMonth()).toBe(15);
+  });
+
+  it('round-trips correctly', () => {
+    const original = Birthdate.FromYMD(1980, 11, 25); // Dec 25, 1980
+
+    const roundTripped = Birthdate.deserialize(original.serialize());
+
+    expect(roundTripped.layBirthYear()).toBe(original.layBirthYear());
+    expect(roundTripped.layBirthMonth()).toBe(original.layBirthMonth());
+    expect(roundTripped.layBirthDayOfMonth()).toBe(
+      original.layBirthDayOfMonth()
+    );
+  });
+
+  it('preserves SSA date calculations after round-trip', () => {
+    const original = Birthdate.FromYMD(2000, 0, 1); // Jan 1, 2000
+
+    const roundTripped = Birthdate.deserialize(original.serialize());
+
+    expect(roundTripped.ssaBirthYear()).toBe(original.ssaBirthYear());
+    expect(roundTripped.ssaBirthMonth()).toBe(original.ssaBirthMonth());
+  });
+});

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the context module and session persistence.
+ */
+
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Birthdate } from '$lib/birthday';
+import { EarningRecord } from '$lib/earning-record';
+import { Money } from '$lib/money';
+import { Recipient } from '$lib/recipient';
+
+// Mock sessionStorage
+const mockSessionStorage: Record<string, string> = {};
+const sessionStorageMock = {
+  getItem: vi.fn((key: string) => mockSessionStorage[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete mockSessionStorage[key];
+  }),
+  clear: vi.fn(() => {
+    for (const key in mockSessionStorage) {
+      delete mockSessionStorage[key];
+    }
+  }),
+};
+
+// Mock $app/environment
+vi.mock('$app/environment', () => ({
+  browser: true,
+}));
+
+// Set up sessionStorage mock globally
+vi.stubGlobal('sessionStorage', sessionStorageMock);
+
+// Import after mocking
+import {
+  clearSession,
+  context,
+  hasSession,
+  isDemo,
+  restoreSession,
+  saveSession,
+} from '$lib/context';
+
+describe('Context session management', () => {
+  beforeEach(() => {
+    // Clear mocks and storage before each test
+    vi.clearAllMocks();
+    sessionStorageMock.clear();
+
+    // Reset context state
+    context.recipient = null;
+    context.spouse = null;
+    isDemo.set(false);
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    context.recipient = null;
+    context.spouse = null;
+  });
+
+  describe('saveSession', () => {
+    it('saves recipient to sessionStorage', () => {
+      const r = new Recipient();
+      r.birthdate = Birthdate.FromYMD(1965, 6, 15);
+      r.name = 'Test User';
+      r.earningsRecords = [
+        new EarningRecord({
+          year: 2020,
+          taxedEarnings: Money.from(50000),
+          taxedMedicareEarnings: Money.from(50000),
+        }),
+      ];
+      context.recipient = r;
+
+      saveSession();
+
+      expect(sessionStorageMock.setItem).toHaveBeenCalledTimes(1);
+      const savedData = JSON.parse(sessionStorageMock.setItem.mock.calls[0][1]);
+      expect(savedData.recipient).not.toBeNull();
+      expect(savedData.recipient.name).toBe('Test User');
+      expect(savedData.spouse).toBeNull();
+      expect(savedData.isDemo).toBe(false);
+      expect(savedData.version).toBe(1);
+    });
+
+    it('saves both recipient and spouse', () => {
+      const r = new Recipient();
+      r.birthdate = Birthdate.FromYMD(1965, 6, 15);
+      r.name = 'Person 1';
+      r.markFirst();
+
+      const s = new Recipient();
+      s.birthdate = Birthdate.FromYMD(1967, 3, 20);
+      s.name = 'Person 2';
+      s.markSecond();
+
+      context.recipient = r;
+      context.spouse = s;
+
+      saveSession();
+
+      const savedData = JSON.parse(sessionStorageMock.setItem.mock.calls[0][1]);
+      expect(savedData.recipient.name).toBe('Person 1');
+      expect(savedData.spouse.name).toBe('Person 2');
+    });
+
+    it('sets isDemo flag when saving demo data', () => {
+      const r = new Recipient();
+      r.birthdate = Birthdate.FromYMD(1965, 0, 1);
+      context.recipient = r;
+
+      saveSession(true);
+
+      const savedData = JSON.parse(sessionStorageMock.setItem.mock.calls[0][1]);
+      expect(savedData.isDemo).toBe(true);
+      expect(get(isDemo)).toBe(true);
+    });
+
+    it('saves null when no recipient exists', () => {
+      saveSession();
+
+      const savedData = JSON.parse(sessionStorageMock.setItem.mock.calls[0][1]);
+      expect(savedData.recipient).toBeNull();
+      expect(savedData.spouse).toBeNull();
+    });
+  });
+
+  describe('restoreSession', () => {
+    it('restores recipient from sessionStorage', () => {
+      const sessionData = {
+        recipient: {
+          birthdate: { year: 1965, month: 6, day: 15 },
+          name: 'Restored User',
+          gender: 'female',
+          healthMultiplier: 1.0,
+          isPiaOnly: false,
+          overridePiaCents: null,
+          isFirst: true,
+          earningsRecords: [
+            {
+              year: 2020,
+              taxedEarningsCents: 5000000,
+              taxedMedicareEarningsCents: 5000000,
+              incomplete: false,
+            },
+          ],
+        },
+        spouse: null,
+        isDemo: false,
+        version: 1,
+      };
+      mockSessionStorage['ssa-tools-session'] = JSON.stringify(sessionData);
+
+      const result = restoreSession();
+
+      expect(result).toBe(true);
+      expect(context.recipient).not.toBeNull();
+      expect(context.recipient?.name).toBe('Restored User');
+      expect(context.recipient?.birthdate.layBirthYear()).toBe(1965);
+      expect(context.recipient?.earningsRecords).toHaveLength(1);
+    });
+
+    it('restores both recipient and spouse', () => {
+      const sessionData = {
+        recipient: {
+          birthdate: { year: 1965, month: 6, day: 15 },
+          name: 'Person 1',
+          gender: 'male',
+          healthMultiplier: 1.0,
+          isPiaOnly: false,
+          overridePiaCents: null,
+          isFirst: true,
+          earningsRecords: [],
+        },
+        spouse: {
+          birthdate: { year: 1967, month: 3, day: 20 },
+          name: 'Person 2',
+          gender: 'female',
+          healthMultiplier: 1.0,
+          isPiaOnly: false,
+          overridePiaCents: null,
+          isFirst: false,
+          earningsRecords: [],
+        },
+        isDemo: false,
+        version: 1,
+      };
+      mockSessionStorage['ssa-tools-session'] = JSON.stringify(sessionData);
+
+      const result = restoreSession();
+
+      expect(result).toBe(true);
+      expect(context.recipient?.name).toBe('Person 1');
+      expect(context.recipient?.first).toBe(true);
+      expect(context.spouse?.name).toBe('Person 2');
+      expect(context.spouse?.first).toBe(false);
+    });
+
+    it('restores isDemo flag', () => {
+      const sessionData = {
+        recipient: {
+          birthdate: { year: 1965, month: 0, day: 1 },
+          name: 'Demo User',
+          gender: 'blended',
+          healthMultiplier: 1.0,
+          isPiaOnly: false,
+          overridePiaCents: null,
+          isFirst: true,
+          earningsRecords: [],
+        },
+        spouse: null,
+        isDemo: true,
+        version: 1,
+      };
+      mockSessionStorage['ssa-tools-session'] = JSON.stringify(sessionData);
+
+      restoreSession();
+
+      expect(get(isDemo)).toBe(true);
+    });
+
+    it('returns false when no session exists', () => {
+      const result = restoreSession();
+
+      expect(result).toBe(false);
+      expect(context.recipient).toBeNull();
+    });
+
+    it('clears and returns false for incompatible version', () => {
+      const sessionData = {
+        recipient: {
+          birthdate: { year: 1965, month: 0, day: 1 },
+          name: 'Old Version User',
+          gender: 'blended',
+          healthMultiplier: 1.0,
+          isPiaOnly: false,
+          overridePiaCents: null,
+          isFirst: true,
+          earningsRecords: [],
+        },
+        spouse: null,
+        isDemo: false,
+        version: 999, // Invalid version
+      };
+      mockSessionStorage['ssa-tools-session'] = JSON.stringify(sessionData);
+
+      const result = restoreSession();
+
+      expect(result).toBe(false);
+      expect(sessionStorageMock.removeItem).toHaveBeenCalled();
+    });
+
+    it('handles corrupted data gracefully', () => {
+      mockSessionStorage['ssa-tools-session'] = 'not valid json';
+
+      const result = restoreSession();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearSession', () => {
+    it('removes session from storage and resets context', () => {
+      const r = new Recipient();
+      r.birthdate = Birthdate.FromYMD(1965, 0, 1);
+      context.recipient = r;
+      context.spouse = new Recipient();
+      mockSessionStorage['ssa-tools-session'] = '{}';
+
+      clearSession();
+
+      expect(sessionStorageMock.removeItem).toHaveBeenCalledWith(
+        'ssa-tools-session'
+      );
+      expect(context.recipient).toBeNull();
+      expect(context.spouse).toBeNull();
+      expect(get(isDemo)).toBe(false);
+    });
+  });
+
+  describe('hasSession', () => {
+    it('returns true when session exists', () => {
+      mockSessionStorage['ssa-tools-session'] = '{}';
+
+      expect(hasSession()).toBe(true);
+    });
+
+    it('returns false when no session exists', () => {
+      expect(hasSession()).toBe(false);
+    });
+  });
+
+  describe('round-trip integration', () => {
+    it('saves and restores a complete session', () => {
+      // Set up original data
+      const r = new Recipient();
+      r.birthdate = Birthdate.FromYMD(1970, 5, 10);
+      r.name = 'Integration Test';
+      r.gender = 'male';
+      r.healthMultiplier = 1.1;
+      r.earningsRecords = [
+        new EarningRecord({
+          year: 2015,
+          taxedEarnings: Money.from(60000),
+          taxedMedicareEarnings: Money.from(60000),
+        }),
+        new EarningRecord({
+          year: 2016,
+          taxedEarnings: Money.from(65000),
+          taxedMedicareEarnings: Money.from(65000),
+        }),
+      ];
+
+      context.recipient = r;
+      saveSession(true);
+
+      // Clear context
+      context.recipient = null;
+      isDemo.set(false);
+
+      // Restore
+      const result = restoreSession();
+
+      expect(result).toBe(true);
+      expect(context.recipient?.name).toBe('Integration Test');
+      expect(context.recipient?.birthdate.layBirthYear()).toBe(1970);
+      expect(context.recipient?.birthdate.layBirthMonth()).toBe(5);
+      expect(context.recipient?.birthdate.layBirthDayOfMonth()).toBe(10);
+      expect(context.recipient?.gender).toBe('male');
+      expect(context.recipient?.healthMultiplier).toBe(1.1);
+      expect(context.recipient?.earningsRecords).toHaveLength(2);
+      expect(get(isDemo)).toBe(true);
+    });
+
+    it('saves and restores PIA-only recipient', () => {
+      const r = new Recipient();
+      r.birthdate = Birthdate.FromYMD(1960, 0, 1);
+      r.setPia(Money.from(2500));
+      r.name = 'PIA Only Test';
+
+      context.recipient = r;
+      saveSession();
+
+      context.recipient = null;
+      restoreSession();
+
+      expect(context.recipient?.isPiaOnly).toBe(true);
+      expect(context.recipient?.overridePia?.value()).toBe(2500);
+      expect(context.recipient?.name).toBe('PIA Only Test');
+    });
+  });
+});

--- a/src/test/earning-record.test.ts
+++ b/src/test/earning-record.test.ts
@@ -99,3 +99,59 @@ describe('EarningRecord', () => {
     );
   });
 });
+
+describe('EarningRecord serialization', () => {
+  it('serializes to plain object', () => {
+    const record = new EarningRecord({
+      year: 2020,
+      taxedEarnings: Money.from(50000),
+      taxedMedicareEarnings: Money.from(55000),
+    });
+    record.incomplete = true;
+
+    const serialized = record.serialize();
+
+    expect(serialized).toEqual({
+      year: 2020,
+      taxedEarningsCents: 5000000,
+      taxedMedicareEarningsCents: 5500000,
+      incomplete: true,
+    });
+  });
+
+  it('deserializes back to EarningRecord', () => {
+    const serialized = {
+      year: 2020,
+      taxedEarningsCents: 5000000,
+      taxedMedicareEarningsCents: 5500000,
+      incomplete: true,
+    };
+
+    const record = EarningRecord.deserialize(serialized);
+
+    expect(record.year).toBe(2020);
+    expect(record.taxedEarnings.cents()).toBe(5000000);
+    expect(record.taxedMedicareEarnings.cents()).toBe(5500000);
+    expect(record.incomplete).toBe(true);
+  });
+
+  it('round-trips correctly', () => {
+    const original = new EarningRecord({
+      year: 2015,
+      taxedEarnings: Money.from(75432.5),
+      taxedMedicareEarnings: Money.from(80000),
+    });
+    original.incomplete = false;
+
+    const roundTripped = EarningRecord.deserialize(original.serialize());
+
+    expect(roundTripped.year).toBe(original.year);
+    expect(roundTripped.taxedEarnings.cents()).toBe(
+      original.taxedEarnings.cents()
+    );
+    expect(roundTripped.taxedMedicareEarnings.cents()).toBe(
+      original.taxedMedicareEarnings.cents()
+    );
+    expect(roundTripped.incomplete).toBe(original.incomplete);
+  });
+});


### PR DESCRIPTION
## Summary

- Move serialization logic into domain classes (Birthdate, EarningRecord, Recipient) with `serialize()` and `static deserialize()` methods
- Add session persistence infrastructure to `context.ts` (saveSession, restoreSession, clearSession, hasSession, isDemo store)
- Add comprehensive tests for all serialization round-trips

This enables data to persist across page navigation and reloads within a browser session, while clearing when the tab is closed (sessionStorage).

## Test plan

- [x] All 926 tests pass
- [x] New tests cover serialization round-trips for Birthdate, EarningRecord, and Recipient
- [x] New tests cover context session save/restore/clear functions
- [ ] Manual test: Complete paste flow, navigate to Guides, return to Calculator