### PR TITLE
Fix dark input fields on Mac Chrome

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,5 @@
 html {
-  color-scheme: light dark;
+  color-scheme: light;
   width: 100%;
   overflow-x: hidden;
   scrollbar-gutter: stable;


### PR DESCRIPTION
## Summary
- Change `color-scheme` from `light dark` to `light` in app.css to prevent Mac Chrome from applying dark mode styling to form inputs

## Problem
On Mac Chrome, when the system is in dark mode, certain input fields (the PIA input in "Alternative data entry" and the MM/DD/YYYY birthdate inputs) were displaying with black/dark styling, making them hard to read.

The `color-scheme: light dark` declaration was telling browsers the site supports both modes, but Mac Chrome was more aggressively applying dark mode styling to form controls than Linux Chrome.

## Test plan
- [ ] On Mac with dark mode enabled, verify the PIA input field in "Alternative data entry options" has white background
- [ ] On Mac with dark mode enabled, verify the MM/DD/YYYY birthdate inputs have white background
- [ ] On Linux/Windows, verify no visual regression in input field styling