### PR TITLE
chore: remove strategy page warning banner

### DIFF
--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -290,11 +290,6 @@
 
 <main>
   <div class="limited-width">
-    <h1>
-      Warning: This is a work in progress and probably incorrect. Please
-      disregard.
-    </h1>
-
     <p>
       This calculation shows an "optimal" social security filing strategy for
       your personal situation, for all possible years of death ranging from 62


### PR DESCRIPTION
## Summary

- Removes the "Warning: This is a work in progress and probably incorrect. Please disregard." banner from the strategy page

The strategy optimizer has been verified with 882 tests. The warning is no longer needed.

## Test plan

- [x] All 1876 tests pass
- [x] `npm run quality` clean
- [ ] CI passes