### PR TITLE
Skip Chromatic for Dependabot and fork PRs

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -15,8 +15,11 @@ concurrency:
 jobs:
   chromatic:
     runs-on: ubuntu-latest
-    # Skip draft PRs to save snapshots
-    if: github.event.pull_request.draft != true
+    # Skip draft PRs, Dependabot PRs, and fork PRs (no access to secrets)
+    if: |
+      github.event.pull_request.draft != true &&
+      github.actor != 'dependabot[bot]' &&
+      !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Skips the Chromatic visual regression check for Dependabot PRs and PRs from forks
- These PRs don't have access to repository secrets, so Chromatic fails with "Missing project token"
- This prevents false CI failures on otherwise valid PRs

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Future Dependabot PRs should skip Chromatic instead of failing