### PR TITLE
refactor: decouple PIA from full Recipient interface

### DIFF
--- a/src/lib/pia.ts
+++ b/src/lib/pia.ts
@@ -1,6 +1,19 @@
+import type { Birthdate } from './birthday';
 import * as constants from './constants';
 import { Money } from './money';
-import type { Recipient } from './recipient';
+
+/**
+ * The subset of recipient data needed for PIA calculation.
+ * Recipient implements this interface, but tests can pass a plain object.
+ */
+export interface PiaInput {
+  isPiaOnly: boolean;
+  overridePia: Money | null;
+  indexingYear(): number;
+  birthdate: Birthdate;
+  monthlyIndexedEarnings(): Money;
+  isEligible(): boolean;
+}
 
 /**
  * A PrimaryInsuranceAmount object manages calculating the user's Primary
@@ -17,15 +30,10 @@ import type { Recipient } from './recipient';
  *   have been applied to benefits
  */
 export class PrimaryInsuranceAmount {
-  /**
-   * The recipient for whom the PIA is being calculated.
-   * Contains all the personal information and earnings history needed for PIA.
-   * @private
-   */
-  private recipient_: Recipient;
+  private input_: PiaInput;
 
-  constructor(recipient: Recipient) {
-    this.recipient_ = recipient;
+  constructor(input: PiaInput) {
+    this.input_ = input;
   }
 
   /**
@@ -41,7 +49,7 @@ export class PrimaryInsuranceAmount {
     // If the indexing year is beyond the WAGE_INDICES data range, use the
     // maximum year in the data range.
     const effectiveIndexingYear = Math.min(
-      this.recipient_.indexingYear(),
+      this.input_.indexingYear(),
       constants.MAX_WAGE_INDEX_YEAR
     );
     const wage_in_1977: Money = constants.WAGE_INDICES[1977];
@@ -91,15 +99,15 @@ export class PrimaryInsuranceAmount {
     if (bracket !== 0 && bracket !== 1 && bracket !== 2) {
       throw new Error(`Invalid bracket: ${bracket}`);
     }
-    if (this.recipient_.isPiaOnly) {
+    if (this.input_.isPiaOnly) {
       throw new Error('Cannot calculate PIA brackets for PIA-only recipient');
     }
     // If the recipient is not eligible for benefits, return $0.
-    if (!this.recipient_.isEligible()) {
+    if (!this.input_.isEligible()) {
       return Money.from(0);
     }
 
-    const aime = this.recipient_.monthlyIndexedEarnings().roundToDollar();
+    const aime = this.input_.monthlyIndexedEarnings().roundToDollar();
     const firstBend = this.firstBendPoint();
     const secondBend = this.secondBendPoint();
 
@@ -129,7 +137,7 @@ export class PrimaryInsuranceAmount {
    * @throws {Error} If recipient is PIA-only
    */
   primaryInsuranceAmountUnadjusted(): Money {
-    if (this.recipient_.isPiaOnly) {
+    if (this.input_.isPiaOnly) {
       throw new Error('Cannot calculate unadjusted PIA for PIA-only recipient');
     }
     let sum = Money.from(0);
@@ -150,8 +158,8 @@ export class PrimaryInsuranceAmount {
    * @returns {Money} The final PIA amount after all applicable COLA adjustments
    */
   primaryInsuranceAmount(): Money {
-    if (this.recipient_.isPiaOnly) {
-      return this.recipient_.overridePia;
+    if (this.input_.isPiaOnly) {
+      return this.input_.overridePia;
     }
 
     const pia = this.primaryInsuranceAmountUnadjusted();
@@ -218,7 +226,7 @@ export class PrimaryInsuranceAmount {
   private applyColaAdjustments(pia: Money): Money {
     let adjusted = pia;
     for (
-      let year = this.recipient_.birthdate.yearTurningSsaAge(62);
+      let year = this.input_.birthdate.yearTurningSsaAge(62);
       year <= this.lastAppliedColaYear();
       ++year
     ) {
@@ -241,7 +249,7 @@ export class PrimaryInsuranceAmount {
    */
   shouldAdjustForCOLA(): boolean {
     return (
-      this.recipient_.birthdate.yearTurningSsaAge(62) <= constants.MAX_COLA_YEAR
+      this.input_.birthdate.yearTurningSsaAge(62) <= constants.MAX_COLA_YEAR
     );
   }
 
@@ -261,7 +269,7 @@ export class PrimaryInsuranceAmount {
 
     const adjustments: Array<ColaAdjustment> = [];
     for (
-      let year = this.recipient_.birthdate.yearTurningSsaAge(62);
+      let year = this.input_.birthdate.yearTurningSsaAge(62);
       year <= constants.CURRENT_YEAR;
       ++year
     ) {

--- a/src/lib/pia.ts
+++ b/src/lib/pia.ts
@@ -7,10 +7,10 @@ import { Money } from './money';
  * Recipient implements this interface, but tests can pass a plain object.
  */
 export interface PiaInput {
-  isPiaOnly: boolean;
-  overridePia: Money | null;
+  readonly isPiaOnly: boolean;
+  readonly overridePia: Money | null;
+  readonly birthdate: Birthdate;
   indexingYear(): number;
-  birthdate: Birthdate;
   monthlyIndexedEarnings(): Money;
   isEligible(): boolean;
 }
@@ -43,7 +43,6 @@ export class PrimaryInsuranceAmount {
    * This ratio is used to adjust the bend points in the PIA formula.
    *
    * @returns {number} The wage ratio used for indexing calculations
-   * @private
    */
   private wageRatio(): number {
     // If the indexing year is beyond the WAGE_INDICES data range, use the
@@ -84,7 +83,7 @@ export class PrimaryInsuranceAmount {
 
   /**
    * Calculates the PIA component for a specific bend point bracket based on
-   * the recipient's monthly indexed earnings.
+   * the provided monthly indexed earnings.
    *
    * The PIA formula has three brackets with different benefit percentages:
    * - Bracket 0: 90% of AIME up to the first bend point
@@ -93,7 +92,7 @@ export class PrimaryInsuranceAmount {
    *
    * @param {number} bracket - Which component: Must be 0, 1 or 2
    * @returns {Money} The benefit amount from the specified bracket
-   * @throws {Error} If invalid bracket or if recipient is PIA-only
+   * @throws {Error} If invalid bracket or if isPiaOnly is true
    */
   primaryInsuranceAmountByBracket(bracket: number): Money {
     if (bracket !== 0 && bracket !== 1 && bracket !== 2) {
@@ -102,7 +101,7 @@ export class PrimaryInsuranceAmount {
     if (this.input_.isPiaOnly) {
       throw new Error('Cannot calculate PIA brackets for PIA-only recipient');
     }
-    // If the recipient is not eligible for benefits, return $0.
+    // If not eligible for benefits, return $0.
     if (!this.input_.isEligible()) {
       return Money.from(0);
     }
@@ -134,7 +133,7 @@ export class PrimaryInsuranceAmount {
    * This is the initial PIA value before any COLA adjustments are applied.
    *
    * @returns {Money} The unadjusted PIA amount, rounded down to the nearest dime
-   * @throws {Error} If recipient is PIA-only
+   * @throws {Error} If isPiaOnly is true
    */
   primaryInsuranceAmountUnadjusted(): Money {
     if (this.input_.isPiaOnly) {
@@ -143,7 +142,7 @@ export class PrimaryInsuranceAmount {
     let sum = Money.from(0);
     for (let i = 0; i < 3; ++i)
       sum = sum.plus(this.primaryInsuranceAmountByBracket(i));
-    // Primary Insurance amounts are always rounded down the the nearest dime.
+    // Primary Insurance amounts are always rounded down to the nearest dime.
     // Who decided this was an important step?
     return sum.floorToDime();
   }
@@ -153,12 +152,15 @@ export class PrimaryInsuranceAmount {
    * then adjusted for cost of living increases (COLAs).
    *
    * This is the final PIA value that would be used to determine actual benefit
-   * payments. COLAs are applied starting from the year the recipient turns 62.
+   * payments. COLAs are applied starting from the year the individual turns 62.
    *
    * @returns {Money} The final PIA amount after all applicable COLA adjustments
    */
   primaryInsuranceAmount(): Money {
     if (this.input_.isPiaOnly) {
+      if (this.input_.overridePia === null) {
+        throw new Error('overridePia must not be null when isPiaOnly is true');
+      }
       return this.input_.overridePia;
     }
 
@@ -167,11 +169,9 @@ export class PrimaryInsuranceAmount {
   }
 
   /**
-   * Calculates the Primary Insurance Amount for this recipient as though they
-   * had an AIME of the given amount.
-   *
-   * This method is useful for simulating different earnings scenarios without
-   * changing the recipient's actual earnings record.
+   * Calculates the PIA as though the AIME were the given amount, instead of
+   * using monthlyIndexedEarnings(). Useful for simulating different earnings
+   * scenarios.
    *
    * @param {Money} aime - The AIME to use for the simulated calculation
    * @returns {Money} The PIA that would result from the specified AIME
@@ -200,7 +200,7 @@ export class PrimaryInsuranceAmount {
       )
     );
 
-    // Round to nearest dime.
+    // Round down to nearest dime.
     pia = pia.floorToDime();
 
     return this.applyColaAdjustments(pia);
@@ -216,7 +216,7 @@ export class PrimaryInsuranceAmount {
   }
 
   /**
-   * Applies COLA adjustments to a PIA value from the year the recipient turns 62
+   * Applies COLA adjustments to a PIA value from the year the individual turns 62
    * through the last applied COLA year. Each year's adjustment is rounded down
    * to the nearest dime per SSA rules.
    *
@@ -240,7 +240,7 @@ export class PrimaryInsuranceAmount {
   }
 
   /**
-   * Determines if the recipient is old enough (62+) to receive COLA adjustments.
+   * Determines if the individual is old enough (62+) to receive COLA adjustments.
    *
    * COLA adjustments are applied to the PIA starting from the year a person
    * turns 62, even if they don't claim benefits until later.

--- a/src/lib/recipient.ts
+++ b/src/lib/recipient.ts
@@ -8,7 +8,7 @@ import { EarningsManager } from '$lib/earnings-manager';
 import type { GenderOption } from '$lib/life-tables';
 import { Money } from '$lib/money';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
-import { PrimaryInsuranceAmount } from '$lib/pia';
+import { type PiaInput, PrimaryInsuranceAmount } from '$lib/pia';
 import { type RecipientColors, recipientColors } from '$lib/recipient-colors';
 
 export type { GenderOption };
@@ -37,7 +37,7 @@ export interface SerializedRecipient {
  * in benefit-calculator.ts. Earnings indexing and top-35 computation live
  * in EarningsManager.
  */
-export class Recipient {
+export class Recipient implements PiaInput {
   // ---------------------------------------------------------------------------
   // Health & Gender
   // ---------------------------------------------------------------------------

--- a/src/test/pia.test.ts
+++ b/src/test/pia.test.ts
@@ -1,10 +1,58 @@
 import { describe, expect, it } from 'vitest';
 import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
 import demo0 from '$lib/pastes/averagepaste.txt?raw';
+import { type PiaInput, PrimaryInsuranceAmount } from '$lib/pia';
 import { Recipient } from '$lib/recipient';
 import { parsePaste } from '$lib/ssa-parse';
 
 import * as constants from '../lib/constants';
+
+describe('PrimaryInsuranceAmount with PiaInput', () => {
+  it('calculates bend points from a plain object', () => {
+    const input: PiaInput = {
+      isPiaOnly: false,
+      overridePia: null,
+      indexingYear: () => 2017,
+      birthdate: Birthdate.FromYMD(1957, 0, 2),
+      monthlyIndexedEarnings: () => Money.from(0),
+      isEligible: () => false,
+    };
+    const pia = new PrimaryInsuranceAmount(input);
+    expect(pia.firstBendPoint().value()).toEqual(926);
+    expect(pia.secondBendPoint().value()).toEqual(5583);
+  });
+
+  it('calculates PIA from a plain object with earnings', () => {
+    const input: PiaInput = {
+      isPiaOnly: false,
+      overridePia: null,
+      indexingYear: () => 2017,
+      birthdate: Birthdate.FromYMD(1957, 0, 2),
+      monthlyIndexedEarnings: () => Money.from(3000),
+      isEligible: () => true,
+    };
+    const pia = new PrimaryInsuranceAmount(input);
+    // With AIME of $3000: 90% of $926 + 32% of ($3000-$926) = $833.4 + $663.68
+    // = $1497.0 (floored to dime)
+    expect(pia.primaryInsuranceAmountByBracket(0).value()).toEqual(833.4);
+    expect(pia.primaryInsuranceAmountByBracket(1).value()).toEqual(663.68);
+    expect(pia.primaryInsuranceAmountByBracket(2).value()).toEqual(0);
+  });
+
+  it('returns override PIA for PIA-only input', () => {
+    const input: PiaInput = {
+      isPiaOnly: true,
+      overridePia: Money.from(1500),
+      indexingYear: () => 2017,
+      birthdate: Birthdate.FromYMD(1957, 0, 2),
+      monthlyIndexedEarnings: () => Money.from(0),
+      isEligible: () => true,
+    };
+    const pia = new PrimaryInsuranceAmount(input);
+    expect(pia.primaryInsuranceAmount().value()).toEqual(1500);
+  });
+});
 
 describe('Recipient', () => {
   it('calculates bendpoints', () => {


### PR DESCRIPTION
## Summary
- Introduce `PiaInput` interface in `pia.ts` with only the 6 properties PIA actually uses (`isPiaOnly`, `overridePia`, `indexingYear()`, `birthdate`, `monthlyIndexedEarnings()`, `isEligible()`)
- `PrimaryInsuranceAmount` now accepts `PiaInput` instead of `Recipient`, breaking the tight coupling
- `Recipient` implements `PiaInput`, so all existing call sites are unchanged
- Added 3 new tests that construct `PrimaryInsuranceAmount` with plain objects (no `Recipient` dependency)

## Test plan
- [x] All 989 existing tests pass
- [x] `npm run quality` passes (lint + type check)
- [x] New tests verify bend points, bracket calculations, and PIA-only mode using plain `PiaInput` objects