### PR TITLE
Add year-by-year future earnings customization

### DIFF
--- a/src/lib/components/EarningsTable.svelte
+++ b/src/lib/components/EarningsTable.svelte
@@ -1,7 +1,25 @@
 <script lang="ts">
+import { createEventDispatcher } from 'svelte';
 import type { EarningRecord } from '$lib/earning-record';
 
 export let earningsRecords: Array<EarningRecord> = [];
+
+/**
+ * When true, earnings cells become editable inputs.
+ */
+export let editable: boolean = false;
+
+const dispatch = createEventDispatcher<{
+  earningsChange: { index: number; year: number; wage: number };
+}>();
+
+function handleEarningsInput(index: number, year: number, event: Event) {
+  const input = event.target as HTMLInputElement;
+  const rawValue = input.value.replace(/[^0-9]/g, '');
+  let value = parseInt(rawValue, 10);
+  if (isNaN(value)) value = 0;
+  dispatch('earningsChange', { index, year, wage: value });
+}
 </script>
 
 <div>
@@ -15,7 +33,7 @@ export let earningsRecords: Array<EarningRecord> = [];
         </tr>
       </thead>
       <tbody>
-        {#each earningsRecords as earningRecord}
+        {#each earningsRecords as earningRecord, index}
           <tr>
             <td class="workyear">{earningRecord.year}</td>
             <td class="age onlyDisplayLarge">
@@ -25,7 +43,18 @@ export let earningsRecords: Array<EarningRecord> = [];
               <td class="taxedearnings">Not yet recorded </td>
             {:else}
               <td class="taxedearnings">
-                {earningRecord.taxedEarnings.wholeDollars()}
+                {#if editable}
+                  <input
+                    type="text"
+                    inputmode="numeric"
+                    class="earnings-input"
+                    value={earningRecord.taxedEarnings.value().toLocaleString()}
+                    on:change={(e) => handleEarningsInput(index, earningRecord.year, e)}
+                    on:focus={(e) => e.currentTarget.select()}
+                  />
+                {:else}
+                  {earningRecord.taxedEarnings.wholeDollars()}
+                {/if}
               </td>
             {/if}
           </tr>
@@ -70,5 +99,19 @@ export let earningsRecords: Array<EarningRecord> = [];
   }
   td.taxedearnings {
     padding-right: 8px;
+  }
+  .earnings-input {
+    width: 80px;
+    padding: 2px 6px;
+    border: 1px solid #a8c7f5;
+    border-radius: 3px;
+    font-size: 14px;
+    text-align: right;
+    background: #fff;
+  }
+  .earnings-input:focus {
+    outline: none;
+    border-color: #4a90d9;
+    box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.2);
   }
 </style>

--- a/src/lib/components/IndexedEarningsTable.svelte
+++ b/src/lib/components/IndexedEarningsTable.svelte
@@ -1,46 +1,46 @@
 <script lang="ts">
-import { Recipient } from '$lib/recipient';
+  import { Recipient } from "$lib/recipient";
 
-export let recipient: Recipient = new Recipient();
+  export let recipient: Recipient = new Recipient();
 
-function countAllRecords(recipient: Recipient): number {
-  return (
-    recipient.earningsRecords.length + recipient.futureEarningsRecords.length
-  );
-}
-let totalRecords: number = 0;
-$: totalRecords = countAllRecords($recipient);
+  function countAllRecords(recipient: Recipient): number {
+    return (
+      recipient.earningsRecords.length + recipient.futureEarningsRecords.length
+    );
+  }
+  let totalRecords: number = 0;
+  $: totalRecords = countAllRecords($recipient);
 
-// If there is an incomplete record in the earnigns record, we should show it
-// only if there isn't a matching year in the future earnings records.
-function decideShowIncompleteRecords(recipient: Recipient): boolean {
-  let incompleteYear: number | undefined;
-  for (const record of recipient.earningsRecords) {
-    if (record.incomplete) {
-      incompleteYear = record.year;
-      break;
+  // If there is an incomplete record in the earnigns record, we should show it
+  // only if there isn't a matching year in the future earnings records.
+  function decideShowIncompleteRecords(recipient: Recipient): boolean {
+    let incompleteYear: number | undefined;
+    for (const record of recipient.earningsRecords) {
+      if (record.incomplete) {
+        incompleteYear = record.year;
+        break;
+      }
     }
-  }
-  if (incompleteYear === undefined) {
-    // If there is no incomplete year, it doesn't matter what the response is.
-    return false;
-  }
-  for (const record of recipient.futureEarningsRecords) {
-    if (record.year === incompleteYear) {
+    if (incompleteYear === undefined) {
+      // If there is no incomplete year, it doesn't matter what the response is.
       return false;
     }
+    for (const record of recipient.futureEarningsRecords) {
+      if (record.year === incompleteYear) {
+        return false;
+      }
+    }
+    return true;
   }
-  return true;
-}
-let showIncompleteRecords: boolean = true;
-$: showIncompleteRecords = decideShowIncompleteRecords($recipient);
+  let showIncompleteRecords: boolean = true;
+  $: showIncompleteRecords = decideShowIncompleteRecords($recipient);
 
-function twoSignificantDigits(n: number) {
-  return n.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-}
+  function twoSignificantDigits(n: number) {
+    return n.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  }
 </script>
 
 <div>

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -127,6 +127,10 @@ export function hasSession(): boolean {
 export const isFirstStuck = writable<boolean>(false);
 export const isSecondStuck = writable<boolean>(false);
 
+// Track whether future earnings are being edited (custom mode) for each recipient
+export const firstFutureEarningsEditable = writable<boolean>(false);
+export const secondFutureEarningsEditable = writable<boolean>(false);
+
 // Derived store for overall stuck state
 export const isStuck = derived(
   [isFirstStuck, isSecondStuck],


### PR DESCRIPTION
## Summary

Implements the feature request from #19 - allows users to customize future earnings projections year by year.

- Adds an "Edit" toggle next to the future earnings sliders
- When enabled, future earnings table becomes directly editable
- Years slider still works in custom mode (adds/removes years from end)
- Wage slider is disabled in custom mode (edit table instead)
- Values are automatically capped at the Social Security maximum for each year
- Inline confirmation when reverting to slider mode (replaces browser alert dialog)

## Test plan

- [ ] Verify sliders work normally when Edit toggle is off
- [ ] Enable Edit toggle and verify table becomes editable
- [ ] Edit individual year values and verify they persist
- [ ] Enter a value above the SS cap and verify it's capped
- [ ] Use years slider in custom mode to add/remove years
- [ ] Disable Edit toggle and confirm inline revert prompt works
- [ ] Verify cap note appears below table only in edit mode
- [ ] Test print view hides edit controls

Closes #19