### PR TITLE
refactor: replace createEventDispatcher with callback props

### DIFF
--- a/src/lib/components/EarningsReport.svelte
+++ b/src/lib/components/EarningsReport.svelte
@@ -17,10 +17,12 @@ $: editable = $recipient.first
   ? $firstFutureEarningsEditable
   : $secondFutureEarningsEditable;
 
-function handleEarningsChange(
-  event: CustomEvent<{ index: number; year: number; wage: number }>
-) {
-  const { index, wage } = event.detail;
+function handleEarningsChange(detail: {
+  index: number;
+  year: number;
+  wage: number;
+}) {
+  const { index, wage } = detail;
   // Build new records from existing, with the changed value
   const records = $recipient.futureEarningsRecords.map((r, i) => ({
     year: r.year,
@@ -97,7 +99,7 @@ $: priorYear = constants.CURRENT_YEAR - 1;
   <EarningsTable
     earningsRecords={$recipient.futureEarningsRecords}
     {editable}
-    on:earningsChange={handleEarningsChange}
+    onearningschange={handleEarningsChange}
   />
   {#if editable}
     <p class="cap-note noprint">

--- a/src/lib/components/EarningsTable.svelte
+++ b/src/lib/components/EarningsTable.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
 import type { EarningRecord } from '$lib/earning-record';
 
 export let earningsRecords: ReadonlyArray<EarningRecord> = [];
@@ -9,16 +8,16 @@ export let earningsRecords: ReadonlyArray<EarningRecord> = [];
  */
 export let editable: boolean = false;
 
-const dispatch = createEventDispatcher<{
-  earningsChange: { index: number; year: number; wage: number };
-}>();
+export let onearningschange:
+  | ((detail: { index: number; year: number; wage: number }) => void)
+  | undefined = undefined;
 
 function handleEarningsInput(index: number, year: number, event: Event) {
   const input = event.target as HTMLInputElement;
   const rawValue = input.value.replace(/[^0-9]/g, '');
   let value = parseInt(rawValue, 10);
   if (isNaN(value)) value = 0;
-  dispatch('earningsChange', { index, year, wage: value });
+  onearningschange?.({ index, year, wage: value });
 }
 </script>
 

--- a/src/lib/strategy/ui/calculation-results.ts
+++ b/src/lib/strategy/ui/calculation-results.ts
@@ -1,6 +1,23 @@
 import type { Money } from '$lib/money';
-import type { MonthDuration } from '$lib/month-time';
+import type { MonthDate, MonthDuration } from '$lib/month-time';
 import type { DeathAgeBucket } from './grid-sizing.js';
+
+export interface CellPosition {
+  rowIndex: number;
+  colIndex: number;
+}
+
+export interface CellSelectionDetail {
+  deathAge1: string;
+  deathAge2: string;
+  filingAge1Years: number;
+  filingAge1Months: number;
+  filingDate1: MonthDate;
+  filingAge2Years: number;
+  filingAge2Months: number;
+  filingDate2: MonthDate;
+  netPresentValue: Money;
+}
 
 export interface StrategyResult {
   deathAge1: string;

--- a/src/lib/strategy/ui/index.ts
+++ b/src/lib/strategy/ui/index.ts
@@ -1,6 +1,10 @@
 // UI utility functions
 
-export type { StrategyResult } from './calculation-results.js';
+export type {
+  CellPosition,
+  CellSelectionDetail,
+  StrategyResult,
+} from './calculation-results.js';
 export {
   CalculationResults,
   CalculationStatus,

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -11,6 +11,7 @@
   import {
     CalculationResults,
     CalculationStatus,
+    type CellSelectionDetail,
     type DeathAgeBucket,
     generateMonthlyBuckets,
     generateThreeYearBuckets,
@@ -269,7 +270,7 @@
       }
     }
   }
-  function handleCellSelect(detail: any) {
+  function handleCellSelect(detail: CellSelectionDetail) {
     calculationResults.setSelectedByLabels(
       String(detail.deathAge1),
       String(detail.deathAge2)

--- a/src/routes/strategy/components/StrategyCell.svelte
+++ b/src/routes/strategy/components/StrategyCell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import RecipientName from '$lib/components/RecipientName.svelte';
 import type { Recipient } from '$lib/recipient';
+import type { CellPosition } from '$lib/strategy/ui';
 import { getFilingAge, getFilingDate } from '$lib/strategy/ui';
 
 // Props
@@ -10,20 +11,18 @@ export let calculationResult: any;
 export let displayAsAges: boolean;
 export let recipients: [Recipient, Recipient];
 export let recipientIndex: number;
-export let hoveredCell: { rowIndex: number; colIndex: number } | null;
+export let hoveredCell: CellPosition | null;
 export let isSelected: boolean = false;
 export let cellWidth: number = 0;
 export let cellHeight: number = 0;
 export let cellStyle: string = '';
 
 // Callback props
-export let onhover:
-  | ((detail: { rowIndex: number; colIndex: number }) => void)
-  | undefined = undefined;
+export let onhover: ((position: CellPosition) => void) | undefined =
+  undefined;
 export let onhoverout: (() => void) | undefined = undefined;
-export let onselect:
-  | ((detail: { rowIndex: number; colIndex: number }) => void)
-  | undefined = undefined;
+export let onselect: ((position: CellPosition) => void) | undefined =
+  undefined;
 
 // Cell hover overlay state
 let cellHoverInfo: {

--- a/src/routes/strategy/components/StrategyCell.svelte
+++ b/src/routes/strategy/components/StrategyCell.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
 import RecipientName from '$lib/components/RecipientName.svelte';
 import type { Recipient } from '$lib/recipient';
 import { getFilingAge, getFilingDate } from '$lib/strategy/ui';
@@ -17,7 +16,14 @@ export let cellWidth: number = 0;
 export let cellHeight: number = 0;
 export let cellStyle: string = '';
 
-const dispatch = createEventDispatcher();
+// Callback props
+export let onhover:
+  | ((detail: { rowIndex: number; colIndex: number }) => void)
+  | undefined = undefined;
+export let onhoverout: (() => void) | undefined = undefined;
+export let onselect:
+  | ((detail: { rowIndex: number; colIndex: number }) => void)
+  | undefined = undefined;
 
 // Cell hover overlay state
 let cellHoverInfo: {
@@ -47,7 +53,7 @@ $: isHighlightedRow =
 
 // Handle events
 function handleMouseOver(event: MouseEvent) {
-  dispatch('hover', { rowIndex, colIndex });
+  onhover?.({ rowIndex, colIndex });
 
   if (calculationResult) {
     // Calculate filing dates for both recipients
@@ -75,20 +81,20 @@ function handleMouseOver(event: MouseEvent) {
 }
 
 function handleFocus() {
-  dispatch('hover', { rowIndex, colIndex });
+  onhover?.({ rowIndex, colIndex });
 }
 
 function handleMouseOut() {
-  dispatch('hoverout');
+  onhoverout?.();
   cellHoverInfo = null;
 }
 
 function handleBlur() {
-  dispatch('hoverout');
+  onhoverout?.();
 }
 
 function handleClick() {
-  dispatch('select', { rowIndex, colIndex });
+  onselect?.({ rowIndex, colIndex });
 }
 
 function handleKeydown(e: KeyboardEvent) {

--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -232,9 +232,11 @@ function getCellStyle(i: number, j: number): string {
 }
 
 // Handle events
-function handleCellHover(event) {
-  const { rowIndex, colIndex } = event.detail;
-  onhovercell?.({ rowIndex, colIndex });
+function handleCellHover(detail: {
+  rowIndex: number;
+  colIndex: number;
+}) {
+  onhovercell?.(detail);
 }
 
 function handleCellHoverOut() {
@@ -265,8 +267,11 @@ function handleHeaderHoverOut() {
   headerHoverInfo = null;
 }
 
-function handleCellSelect(event) {
-  const { rowIndex, colIndex } = event.detail;
+function handleCellSelect(detail: {
+  rowIndex: number;
+  colIndex: number;
+}) {
+  const { rowIndex, colIndex } = detail;
   const result = calculationResults.get(
     rowIndex,
     colIndex
@@ -421,9 +426,9 @@ function handleCellSelect(event) {
               cellWidth={cellDimensions[i]?.[j]?.width || 0}
               cellHeight={cellDimensions[i]?.[j]?.height || 0}
               cellStyle={getCellStyle(i, j)}
-              on:hover={handleCellHover}
-              on:hoverout={handleCellHoverOut}
-              on:select={handleCellSelect}
+              onhover={handleCellHover}
+              onhoverout={handleCellHoverOut}
+              onselect={handleCellSelect}
             />
           {/each}
         {/each}

--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -3,7 +3,12 @@ import RecipientName from '$lib/components/RecipientName.svelte';
 import type { Money } from '$lib/money';
 import { MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
-import type { CalculationResults, DeathAgeBucket } from '$lib/strategy/ui';
+import type {
+  CalculationResults,
+  CellPosition,
+  CellSelectionDetail,
+  DeathAgeBucket,
+} from '$lib/strategy/ui';
 import {
   createBorderRemovalFunctions,
   getMonthYearColor,
@@ -17,13 +22,15 @@ export let displayAsAges: boolean = false;
 export let calculationResults: CalculationResults;
 export let deathProbDistribution1: { age: number; probability: number }[];
 export let deathProbDistribution2: { age: number; probability: number }[];
-export let hoveredCell: { rowIndex: number; colIndex: number } | null = null;
+export let hoveredCell: CellPosition | null = null;
 
 // Callback props for events
 export let onhovercell:
-  | ((detail: { rowIndex: number; colIndex: number } | null) => void)
+  | ((detail: CellPosition | null) => void)
   | undefined = undefined;
-export let onselectcell: ((detail: any) => void) | undefined = undefined;
+export let onselectcell:
+  | ((detail: CellSelectionDetail) => void)
+  | undefined = undefined;
 
 // Matrix width tracking
 let matrixWidth: number = 0;
@@ -232,11 +239,8 @@ function getCellStyle(i: number, j: number): string {
 }
 
 // Handle events
-function handleCellHover(detail: {
-  rowIndex: number;
-  colIndex: number;
-}) {
-  onhovercell?.(detail);
+function handleCellHover(position: CellPosition) {
+  onhovercell?.(position);
 }
 
 function handleCellHoverOut() {
@@ -267,11 +271,8 @@ function handleHeaderHoverOut() {
   headerHoverInfo = null;
 }
 
-function handleCellSelect(detail: {
-  rowIndex: number;
-  colIndex: number;
-}) {
-  const { rowIndex, colIndex } = detail;
+function handleCellSelect(position: CellPosition) {
+  const { rowIndex, colIndex } = position;
   const result = calculationResults.get(
     rowIndex,
     colIndex

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import type { Recipient } from '$lib/recipient';
-import type { CalculationResults } from '$lib/strategy/ui';
+import type {
+  CalculationResults,
+  CellPosition,
+  CellSelectionDetail,
+} from '$lib/strategy/ui';
 import { CalculationStatus } from '$lib/strategy/ui';
 import StrategyMatrix from './StrategyMatrix.svelte';
 
@@ -9,19 +13,19 @@ export let recipients: [Recipient, Recipient];
 export let displayAsAges: boolean;
 
 // Callback props for events
-export let onselectcell: ((detail: any) => void) | undefined = undefined;
+export let onselectcell:
+  | ((detail: CellSelectionDetail) => void)
+  | undefined = undefined;
 export let calculationResults: CalculationResults;
 export let deathProbDistribution1: { age: number; probability: number }[];
 export let deathProbDistribution2: { age: number; probability: number }[];
 
 // Shared state for matrix hovering
-let hoveredCell: { rowIndex: number; colIndex: number } | null = null;
+let hoveredCell: CellPosition | null = null;
 
 // Handle hover cell events from child components
-function handleHoverCell(
-  detail: { rowIndex: number; colIndex: number } | null
-) {
-  hoveredCell = detail; // detail will be null or { rowIndex, colIndex }
+function handleHoverCell(detail: CellPosition | null) {
+  hoveredCell = detail;
 }
 </script>
 
@@ -66,7 +70,7 @@ function handleHoverCell(
           {hoveredCell}
           {displayAsAges}
           onhovercell={handleHoverCell}
-          onselectcell={(detail) => onselectcell?.(detail)}
+          {onselectcell}
         />
       {/each}
     </div>


### PR DESCRIPTION
## Summary
- Replaced `createEventDispatcher` with callback props in **EarningsTable** and **StrategyCell**, the last two components using the Svelte event dispatcher pattern
- Updated consumers (**EarningsReport**, **StrategyMatrix**) to pass callbacks via props and receive detail objects directly instead of unwrapping `event.detail`
- Standardizes the codebase on a single communication pattern (callback props) for parent-child component interaction

## Test plan
- [x] `npm run quality` passes (zero lint/type errors)
- [x] All 986 tests pass including StrategyCell and StrategyMatrix test suites
- [x] No `createEventDispatcher` imports remain in the codebase
- [ ] Manual verification: strategy matrix cell hover/select interactions work correctly
- [ ] Manual verification: future earnings table editing works correctly