### PR TITLE
Fix combined chart crash with large age gaps and $0 PIA

### DIFF
--- a/src/lib/components/CombinedChart.svelte
+++ b/src/lib/components/CombinedChart.svelte
@@ -669,11 +669,17 @@
     // If one of the users has a zero PIA, we don't allow them to file before
     // the other user:
     if (ctx0.r.pia().primaryInsuranceAmount().value() === 0) {
-      ctx0.userFloor = ctx0.r.birthdate
-        .ageAtSsaDate(
-          ctx1.r.birthdate.dateAtSsaAge(new MonthDuration(ctx1.sliderMonths))
-        )
-        .asMonths();
+      // Calculate when the spouse files, but never allow filing before age 62
+      // (the legal minimum). With large age gaps, the spouse may file before
+      // this person turns 62.
+      ctx0.userFloor = Math.max(
+        62 * 12,
+        ctx0.r.birthdate
+          .ageAtSsaDate(
+            ctx1.r.birthdate.dateAtSsaAge(new MonthDuration(ctx1.sliderMonths))
+          )
+          .asMonths()
+      );
       // Similarly min cap the actual slider value:
       if (ctx0.sliderMonths < ctx0.userFloor) {
         ctx0.sliderMonths = ctx0.userFloor;


### PR DESCRIPTION
## Summary

- Fixes crash when entering two users with a large age gap where one has $0 PIA
- Example: User A born 10/10/1982 with $1000 PIA, User B born 10/10/1992 with $0 PIA
- The chart would crash with "Filing age must be at least 62, got 57y 0m"

## Root Cause

The `minCapSlider` function calculates the minimum filing age for someone with $0 PIA based on when their spouse files (since they only get spousal benefits). However, it didn't enforce the legal minimum of 62 years.

With a 10-year age gap, when the older person's slider is at age 67, the younger person would only be 57 at that date - below the minimum filing age.

## Fix

Ensure `userFloor` is never less than 62 years (744 months) by wrapping the calculation in `Math.max(62 * 12, ...)`.

## Test plan

- [x] Type checking passes (`npm run check`)
- [x] All 936 tests pass (`npm test`)
- [ ] Manual test: Enter User A born 10/10/1982 with $1000 PIA, User B born 10/10/1992 with $0 PIA - chart should render without crashing