### PR TITLE
refactor: improve CellPosition and CellSelectionDetail types

### DIFF
--- a/src/lib/strategy/ui/calculation-results.ts
+++ b/src/lib/strategy/ui/calculation-results.ts
@@ -2,21 +2,14 @@ import type { Money } from '$lib/money';
 import type { MonthDate, MonthDuration } from '$lib/month-time';
 import type { DeathAgeBucket } from './grid-sizing.js';
 
-export interface CellPosition {
-  rowIndex: number;
-  colIndex: number;
-}
-
 export interface CellSelectionDetail {
-  deathAge1: string;
-  deathAge2: string;
-  filingAge1Years: number;
-  filingAge1Months: number;
-  filingDate1: MonthDate;
-  filingAge2Years: number;
-  filingAge2Months: number;
-  filingDate2: MonthDate;
-  netPresentValue: Money;
+  readonly deathAge1: string;
+  readonly deathAge2: string;
+  readonly filingAge1: MonthDuration;
+  readonly filingDate1: MonthDate;
+  readonly filingAge2: MonthDuration;
+  readonly filingDate2: MonthDate;
+  readonly netPresentValue: Money;
 }
 
 export interface StrategyResult {

--- a/src/lib/strategy/ui/grid-sizing.ts
+++ b/src/lib/strategy/ui/grid-sizing.ts
@@ -125,6 +125,11 @@ export function generateDeathAgeRange(deathAgeRangeStart: number): number[] {
 
 import { MonthDuration } from '$lib/month-time';
 
+export interface CellPosition {
+  readonly rowIndex: number;
+  readonly colIndex: number;
+}
+
 export interface DeathAgeBucket {
   label: string; // Display label (e.g. '63', '66', '101+')
   // Representative age (middle year for 3-year buckets, or start for + bucket)

--- a/src/lib/strategy/ui/index.ts
+++ b/src/lib/strategy/ui/index.ts
@@ -1,7 +1,6 @@
 // UI utility functions
 
 export type {
-  CellPosition,
   CellSelectionDetail,
   StrategyResult,
 } from './calculation-results.js';
@@ -19,7 +18,7 @@ export {
   getFilingDate,
   parseBirthdate,
 } from './formatting.js';
-export type { DeathAgeBucket } from './grid-sizing.js';
+export type { CellPosition, DeathAgeBucket } from './grid-sizing.js';
 export {
   calculateAgeRangePercentages,
   calculateGridTemplates,

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -272,8 +272,8 @@
   }
   function handleCellSelect(detail: CellSelectionDetail) {
     calculationResults.setSelectedByLabels(
-      String(detail.deathAge1),
-      String(detail.deathAge2)
+      detail.deathAge1,
+      detail.deathAge2
     );
     calculationResultsStore.set(calculationResults);
   }

--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -284,28 +284,16 @@ function handleCellSelect(position: CellPosition) {
   // Set selection on the shared CalculationResults state
   calculationResults.setSelectedCell(rowIndex, colIndex);
 
-  const {
-    filingAge1,
-    filingAge2,
-    filingAge1Years,
-    filingAge1Months,
-    filingAge2Years,
-    filingAge2Months,
-    totalBenefit,
-  } = result;
-  const filingDate1 = recipients[0].birthdate.dateAtLayAge(filingAge1);
-  const filingDate2 = recipients[1].birthdate.dateAtLayAge(filingAge2);
+  const { filingAge1, filingAge2, totalBenefit } = result;
 
   // Emit a normalized details payload for external consumers (e.g., details panel)
   onselectcell?.({
     deathAge1: bucket1.label,
     deathAge2: bucket2.label,
-    filingAge1Years,
-    filingAge1Months,
-    filingDate1,
-    filingAge2Years,
-    filingAge2Months,
-    filingDate2,
+    filingAge1,
+    filingDate1: recipients[0].birthdate.dateAtLayAge(filingAge1),
+    filingAge2,
+    filingDate2: recipients[1].birthdate.dateAtLayAge(filingAge2),
     netPresentValue: totalBenefit,
   });
 }


### PR DESCRIPTION
## Summary
Follow-up to #513. Addresses review suggestions for the newly introduced types:

- Add `readonly` to all fields in `CellPosition` and `CellSelectionDetail` to prevent accidental mutation
- Replace four decomposed age fields (`filingAge1Years`, `filingAge1Months`, etc.) with two `MonthDuration` fields, aligning with the codebase convention of using domain types
- Move `CellPosition` from `calculation-results.ts` to `grid-sizing.ts` alongside `DeathAgeBucket` (both are grid-structure concerns)
- Remove redundant `String()` wrapping in `+page.svelte` now that `deathAge1`/`deathAge2` are typed as `string`

Net result: -15 lines, stronger types, better file organization.

## Test plan
- [x] `npm run quality` passes (zero lint/type errors)
- [x] All 986 tests pass
- [ ] Manual verification: strategy matrix cell selection still works