### PR TITLE
chore: add local/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ dist-ssr
 
 # Test coverage reports
 /coverage
+
+# Local developer files
+/local


### PR DESCRIPTION
## Summary
- Adds a `local/` directory to the project for developer-specific files
- Adds `/local` to `.gitignore` so these files are not tracked

## Test plan
- [x] Verify `local/` directory exists
- [x] Verify `.gitignore` includes `/local`