### PR TITLE
feat(strategy): polish pass on /strategy UI

### DIFF
--- a/src/lib/components/BirthdateInput.svelte
+++ b/src/lib/components/BirthdateInput.svelte
@@ -239,38 +239,47 @@ function autoFocusAction(el) {
   }
   .date-input-item {
     display: inline-block;
-    margin-right: 20px;
+    margin-right: 0.75rem;
   }
   .date-input-label {
     display: block;
-    margin-bottom: 5px;
-    font-weight: 400;
-    color: #0b0c0c;
+    margin-bottom: 0.3rem;
+    font-weight: 500;
+    font-size: 0.85rem;
+    color: #4b5563;
   }
   .input {
-    font-size: 1.2em;
-    line-height: 1.3;
-    height: 2.5em;
-    padding: 5px;
-    border: 2px solid #0b0c0c;
-    border-radius: 0;
+    font-size: 1rem;
+    line-height: 1.4;
+    padding: 0.65rem 0.75rem;
+    border: 1.5px solid #d1d5db;
+    border-radius: 6px;
+    background-color: white;
+    color: #0b0c0c;
+    font-family: inherit;
     appearance: none;
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
   .input:focus {
-    outline: 3px solid #fd0;
-    outline-offset: 0;
-    box-shadow: inset 0 0 0 2px;
+    outline: none;
+    border-color: #081d88;
+    box-shadow: 0 0 0 3px rgba(8, 29, 136, 0.15);
   }
   .input-width-2 {
-    max-width: 2.75em;
+    max-width: 3.75rem;
   }
   .input-width-4 {
-    max-width: 4.5em;
+    max-width: 5.5rem;
   }
 
   .input.invalid {
     border-color: #d4351c;
-    background-color: #fee;
+    background-color: #fef5f5;
+  }
+  .input.invalid:focus {
+    box-shadow: 0 0 0 3px rgba(212, 53, 28, 0.15);
   }
 
   .error-messages {
@@ -280,7 +289,7 @@ function autoFocusAction(el) {
   .error-message {
     display: block;
     color: #d4351c;
-    font-size: 0.9em;
-    margin-bottom: 0.25rem;
+    font-size: 0.85rem;
+    margin-bottom: 0.2rem;
   }
 </style>

--- a/src/lib/components/HowToReadChart.svelte
+++ b/src/lib/components/HowToReadChart.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+  import { slide } from "svelte/transition";
+  import { cubicOut } from "svelte/easing";
+
+  export let label: string = "How to read this chart";
+  let open = false;
+</script>
+
+<div class="how-to-read">
+  <button
+    type="button"
+    class="toggle"
+    aria-expanded={open}
+    on:click={() => (open = !open)}
+  >
+    <svg
+      class="help-icon"
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="8" cy="8" r="7" />
+      <path d="M6 6a2 2 0 0 1 4 0c0 1.2-1 1.7-2 2.3v0.7" />
+      <circle cx="8" cy="11.3" r="0.7" fill="currentColor" stroke="none" />
+    </svg>
+    <span>{label}</span>
+    <svg
+      class="chevron"
+      class:open
+      viewBox="0 0 16 16"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 3l5 5-5 5" />
+    </svg>
+  </button>
+  {#if open}
+    <div
+      class="content"
+      transition:slide={{ duration: 220, easing: cubicOut }}
+    >
+      <slot />
+    </div>
+  {/if}
+</div>
+
+<style>
+  .how-to-read {
+    margin-top: 0.5rem;
+  }
+  .toggle {
+    background: transparent;
+    border: none;
+    color: #4b5563;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0.35rem 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition: color 0.15s ease;
+  }
+  .toggle:hover,
+  .toggle:focus-visible {
+    color: #081d88;
+    outline: none;
+  }
+  .help-icon {
+    display: block;
+    flex-shrink: 0;
+  }
+  .chevron {
+    display: block;
+    flex-shrink: 0;
+    transition: transform 0.2s ease;
+  }
+  .chevron.open {
+    transform: rotate(90deg);
+  }
+  .content {
+    margin-top: 0.45rem;
+    padding: 0.85rem 1rem;
+    background: #f7f8fd;
+    border: 1px solid #dcdef5;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    color: #374151;
+    line-height: 1.55;
+  }
+  .content :global(ul) {
+    margin: 0;
+    padding-left: 1.2rem;
+  }
+  .content :global(li) {
+    margin-bottom: 0.3rem;
+  }
+  .content :global(li:last-child) {
+    margin-bottom: 0;
+  }
+  .content :global(p) {
+    margin: 0.6rem 0 0;
+  }
+  .content :global(p:first-child) {
+    margin-top: 0;
+  }
+  .content :global(strong) {
+    color: #081d88;
+    font-weight: 700;
+  }
+</style>

--- a/src/lib/components/InfoTip.svelte
+++ b/src/lib/components/InfoTip.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  export let label: string = "More info";
+
+  let open = false;
+  let tipEl: HTMLSpanElement;
+
+  function toggle(event: MouseEvent) {
+    event.stopPropagation();
+    open = !open;
+  }
+
+  function handleDocClick(event: MouseEvent) {
+    if (tipEl && !tipEl.contains(event.target as Node)) {
+      open = false;
+    }
+  }
+
+  function handlePointerEnter(event: PointerEvent) {
+    if (event.pointerType === "mouse") open = true;
+  }
+
+  function handlePointerLeave(event: PointerEvent) {
+    if (event.pointerType === "mouse") open = false;
+  }
+</script>
+
+<svelte:window on:click={handleDocClick} />
+
+<span
+  class="info-tip"
+  bind:this={tipEl}
+  role="presentation"
+  on:pointerenter={handlePointerEnter}
+  on:pointerleave={handlePointerLeave}
+>
+  <button
+    type="button"
+    class="info-trigger"
+    tabindex="-1"
+    aria-label={label}
+    aria-expanded={open}
+    on:click={toggle}
+  >
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="7"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+      />
+      <circle cx="8" cy="4.8" r="0.9" fill="currentColor" />
+      <path
+        d="M6.5 7.5h1.8v4.7"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </button>
+  {#if open}
+    <span class="info-bubble" role="tooltip">
+      <slot />
+    </span>
+  {/if}
+</span>
+
+<style>
+  .info-tip {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.35rem;
+    vertical-align: baseline;
+  }
+  .info-trigger {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #9ca3af;
+    cursor: help;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    border-radius: 50%;
+    transition: color 0.15s ease;
+  }
+  .info-trigger:hover,
+  .info-trigger:focus-visible {
+    color: #081d88;
+    outline: none;
+  }
+  .info-bubble {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #0b1130;
+    color: #f3f4f6;
+    padding: 0.6rem 0.8rem;
+    border-radius: 6px;
+    font-size: 0.82rem;
+    font-weight: 400;
+    line-height: 1.45;
+    width: max-content;
+    max-width: 260px;
+    box-shadow: 0 4px 14px rgba(11, 17, 48, 0.18);
+    z-index: 20;
+    text-align: left;
+  }
+  /* Invisible bridge across the gap between icon and bubble so the
+     pointer can travel up to the bubble (e.g. to click a link) without
+     leaving the .info-tip hover region. */
+  .info-bubble::before {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: 12px;
+  }
+  .info-bubble::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #0b1130;
+  }
+  .info-bubble :global(a) {
+    color: #a5b4fc;
+    text-decoration: underline;
+  }
+  .info-bubble :global(a:hover),
+  .info-bubble :global(a:focus-visible) {
+    color: #c7d2fe;
+  }
+  @media (max-width: 500px) {
+    .info-bubble {
+      max-width: 220px;
+    }
+  }
+</style>

--- a/src/lib/components/InfoTip.svelte
+++ b/src/lib/components/InfoTip.svelte
@@ -5,6 +5,9 @@
   let tipEl: HTMLSpanElement;
 
   function toggle(event: MouseEvent) {
+    // preventDefault stops the surrounding <label> from redirecting focus
+    // to its associated input when the InfoTip button is clicked.
+    event.preventDefault();
     event.stopPropagation();
     open = !open;
   }

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -88,6 +88,7 @@
     if (!el || typeof IntersectionObserver === "undefined") return;
     tunableObserver = new IntersectionObserver(
       (entries) => {
+        if (entries.length === 0) return;
         tunableIsStuck = !entries[0].isIntersecting;
       },
       { threshold: 0 }
@@ -112,6 +113,7 @@
   onDestroy(() => {
     tunableObserver?.disconnect();
     tunableResizeObserver?.disconnect();
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
   });
 
   $: formIsValid = recipientInputsValid && discountRateValid;
@@ -145,10 +147,6 @@
       });
     }, REACTIVE_DEBOUNCE_MS);
   }
-
-  onDestroy(() => {
-    if (debounceTimer !== null) clearTimeout(debounceTimer);
-  });
 
   let recipients: [Recipient, Recipient] = initializeRecipients();
 
@@ -208,15 +206,13 @@
 
   function handleModeSelect(single: boolean) {
     isSingle = single;
-    if (single) {
-      // Single recipient: leave recipient1 in default (only=true) so
-      // <RecipientName> renders slot content ("Your") instead of the name.
-    } else {
+    // Couple mode marks the two recipients so <RecipientName> shows their
+    // colored names. Single mode leaves recipient1's default (only=true)
+    // intact so <RecipientName> renders slot content ("Your") instead.
+    if (!single) {
       recipients[0].markFirst();
       recipients[1].markSecond();
-      if (recipients[1].name === "") {
-        recipients[1].name = "Spouse";
-      }
+      if (recipients[1].name === "") recipients[1].name = "Spouse";
       recipients = [...recipients];
     }
     stage = "form";

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
+  import { slide } from "svelte/transition";
+  import { cubicOut } from "svelte/easing";
+  import Header from "$lib/components/Header.svelte";
   import { getDeathProbabilityDistribution } from "$lib/life-tables";
   import { Money } from "$lib/money";
   import { MonthDate } from "$lib/month-time";
@@ -52,7 +55,7 @@
   let deathAgeBuckets2: DeathAgeBucket[] = [];
   let deathProbDistribution1: { age: number; probability: number }[] = [];
   let deathProbDistribution2: { age: number; probability: number }[] = [];
-  let displayAsAges: boolean = false;
+  let displayAsAges: boolean = true;
   let optimalSingleResult: FilingAgeResult | undefined = undefined;
   let optimalCoupleResult: CoupleFilingAgeResult | undefined = undefined;
 
@@ -68,6 +71,48 @@
   let rerunPending = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let isRunning = false;
+
+  let tunableSentinelEl: HTMLDivElement | null = null;
+  let tunableWrapperEl: HTMLDivElement | null = null;
+  let tunableIsStuck = false;
+  let tunableExpandedHeight = 0;
+  let tunableObserver: IntersectionObserver | null = null;
+  let tunableResizeObserver: ResizeObserver | null = null;
+
+  $: observeTunableSentinel(tunableSentinelEl);
+  $: observeTunableWrapper(tunableWrapperEl);
+
+  function observeTunableSentinel(el: HTMLDivElement | null) {
+    tunableObserver?.disconnect();
+    tunableObserver = null;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    tunableObserver = new IntersectionObserver(
+      (entries) => {
+        tunableIsStuck = !entries[0].isIntersecting;
+      },
+      { threshold: 0 }
+    );
+    tunableObserver.observe(el);
+  }
+
+  function observeTunableWrapper(el: HTMLDivElement | null) {
+    tunableResizeObserver?.disconnect();
+    tunableResizeObserver = null;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    tunableResizeObserver = new ResizeObserver(() => {
+      // Only track size while expanded — that's the "natural" height the
+      // spacer needs to reserve when we flip to fixed/compact.
+      if (!tunableIsStuck) {
+        tunableExpandedHeight = el.offsetHeight;
+      }
+    });
+    tunableResizeObserver.observe(el);
+  }
+
+  onDestroy(() => {
+    tunableObserver?.disconnect();
+    tunableResizeObserver?.disconnect();
+  });
 
   $: formIsValid = recipientInputsValid && discountRateValid;
   $: discountRate = discountRatePercent / 100;
@@ -150,8 +195,6 @@
   function initializeRecipients(): [Recipient, Recipient] {
     const recipient1 = new Recipient();
     const recipient2 = new Recipient();
-    recipient1.markFirst();
-    recipient2.markSecond();
     recipient1.name = "Self";
     recipient2.name = "Spouse";
     recipient1.setPia(Money.from(0));
@@ -165,8 +208,15 @@
 
   function handleModeSelect(single: boolean) {
     isSingle = single;
-    if (!single && recipients[1].name === "") {
-      recipients[1].name = "Spouse";
+    if (single) {
+      // Single recipient: leave recipient1 in default (only=true) so
+      // <RecipientName> renders slot content ("Your") instead of the name.
+    } else {
+      recipients[0].markFirst();
+      recipients[1].markSecond();
+      if (recipients[1].name === "") {
+        recipients[1].name = "Spouse";
+      }
       recipients = [...recipients];
     }
     stage = "form";
@@ -345,29 +395,53 @@
   }
 </script>
 
+<svelte:head>
+  <link
+    href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap"
+    rel="stylesheet"
+  />
+</svelte:head>
+
+<Header />
+
 <main>
   <div class="limited-width">
-    <p>
-      This calculation shows an "optimal" social security filing strategy for
-      your personal situation, for all possible years of death ranging from 62
-      to 90. Optimal is defined as the largest sum of money, adjusted by the
-      discount rate such that a dollar today is worth more than a dollar in the
-      future.
-    </p>
+    {#if stage === "mode"}
+      <header
+        class="page-hero"
+        transition:slide={{ duration: 320, easing: cubicOut }}
+      >
+        <h1 class="page-hero__title">
+          Find your <span class="accent">optimal</span> filing strategy
+        </h1>
+        <p class="page-hero__lede">
+          See the Social Security filing strategy that maximizes your expected
+          benefits across every plausible life span. <em>Optimal</em> means
+          the largest total, adjusted by a discount rate so a dollar today is
+          worth more than a dollar in the future.
+        </p>
+      </header>
+    {/if}
 
     {#if stage === "mode"}
-      <section class="stage-section">
+      <section
+        class="stage-section"
+        transition:slide={{ duration: 320, easing: cubicOut }}
+      >
         <ModePicker onselect={handleModeSelect} />
       </section>
     {/if}
 
     {#if stage === "form"}
-      <section class="stage-section input-section">
+      <section
+        class="stage-section"
+        transition:slide={{ duration: 320, easing: cubicOut }}
+      >
         <RecipientInputs
           {recipients}
           {isSingle}
-          {piaValues}
-          {birthdateInputs}
+          bind:piaValues
+          bind:birthdateInputs
           continueDisabled={!formIsValid}
           errorMessage={formErrorMessage}
           onUpdate={handleRecipientUpdate}
@@ -379,21 +453,42 @@
     {/if}
 
     {#if stage === "results"}
-      <section class="stage-section locked-section">
+      <section
+        class="stage-section locked-section"
+        transition:slide={{ duration: 320, easing: cubicOut }}
+      >
         <LockedSummary {recipients} {isSingle} onedit={handleEdit} />
-        <TunableAssumptions
-          {recipients}
-          {isSingle}
-          bind:discountRatePercent
-          onRecipientUpdate={handleRecipientUpdate}
-          onDiscountRateValidityChange={(isValid) =>
-            (discountRateValid = isValid)}
-        />
       </section>
     {/if}
   </div>
 
   {#if stage === "results"}
+    <div class="tunable-sentinel" bind:this={tunableSentinelEl}></div>
+    <!-- Placeholder reserves the element's natural expanded height in flow
+         while the sticky is detached (position: fixed) in stuck/compact
+         mode, so the document height never changes. -->
+    <div
+      class="tunable-placeholder"
+      style:height={tunableIsStuck ? `${tunableExpandedHeight}px` : "0"}
+    ></div>
+    <div
+      class="tunable-sticky-outer"
+      class:is-stuck={tunableIsStuck}
+      bind:this={tunableWrapperEl}
+    >
+      <div class="limited-width tunable-sticky-inner">
+        <TunableAssumptions
+          {recipients}
+          {isSingle}
+          isStuck={tunableIsStuck}
+          bind:discountRatePercent
+          onRecipientUpdate={handleRecipientUpdate}
+          onDiscountRateValidityChange={(isValid) =>
+            (discountRateValid = isValid)}
+        />
+      </div>
+    </div>
+
     <section class="calculation-section">
       {#if calculationResults.status() === CalculationStatus.Complete}
         <div class="limited-width">
@@ -401,7 +496,7 @@
             {isSingle}
             singleResult={optimalSingleResult}
             coupleResult={optimalCoupleResult}
-            recipientNames={[recipients[0].name, recipients[1].name]}
+            {recipients}
           />
         </div>
         {#if isSingle}
@@ -465,7 +560,7 @@
   main {
     margin: 0 0;
     padding: 0;
-    font-family: Arial, sans-serif;
+    font-family: "Lato", -apple-system, BlinkMacSystemFont, sans-serif;
   }
 
   .limited-width {
@@ -474,14 +569,57 @@
     padding: 0.5rem;
   }
 
-  .stage-section {
-    margin-bottom: 0;
+  .page-hero {
+    padding: 2.75rem 0.25rem 2.25rem;
+    margin: 0;
+    text-align: center;
   }
 
-  .input-section {
-    padding: 1rem;
-    border: 1px solid #ccc;
-    border-radius: 8px;
+  .page-hero__title {
+    color: #060606;
+    font-family: inherit;
+    font-size: 2.5rem;
+    font-weight: 900;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+    margin: 0 0 1rem;
+  }
+
+  .page-hero__title .accent {
+    color: #081d88;
+  }
+
+  .page-hero__lede {
+    color: #4b4b4b;
+    font-family: inherit;
+    font-size: 1.125rem;
+    line-height: 1.55;
+    max-width: 62ch;
+    margin: 0 auto;
+  }
+
+  .page-hero__lede em {
+    font-style: normal;
+    font-weight: 700;
+    color: #333;
+  }
+
+  @media (max-width: 640px) {
+    .page-hero {
+      padding: 1.75rem 0.25rem 1.25rem;
+    }
+
+    .page-hero__title {
+      font-size: 1.875rem;
+    }
+
+    .page-hero__lede {
+      font-size: 1rem;
+    }
+  }
+
+  .stage-section {
+    margin-bottom: 0;
   }
 
   .locked-section {
@@ -489,6 +627,40 @@
     border: 1px solid #ccc;
     border-radius: 8px;
     background: #f5f7fa;
+  }
+
+  .tunable-sentinel {
+    position: relative;
+    height: 1px;
+    width: 100%;
+    margin-bottom: -1px;
+    pointer-events: none;
+  }
+
+  .tunable-placeholder {
+    flex: none;
+    width: 100%;
+  }
+
+  .tunable-sticky-outer {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    transition: box-shadow 0.15s ease;
+  }
+
+  .tunable-sticky-outer.is-stuck {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+  }
+
+  .tunable-sticky-inner {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
   }
 
   .calculation-section {

--- a/src/routes/strategy/components/DiscountRateInput.svelte
+++ b/src/routes/strategy/components/DiscountRateInput.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import InfoTip from '$lib/components/InfoTip.svelte';
 import { getRecommendedDiscountRate } from '$lib/strategy/data';
 
 export let discountRatePercent: number;
+export let isStuck: boolean = false;
 // Two-way binding now used instead of explicit change callback.
 export let onValidityChange: ((isValid: boolean) => void) | undefined =
   undefined;
@@ -13,9 +15,13 @@ let isValid = true;
 let errorMessage = '';
 
 let presetRates = [
-  { label: `20-year Treasury rate (${treasuryRate}%)`, value: treasuryRate },
-  { label: 'US Stock 10y expected (3.5%)', value: 3.5 },
-  { label: 'US Stock historical (7%)', value: 7 },
+  {
+    label: `20-year Treasury rate (${treasuryRate}%)`,
+    shortLabel: `${treasuryRate}%`,
+    value: treasuryRate,
+  },
+  { label: 'US Stock 10y expected (3.5%)', shortLabel: '3.5%', value: 3.5 },
+  { label: 'US Stock historical (7%)', shortLabel: '7%', value: 7 },
 ];
 
 onMount(async () => {
@@ -30,10 +36,15 @@ onMount(async () => {
     presetRates = [
       {
         label: `20-year Treasury rate (${treasuryRate}%)`,
+        shortLabel: `${treasuryRate}%`,
         value: treasuryRate,
       },
-      { label: 'US Stock 10y expected (3.5%)', value: 3.5 },
-      { label: 'US Stock historical (7%)', value: 7 },
+      {
+        label: 'US Stock 10y expected (3.5%)',
+        shortLabel: '3.5%',
+        value: 3.5,
+      },
+      { label: 'US Stock historical (7%)', shortLabel: '7%', value: 7 },
     ];
 
     // Update the discountRatePercent if it's currently set to our default treasury rate (2.5%)
@@ -73,9 +84,34 @@ function validateDiscountRate(value: number) {
 $: validateDiscountRate(discountRatePercent);
 </script>
 
-<div class="global-input-group">
-  <label for="discountRate">Discount Rate (Real %):</label>
-  <div class="preset-buttons">
+<div class="discount-rate" class:is-compact={isStuck}>
+  <div class="discount-rate-row">
+    <label for="discountRate">
+      Discount rate (real)
+      <InfoTip label="About the discount rate">
+        The rate used to convert future benefits into today's dollars. Higher
+        rates make earlier filing look relatively better; lower rates favor
+        waiting. The Treasury yield is a common conservative choice.
+      </InfoTip>
+    </label>
+    <div class="rate-input-wrap">
+      <input
+        id="discountRate"
+        type="number"
+        step="0.1"
+        min="0"
+        max="50"
+        inputmode="decimal"
+        value={discountRatePercent}
+        on:input={(event) => {
+          const value = parseFloat(event.currentTarget.value) || 0;
+          handleDiscountRateChange(value);
+        }}
+        class:highlight={highlightInput}
+        class:invalid={!isValid}
+      />
+      <span class="rate-suffix" aria-hidden="true">%</span>
+    </div>
     {#each presetRates as preset}
       <button
         type="button"
@@ -86,108 +122,165 @@ $: validateDiscountRate(discountRatePercent);
           highlightInput = true;
         }}
       >
-        {preset.label}
+        <span class="preset-full">{preset.label}</span>
+        <span class="preset-short">{preset.shortLabel}</span>
       </button>
     {/each}
   </div>
-  <input
-    id="discountRate"
-    type="number"
-    step="0.1"
-    min="0"
-    max="50"
-    value={discountRatePercent}
-    on:input={(event) => {
-      const value = parseFloat(event.currentTarget.value) || 0;
-      handleDiscountRateChange(value);
-    }}
-    class:highlight={highlightInput}
-    class:invalid={!isValid}
-  />
   {#if !isValid && errorMessage}
     <span class="error-message">{errorMessage}</span>
   {/if}
 </div>
 
 <style>
-  .global-input-group {
+  .discount-rate {
     display: flex;
     flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .discount-rate-row {
+    display: flex;
+    align-items: center;
     gap: 0.5rem;
-    margin-top: 2rem;
-    margin-bottom: 1rem;
+    flex-wrap: wrap;
   }
 
-  .global-input-group label {
-    font-weight: bold;
+  .discount-rate-row .rate-input-wrap {
+    margin-right: 0.35rem;
   }
 
-  .global-input-group input {
-    font-size: 1.2em;
-    line-height: 1.3;
-    height: 2.5em;
-    padding: 5px;
-    border: 2px solid #0b0c0c;
-    border-radius: 0;
+  .discount-rate-row label {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #1f2937;
+  }
+
+  .rate-input-wrap {
+    position: relative;
+    width: 100px;
+  }
+
+  .rate-input-wrap input {
+    width: 100%;
+    font-size: 1rem;
+    line-height: 1.4;
+    padding: 0.6rem 1.75rem 0.6rem 0.75rem;
+    border: 1.5px solid #d1d5db;
+    border-radius: 6px;
+    background-color: white;
+    color: #0b0c0c;
+    font-family: inherit;
     appearance: none;
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
-  .global-input-group input:focus {
-    outline: 3px solid #fd0;
-    outline-offset: 0;
-    box-shadow: inset 0 0 0 2px;
+  .rate-input-wrap input::-webkit-outer-spin-button,
+  .rate-input-wrap input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
   }
 
-  .global-input-group input.invalid {
+  .rate-input-wrap input:focus {
+    outline: none;
+    border-color: #081d88;
+    box-shadow: 0 0 0 3px rgba(8, 29, 136, 0.15);
+  }
+
+  .rate-input-wrap input.invalid {
     border-color: #d4351c;
-    background-color: #fee;
+    background-color: #fef5f5;
+  }
+
+  .rate-input-wrap input.invalid:focus {
+    box-shadow: 0 0 0 3px rgba(212, 53, 28, 0.15);
+  }
+
+  .rate-suffix {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6b7280;
+    font-weight: 500;
+    pointer-events: none;
+    user-select: none;
   }
 
   .error-message {
     color: #d4351c;
-    font-size: 0.9em;
-    margin-top: 0.25rem;
-  }
-
-  .preset-buttons {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin: 0.5rem 0;
+    font-size: 0.85rem;
   }
 
   .preset-button {
-    padding: 0.3rem 0.6rem;
-    font-size: 0.8em;
-    background-color: #f8f8f8;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    color: #333;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.82rem;
+    background-color: white;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    color: #4b5563;
     cursor: pointer;
-    transition: all 0.2s ease;
+    font-family: inherit;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease,
+      color 0.15s ease;
   }
 
   .preset-button:hover {
-    background-color: #e8e8e8;
-    border-color: #999;
+    border-color: #081d88;
+    color: #081d88;
+    background-color: #f7f8fd;
   }
 
   .preset-button.active {
-    background-color: #005ea5;
+    background-color: #081d88;
     color: #fff;
-    border-color: #005ea5;
+    border-color: #081d88;
   }
 
-  .preset-button:focus {
-    outline: 3px solid #fd0;
-    outline-offset: 0;
+  .preset-button:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 2px;
+  }
+
+  .preset-short {
+    display: none;
+  }
+
+  /* Compact (sticky) variant — shrink everything so the discount row
+     matches the height of the compact health cards. */
+  .discount-rate.is-compact .discount-rate-row {
+    gap: 0.4rem;
+  }
+  .discount-rate.is-compact .discount-rate-row label {
+    display: none;
+  }
+  .discount-rate.is-compact .rate-input-wrap {
+    width: 80px;
+  }
+  .discount-rate.is-compact .rate-input-wrap input {
+    font-size: 0.9rem;
+    padding: 0.3rem 1.4rem 0.3rem 0.6rem;
+  }
+  .discount-rate.is-compact .rate-suffix {
+    right: 0.55rem;
+    font-size: 0.9rem;
+  }
+  .discount-rate.is-compact .preset-button {
+    padding: 0.3rem 0.55rem;
+    font-size: 0.8rem;
+  }
+  .discount-rate.is-compact .preset-full {
+    display: none;
+  }
+  .discount-rate.is-compact .preset-short {
+    display: inline;
   }
 
   @media (max-width: 600px) {
-    .preset-buttons {
-      flex-direction: column;
-    }
-
     .preset-button {
       width: 100%;
       text-align: center;

--- a/src/routes/strategy/components/DiscountRateInput.svelte
+++ b/src/routes/strategy/components/DiscountRateInput.svelte
@@ -14,7 +14,7 @@ let treasuryRate: number = 2.5; // Default value
 let isValid = true;
 let errorMessage = '';
 
-let presetRates = [
+$: presetRates = [
   {
     label: `20-year Treasury rate (${treasuryRate}%)`,
     shortLabel: `${treasuryRate}%`,
@@ -28,30 +28,11 @@ onMount(async () => {
   try {
     // getRecommendedDiscountRate returns the rate as a decimal (e.g., 0.038 for 3.8%)
     const rate = await getRecommendedDiscountRate();
-
-    // Convert to percentage value by multiplying by 100
     treasuryRate = parseFloat((rate * 100).toFixed(2));
-
-    // Update the presetRates array with the new treasury rate
-    presetRates = [
-      {
-        label: `20-year Treasury rate (${treasuryRate}%)`,
-        shortLabel: `${treasuryRate}%`,
-        value: treasuryRate,
-      },
-      {
-        label: 'US Stock 10y expected (3.5%)',
-        shortLabel: '3.5%',
-        value: 3.5,
-      },
-      { label: 'US Stock historical (7%)', shortLabel: '7%', value: 7 },
-    ];
-
-    // Update the discountRatePercent if it's currently set to our default treasury rate (2.5%)
     handleDiscountRateChange(treasuryRate);
   } catch (error) {
     console.error('Failed to fetch recommended discount rate:', error);
-    // Keep default 2.5% if fetch fails
+    // Keep default 2.5% if fetch fails.
   }
 });
 

--- a/src/routes/strategy/components/LockedSummary.svelte
+++ b/src/routes/strategy/components/LockedSummary.svelte
@@ -33,9 +33,22 @@
 <div class="locked-header">
   <div class="locked-title">
     <strong>Recipient information</strong>
-    <span class="muted">· locked</span>
   </div>
   <button type="button" class="edit-btn" on:click={onedit}>
+    <svg
+      class="edit-arrow"
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 3 5 8l5 5" />
+    </svg>
     Edit recipient info
   </button>
 </div>
@@ -44,7 +57,9 @@
   {#each recipients as recipient, i}
     {#if !isSingle || i === 0}
       <div class="card">
-        <div class="name"><RecipientName r={recipient} /></div>
+        {#if !recipient.only}
+          <div class="name"><RecipientName r={recipient} /></div>
+        {/if}
         <div class="details">
           Born {formatBirthdate(recipient)} · {formatGender(recipient)} · PIA {formatPia(
             recipient
@@ -66,25 +81,39 @@
     font-size: 0.95rem;
     color: #333;
   }
-  .muted {
-    color: #888;
-    font-weight: normal;
-  }
   .edit-btn {
-    font-size: 0.85rem;
+    flex: 0 0 auto;
     background: white;
-    border: 1px solid #bbb;
-    color: #333;
-    padding: 0.3rem 0.7rem;
-    border-radius: 4px;
-    cursor: pointer;
+    border: 1px solid #d1d5db;
+    color: #4b5563;
+    padding: 0.4rem 0.75rem;
+    border-radius: 6px;
     font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition:
+      border-color 0.15s ease,
+      color 0.15s ease,
+      background-color 0.15s ease;
   }
   .edit-btn:hover,
-  .edit-btn:focus {
-    border-color: #005ea5;
-    color: #005ea5;
+  .edit-btn:focus-visible {
+    border-color: #081d88;
+    color: #081d88;
+    background-color: #f7f8fd;
     outline: none;
+  }
+  .edit-arrow {
+    display: block;
+    transition: transform 0.15s ease;
+  }
+  .edit-btn:hover .edit-arrow,
+  .edit-btn:focus-visible .edit-arrow {
+    transform: translateX(-2px);
   }
   .cards {
     display: grid;

--- a/src/routes/strategy/components/ModePicker.svelte
+++ b/src/routes/strategy/components/ModePicker.svelte
@@ -7,10 +7,38 @@
   <p class="hint">Pick one to continue.</p>
   <div class="choices">
     <button type="button" class="choice" on:click={() => onselect(true)}>
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="8" r="4" />
+        <path d="M5 21a7 7 0 0 1 14 0" />
+      </svg>
       <span class="title">Just me</span>
       <span class="sub">Single filer</span>
     </button>
     <button type="button" class="choice" on:click={() => onselect(false)}>
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="8" cy="9" r="3" />
+        <circle cx="16" cy="9" r="3" />
+        <path d="M2 20a5 5 0 0 1 10 0" />
+        <path d="M12 20a5 5 0 0 1 10 0" />
+      </svg>
       <span class="title">Married couple</span>
       <span class="sub">Two filers</span>
     </button>
@@ -40,8 +68,8 @@
   }
   .choice {
     flex: 1 1 220px;
-    min-height: 120px;
-    padding: 1.25rem 1rem;
+    min-height: 160px;
+    padding: 1.5rem 1rem 1.25rem;
     background: white;
     border: 2px solid #ddd;
     border-radius: 8px;
@@ -52,15 +80,26 @@
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
+    color: #081d88;
     transition:
       border-color 0.15s ease,
-      background-color 0.15s ease;
+      background-color 0.15s ease,
+      color 0.15s ease,
+      transform 0.15s ease;
   }
   .choice:hover,
   .choice:focus {
     border-color: #005ea5;
     background: #f0f7fc;
+    color: #05126b;
     outline: none;
+    transform: translateY(-1px);
+  }
+  .icon {
+    width: 44px;
+    height: 44px;
+    margin-bottom: 0.5rem;
+    flex-shrink: 0;
   }
   .title {
     font-weight: bold;

--- a/src/routes/strategy/components/OptimalStrategyHeadline.svelte
+++ b/src/routes/strategy/components/OptimalStrategyHeadline.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import RecipientName from "$lib/components/RecipientName.svelte";
   import { Money } from "$lib/money";
-  import type { MonthDuration } from "$lib/month-time";
+  import { MonthDuration } from "$lib/month-time";
+  import type { Recipient } from "$lib/recipient";
   import type {
     FilingAgeResult,
     CoupleFilingAgeResult,
@@ -10,11 +12,10 @@
     isSingle: boolean;
     singleResult?: FilingAgeResult;
     coupleResult?: CoupleFilingAgeResult;
-    recipientNames: [string, string];
+    recipients: [Recipient, Recipient];
   }
 
-  let { isSingle, singleResult, coupleResult, recipientNames }: Props =
-    $props();
+  let { isSingle, singleResult, coupleResult, recipients }: Props = $props();
 
   function formatAge(age: MonthDuration): string {
     const years = age.years();
@@ -23,64 +24,240 @@
     return `${years}y ${months}m`;
   }
 
+  function formatFilingDateFull(
+    recipient: Recipient,
+    age: MonthDuration
+  ): string {
+    const date = recipient.birthdate.dateAtLayAge(age);
+    return `${date.monthFullName()} ${date.year()}`;
+  }
+
   function formatMoney(cents: number): string {
     return Money.fromCents(Math.round(cents)).string();
   }
 </script>
 
-{#if isSingle && singleResult}
-  <div class="headline">
-    <h3>Recommended Filing Age</h3>
-    <p class="recommendation">
-      File at age <strong>{formatAge(singleResult.filingAge)}</strong>
-    </p>
-    <p class="npv">
-      Expected lifetime benefit (NPV):
-      <strong>{formatMoney(singleResult.expectedNPVCents)}</strong>
-    </p>
-  </div>
-{:else if !isSingle && coupleResult}
-  <div class="headline">
-    <h3>Recommended Filing Ages</h3>
-    <p class="recommendation">
-      {recipientNames[0]}: file at age
-      <strong>{formatAge(coupleResult.filingAges[0])}</strong>
-      &nbsp;/&nbsp;
-      {recipientNames[1]}: file at age
-      <strong>{formatAge(coupleResult.filingAges[1])}</strong>
-    </p>
-    <p class="npv">
-      Expected combined lifetime benefit (NPV):
-      <strong>{formatMoney(coupleResult.expectedNPVCents)}</strong>
-    </p>
+{#if (isSingle && singleResult) || (!isSingle && coupleResult)}
+  <div class="headline" class:couple={!isSingle}>
+    <div class="kicker">
+      <svg
+        class="kicker-icon"
+        viewBox="0 0 20 20"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.25"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="4 10 8 14 16 6" />
+      </svg>
+      <span>Recommended filing{isSingle ? "" : " ages"}</span>
+    </div>
+
+    {#if isSingle && singleResult}
+      <div class="result">
+        <div class="prefix">File in</div>
+        <div class="date-big">
+          {formatFilingDateFull(recipients[0], singleResult.filingAge)}
+        </div>
+        <div class="age-sub">
+          at age {formatAge(singleResult.filingAge)}
+        </div>
+      </div>
+    {:else if coupleResult}
+      <div class="couple-results">
+        <div class="result">
+          <div class="person-name">
+            <RecipientName r={recipients[0]} />
+          </div>
+          <div class="prefix">File in</div>
+          <div class="date-big">
+            {formatFilingDateFull(recipients[0], coupleResult.filingAges[0])}
+          </div>
+          <div class="age-sub">
+            at age {formatAge(coupleResult.filingAges[0])}
+          </div>
+        </div>
+        <div class="divider" aria-hidden="true"></div>
+        <div class="result">
+          <div class="person-name">
+            <RecipientName r={recipients[1]} />
+          </div>
+          <div class="prefix">File in</div>
+          <div class="date-big">
+            {formatFilingDateFull(recipients[1], coupleResult.filingAges[1])}
+          </div>
+          <div class="age-sub">
+            at age {formatAge(coupleResult.filingAges[1])}
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    <div class="footer">
+      <div class="npv-line">
+        <span class="npv-label">
+          Expected {isSingle ? "" : "combined "}lifetime benefit (NPV):
+        </span>
+        <strong class="npv-value">
+          {#if isSingle && singleResult}
+            {formatMoney(singleResult.expectedNPVCents)}
+          {:else if coupleResult}
+            {formatMoney(coupleResult.expectedNPVCents)}
+          {/if}
+        </strong>
+      </div>
+      <p class="explanation">
+        {#if isSingle}
+          Maximizes your expected lifetime benefits, weighted by the
+          probability of surviving to each age and adjusted for the discount
+          rate.
+        {:else}
+          Maximizes your expected combined lifetime benefits, weighted by
+          each person's probability of surviving to each age and adjusted for
+          the discount rate.
+        {/if}
+      </p>
+    </div>
   </div>
 {/if}
 
 <style>
   .headline {
-    margin: 1rem auto;
-    padding: 1rem 1.5rem;
-    border: 2px solid #2a7ae2;
-    border-radius: 8px;
-    background: #f0f7ff;
-    max-width: 600px;
+    margin: 0.5rem auto 1.5rem;
+    padding: 1.25rem 2rem 1.1rem;
+    border-radius: 14px;
+    background: #ffffff;
+    color: #060606;
+    max-width: 720px;
     text-align: center;
+    border: 1px solid #e5e7eb;
+    box-shadow:
+      0 2px 6px rgba(11, 17, 48, 0.06),
+      0 18px 36px -16px rgba(11, 17, 48, 0.22);
   }
 
-  .headline h3 {
-    margin: 0 0 0.5rem 0;
-    font-size: 1.1rem;
-    color: #333;
+  .kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: #081d88;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.14rem;
+    text-transform: uppercase;
+    margin-bottom: 1.1rem;
   }
 
-  .recommendation {
-    font-size: 1.25rem;
-    margin: 0.25rem 0;
+  .kicker-icon {
+    display: block;
+    color: #081d88;
   }
 
-  .npv {
+  .result {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.1rem;
+  }
+
+  .prefix {
     font-size: 0.95rem;
-    color: #555;
-    margin: 0.25rem 0 0 0;
+    color: #6b7280;
+    font-weight: 500;
+  }
+
+  .date-big {
+    font-size: 3rem;
+    font-weight: 900;
+    line-height: 1.05;
+    letter-spacing: -0.02em;
+    color: #060606;
+    margin: 0.15rem 0 0.35rem;
+  }
+
+  .age-sub {
+    font-size: 1rem;
+    color: #4b5563;
+    font-weight: 500;
+  }
+
+  .couple-results {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 1.25rem;
+    margin-top: 0.3rem;
+  }
+
+  .couple-results .result {
+    min-width: 0;
+  }
+
+  .couple-results .date-big {
+    font-size: 2.25rem;
+  }
+
+  .divider {
+    width: 1px;
+    height: 70%;
+    background: #e5e7eb;
+  }
+
+  .person-name {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin-bottom: 0.3rem;
+  }
+
+  .footer {
+    margin-top: 1.4rem;
+    padding-top: 1rem;
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .npv-line {
+    font-size: 0.9rem;
+    color: #4b5563;
+  }
+
+  .npv-label {
+    color: #4b5563;
+  }
+
+  .npv-value {
+    color: #060606;
+    font-weight: 700;
+  }
+
+  .explanation {
+    font-size: 0.78rem;
+    color: #6b7280;
+    margin: 0.5rem auto 0;
+    line-height: 1.45;
+    max-width: 52ch;
+  }
+
+  @media (max-width: 640px) {
+    .headline {
+      padding: 1.5rem 1.25rem 1.25rem;
+    }
+    .date-big {
+      font-size: 2.5rem;
+    }
+    .couple-results {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+    .couple-results .date-big {
+      font-size: 2rem;
+    }
+    .divider {
+      width: 70%;
+      height: 1px;
+    }
   }
 </style>

--- a/src/routes/strategy/components/OptimalStrategyHeadline.svelte
+++ b/src/routes/strategy/components/OptimalStrategyHeadline.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import RecipientName from "$lib/components/RecipientName.svelte";
   import { Money } from "$lib/money";
-  import { MonthDuration } from "$lib/month-time";
+  import type { MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import type {
     FilingAgeResult,

--- a/src/routes/strategy/components/RecipientInputs.svelte
+++ b/src/routes/strategy/components/RecipientInputs.svelte
@@ -42,10 +42,16 @@
       const year = Number(yearStr);
       const month = Number(monthStr);
       const day = Number(dayStr);
+      // Range-check before constructing Birthdate: FromYMD throws on
+      // out-of-range values (e.g. year < 1900), which would otherwise
+      // surface as an unhandled exception inside onMount.
       if (
-        !Number.isNaN(year) &&
-        !Number.isNaN(month) &&
-        !Number.isNaN(day)
+        year >= 1900 &&
+        year <= 2100 &&
+        month >= 1 &&
+        month <= 12 &&
+        day >= 1 &&
+        day <= 31
       ) {
         birthdates[index] = Birthdate.FromYMD(year, month - 1, day);
       }

--- a/src/routes/strategy/components/RecipientInputs.svelte
+++ b/src/routes/strategy/components/RecipientInputs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Birthdate } from "$lib/birthday";
   import BirthdateInput from "$lib/components/BirthdateInput.svelte";
+  import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
   import { Money } from "$lib/money";
   import type { Recipient } from "$lib/recipient";
@@ -36,15 +37,17 @@
 
   onMount(() => {
     birthdateInputs.forEach((dateStr, index) => {
-      if (dateStr) {
-        const date = new Date(dateStr);
-        if (!Number.isNaN(date.getTime())) {
-          birthdates[index] = Birthdate.FromYMD(
-            date.getFullYear(),
-            date.getMonth(),
-            date.getDate()
-          );
-        }
+      if (!dateStr) return;
+      const [yearStr, monthStr, dayStr] = dateStr.split("-");
+      const year = Number(yearStr);
+      const month = Number(monthStr);
+      const day = Number(dayStr);
+      if (
+        !Number.isNaN(year) &&
+        !Number.isNaN(month) &&
+        !Number.isNaN(day)
+      ) {
+        birthdates[index] = Birthdate.FromYMD(year, month - 1, day);
       }
     });
     // Seed PIA validity from the current values so Continue's disabled state
@@ -113,6 +116,10 @@
     onUpdate?.();
   }
 
+  function handleSubmit() {
+    if (!continueDisabled) oncontinue?.();
+  }
+
   function formatDateForInput(birthdate: Birthdate | null): string {
     if (!birthdate) return "";
     const year = birthdate.layBirthYear();
@@ -122,47 +129,108 @@
   }
 </script>
 
-<div class="form-header">
-  <h2>Recipient information</h2>
-  <button type="button" class="startover-link" on:click={() => onstartover?.()}>
-    ← Start over
-  </button>
-</div>
+<form
+  class="form-wrapper"
+  class:single={isSingle}
+  on:submit|preventDefault={handleSubmit}
+>
+  <header class="form-header">
+    <div class="form-title-block">
+      <h2>Tell us about {isSingle ? "you" : "you and your spouse"}</h2>
+      <p class="form-hint">
+        A few quick details to find your optimal filing strategy.
+      </p>
+    </div>
+    <button
+      type="button"
+      class="back-btn"
+      on:click={() => onstartover?.()}
+    >
+      <svg
+        class="back-arrow"
+        viewBox="0 0 16 16"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.75"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M10 3 5 8l5 5" />
+      </svg>
+      Start over
+    </button>
+  </header>
 
-<div class="input-grid" class:single={isSingle}>
-  {#each recipients as recipient, i}
-    {#if !isSingle || i === 0}
-      <div class="recipient-column">
-        <div class="input-group">
-          <label for="name{i}">Name:</label>
-          <input
-            id="name{i}"
-            type="text"
-            value={recipient.name}
-            on:input={(event) => handleNameChange(i, event)}
-          />
-        </div>
-        <div class="input-group">
-          <label for="pia{i}">
-            <RecipientName r={recipient} apos /> Primary Insurance Amount (PIA):
-          </label>
-          <input
-            id="pia{i}"
-            type="number"
-            step="100"
-            min="0"
-            value={piaValues[i] ?? ""}
-            class:invalid={!piaValidity[i]}
-            on:input={(event) =>
-              handlePiaChange(i, parsePiaInput(event.currentTarget.value))}
-          />
-          {#if !piaValidity[i] && piaErrors[i]}
-            <span class="error-message">{piaErrors[i]}</span>
-          {/if}
-        </div>
+  <div class="input-grid" class:single={isSingle}>
+    {#each recipients as recipient, i}
+      {#if !isSingle || i === 0}
+        <div class="recipient-column">
+        {#if !isSingle}
+          <div class="input-pair">
+            <div class="input-group">
+              <label for="name{i}">
+                Name
+                <InfoTip label="Why we ask for a name">
+                  Shown throughout the results so you can tell strategies
+                  apart, especially when comparing options for a couple.
+                </InfoTip>
+              </label>
+              <input
+                id="name{i}"
+                type="text"
+                value={recipient.name}
+                on:input={(event) => handleNameChange(i, event)}
+              />
+            </div>
+            <div class="input-group">
+              <label for="gender{i}">
+                <RecipientName r={recipient} apos>Your</RecipientName> gender
+                <InfoTip label="Why we ask for gender">
+                  SSA mortality tables differ by sex, so we use this to
+                  estimate life expectancy. Leave as <em>Unspecified</em> for
+                  a blended estimate.
+                </InfoTip>
+              </label>
+              <select
+                id="gender{i}"
+                value={recipient.gender}
+                on:change={(event) => handleGenderChange(i, event)}
+                class="select-input"
+              >
+                <option value="blended">Unspecified</option>
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+              </select>
+            </div>
+          </div>
+        {:else}
+          <div class="input-group">
+            <label for="gender{i}">
+              <RecipientName r={recipient} apos>Your</RecipientName> gender
+              <InfoTip label="Why we ask for gender">
+                SSA mortality tables differ by sex, so we use this to estimate
+                life expectancy. Leave as <em>Unspecified</em> for a blended
+                estimate.
+              </InfoTip>
+            </label>
+            <select
+              id="gender{i}"
+              value={recipient.gender}
+              on:change={(event) => handleGenderChange(i, event)}
+              class="select-input"
+            >
+              <option value="blended">Unspecified</option>
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+            </select>
+          </div>
+        {/if}
         <div class="input-group">
           <label for="birthdate{i}">
-            <RecipientName r={recipient} apos /> Birthdate:
+            <RecipientName r={recipient} apos>Your</RecipientName> birthdate
           </label>
           <BirthdateInput
             bind:birthdate={birthdates[i]}
@@ -172,19 +240,45 @@
           />
         </div>
         <div class="input-group">
-          <label for="gender{i}">
-            <RecipientName r={recipient} apos /> Gender (for mortality calculation):
+          <label for="pia{i}">
+            <RecipientName r={recipient} apos>Your</RecipientName> Primary Insurance
+            Amount (PIA)
           </label>
-          <select
-            id="gender{i}"
-            value={recipient.gender}
-            on:change={(event) => handleGenderChange(i, event)}
-            class="select-input"
-          >
-            <option value="blended">Unspecified</option>
-            <option value="male">Male</option>
-            <option value="female">Female</option>
-          </select>
+          <div class="currency-input">
+            <span class="currency-prefix" aria-hidden="true">$</span>
+            <input
+              id="pia{i}"
+              class="pia-input"
+              type="number"
+              step="100"
+              min="0"
+              inputmode="numeric"
+              value={piaValues[i] ?? ""}
+              class:invalid={piaValues[i] !== null && !piaValidity[i]}
+              on:input={(event) =>
+                handlePiaChange(i, parsePiaInput(event.currentTarget.value))}
+            />
+          </div>
+          {#if piaValues[i] !== null && !piaValidity[i] && piaErrors[i]}
+            <span class="error-message">{piaErrors[i]}</span>
+          {/if}
+          <a class="pia-helper" href="/calculator" tabindex="-1">
+            <span>Don't know your PIA? Start here first</span>
+            <svg
+              class="pia-helper-arrow"
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M6 3l5 5-5 5" />
+            </svg>
+          </a>
         </div>
       </div>
     {/if}
@@ -197,134 +291,257 @@
 
 <div class="actions">
   <button
-    type="button"
+    type="submit"
     class="continue-button"
     disabled={continueDisabled}
-    on:click={() => oncontinue?.()}
     title={continueDisabled ? "Fill in all required fields to continue" : ""}
   >
     Continue →
   </button>
 </div>
+</form>
 
 <style>
+  .form-wrapper.single {
+    max-width: 560px;
+    margin: 0 auto;
+  }
+
   .form-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+  }
+  .form-title-block {
+    flex: 1 1 auto;
+    min-width: 0;
   }
   .form-header h2 {
     margin: 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #060606;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
   }
-  .startover-link {
-    background: transparent;
-    border: none;
-    color: #0074d9;
-    cursor: pointer;
-    font-size: 0.9rem;
-    padding: 0.2rem 0.3rem;
+  .form-hint {
+    margin: 0.4rem 0 0;
+    font-size: 0.95rem;
+    color: #6b7280;
+    line-height: 1.45;
+  }
+  .back-btn {
+    flex: 0 0 auto;
+    background: white;
+    border: 1px solid #d1d5db;
+    color: #4b5563;
+    padding: 0.4rem 0.75rem;
+    border-radius: 6px;
     font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition:
+      border-color 0.15s ease,
+      color 0.15s ease,
+      background-color 0.15s ease;
   }
-  .startover-link:hover,
-  .startover-link:focus {
-    text-decoration: underline;
+  .back-btn:hover,
+  .back-btn:focus-visible {
+    border-color: #081d88;
+    color: #081d88;
+    background-color: #f7f8fd;
     outline: none;
+  }
+  .back-arrow {
+    display: block;
+    transition: transform 0.15s ease;
+  }
+  .back-btn:hover .back-arrow,
+  .back-btn:focus-visible .back-arrow {
+    transform: translateX(-2px);
   }
 
   .input-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 2rem;
+    gap: 2.5rem;
   }
   .input-grid.single {
     grid-template-columns: 1fr;
-    max-width: 600px;
-    margin: 0 auto;
   }
   .recipient-column {
     display: flex;
     flex-direction: column;
+    gap: 1.15rem;
+  }
+  .input-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     gap: 1rem;
   }
   .input-group {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4rem;
   }
   .input-group label {
-    font-weight: bold;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #1f2937;
   }
-  .input-group input:not([type="range"]) {
-    font-size: 1.2em;
-    line-height: 1.3;
-    height: 2.5em;
-    padding: 5px;
-    border: 2px solid #0b0c0c;
-    border-radius: 0;
+  .input-group input:not([type="range"]),
+  .select-input {
+    font-size: 1rem;
+    line-height: 1.4;
+    padding: 0.65rem 0.85rem;
+    border: 1.5px solid #d1d5db;
+    border-radius: 6px;
+    background-color: white;
+    color: #0b0c0c;
+    font-family: inherit;
     appearance: none;
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
   .input-group input:not([type="range"]):focus,
-  .input-group select:focus {
-    outline: 3px solid #fd0;
-    outline-offset: 0;
-    box-shadow: inset 0 0 0 2px;
+  .select-input:focus {
+    outline: none;
+    border-color: #081d88;
+    box-shadow: 0 0 0 3px rgba(8, 29, 136, 0.15);
   }
   .input-group input.invalid {
     border-color: #d4351c;
-    background-color: #fee;
+    background-color: #fef5f5;
+  }
+  .input-group input.invalid:focus {
+    box-shadow: 0 0 0 3px rgba(212, 53, 28, 0.15);
   }
   .error-message {
     color: #d4351c;
-    font-size: 0.9em;
-    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    margin-top: 0.15rem;
+  }
+  .currency-input {
+    position: relative;
+    max-width: 180px;
+  }
+  .currency-prefix {
+    position: absolute;
+    left: 0.85rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6b7280;
+    font-weight: 500;
+    pointer-events: none;
+    user-select: none;
+  }
+  .input-group input.pia-input {
+    width: 100%;
+    padding-left: 1.75rem;
+  }
+  .pia-helper {
+    margin-top: 0.45rem;
+    font-size: 0.85rem;
+    color: #081d88;
+    text-decoration: none;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: fit-content;
+    transition: color 0.15s ease;
+  }
+  .pia-helper:hover span,
+  .pia-helper:focus-visible span {
+    text-decoration: underline;
+  }
+  .pia-helper:hover,
+  .pia-helper:focus-visible {
+    color: #05126b;
+    outline: none;
+  }
+  .pia-helper-arrow {
+    display: block;
+    transition: transform 0.15s ease;
+  }
+  .pia-helper:hover .pia-helper-arrow,
+  .pia-helper:focus-visible .pia-helper-arrow {
+    transform: translateX(2px);
   }
   .select-input {
-    font-size: 1.2em;
-    line-height: 1.3;
-    height: 2.5em;
-    padding: 5px;
-    border: 2px solid #0b0c0c;
-    border-radius: 0;
-    appearance: none;
-    background-color: white;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23000000' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23374151' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right 10px center;
-    padding-right: 30px;
+    background-position: right 12px center;
+    padding-right: 32px;
   }
 
   .error-banner {
-    margin-top: 1rem;
-    padding: 0.6rem 0.9rem;
-    background: #fee;
-    border: 1px solid #d4351c;
+    margin-top: 1.25rem;
+    padding: 0.7rem 0.95rem;
+    background: #fef5f5;
+    border: 1px solid #f0c5c0;
     color: #a1241a;
-    border-radius: 4px;
+    border-radius: 6px;
     font-size: 0.9rem;
   }
 
   .actions {
-    margin-top: 1.25rem;
+    margin-top: 1.75rem;
     display: flex;
     justify-content: flex-end;
+    align-items: center;
   }
   .continue-button {
-    background-color: #007bff;
+    background-color: #081d88;
     color: white;
     border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: 4px;
+    padding: 0.75rem 1.75rem;
+    border-radius: 6px;
     cursor: pointer;
     font-size: 1rem;
+    font-weight: 600;
+    font-family: inherit;
+    box-shadow: 0 1px 2px rgba(11, 17, 48, 0.18);
+    transition:
+      background-color 0.15s ease,
+      transform 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+  .continue-button:hover:not(:disabled) {
+    background-color: #05126b;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(11, 17, 48, 0.28);
+  }
+  .continue-button:focus-visible:not(:disabled) {
+    background-color: #05126b;
+    box-shadow:
+      0 0 0 3px rgba(8, 29, 136, 0.3),
+      0 4px 12px rgba(11, 17, 48, 0.25);
+    outline: none;
+  }
+  .continue-button:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 1px 2px rgba(11, 17, 48, 0.25);
   }
   .continue-button:disabled {
-    background-color: #ccc;
+    background-color: #c7ccd6;
     cursor: not-allowed;
+    box-shadow: none;
   }
 
   @media (max-width: 768px) {
     .input-grid {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+    .input-pair {
       grid-template-columns: 1fr;
     }
   }

--- a/src/routes/strategy/components/StrategyDetails.svelte
+++ b/src/routes/strategy/components/StrategyDetails.svelte
@@ -157,7 +157,7 @@
                 <div class="period-info">
                   <span class="benefit-type">{period.type}</span>
                   <span class="period-dates"
-                    >{period.startFormatted} — {period.endFormatted}</span
+                    >{period.startFormatted} – {period.endFormatted}</span
                   >
                 </div>
                 <div class="benefit-amounts">
@@ -182,7 +182,7 @@
                 <div class="period-info">
                   <span class="benefit-type">{period.type}</span>
                   <span class="period-dates"
-                    >{period.startFormatted} — {period.endFormatted}</span
+                    >{period.startFormatted} – {period.endFormatted}</span
                   >
                 </div>
                 <div class="benefit-amounts">

--- a/src/routes/strategy/components/StrategyDetailsSingle.svelte
+++ b/src/routes/strategy/components/StrategyDetailsSingle.svelte
@@ -65,7 +65,7 @@
         {#each formattedPeriods as period}
           <div class="payment-period">
             <div class="period-dates">
-              {period.startFormatted} — {period.endFormatted}
+              {period.startFormatted} – {period.endFormatted}
             </div>
             <div class="benefit-amounts">
               <span class="monthly-amount">{period.amount}/mo</span>

--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -307,13 +307,6 @@ function handleCellSelect(position: CellPosition) {
       />
     </h4>
   </div>
-  <div class="matrix-legend">
-    <p>
-      <strong>Size</strong>: Row and Column width / height indicate the relative
-      probability of each person's death at that age range.
-    </p>
-  </div>
-
   <div class="strategy-grid-container">
     <!-- Column headers -->
     <div class="grid-headers">
@@ -441,7 +434,7 @@ function handleCellSelect(position: CellPosition) {
           <strong>Age Range:</strong>
           {#if headerHoverInfo.bucket?.endAgeInclusive !== null}
             {headerHoverInfo.bucket?.startAge}y
-            <span class="age-range-dash">—</span>
+            <span class="age-range-dash">–</span>
             {headerHoverInfo.bucket?.endAgeInclusive}y + 11m
           {:else}
             {headerHoverInfo.bucket?.startAge}+
@@ -493,17 +486,6 @@ function handleCellSelect(position: CellPosition) {
   .matrix-title h4 {
     margin: 0;
     color: #0056b3;
-  }
-
-  .matrix-legend {
-    margin-bottom: 1rem;
-    padding: 1rem;
-    background-color: #e9ecef;
-    border-radius: 4px;
-  }
-
-  .matrix-legend p {
-    margin: 0.5rem 0;
   }
 
   .strategy-grid-container {

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import HowToReadChart from '$lib/components/HowToReadChart.svelte';
 import type { Recipient } from '$lib/recipient';
 import type {
   CalculationResults,
@@ -32,31 +33,70 @@ function handleHoverCell(detail: CellPosition | null) {
 <div class="result-box">
   <div class="header-section">
     <div class="header-content">
-      <h3>
-        Optimal Strategies: Filing <span
+      <h3>How death ages shape the strategies</h3>
+      <div class="segmented" role="group" aria-label="Display filing as">
+        <button
+          type="button"
+          class="seg"
           class:active={!displayAsAges}
-          class:inactive={displayAsAges}>Date</span
-        ><label class="toggle-label">
-          <input
-            type="checkbox"
-            bind:checked={displayAsAges}
-            class="toggle-checkbox"
-          />
-          <span class="toggle-slider"></span>
-        </label><span
-          class:active={displayAsAges}
-          class:inactive={!displayAsAges}>Age</span
+          on:click={() => (displayAsAges = false)}
         >
-      </h3>
+          Date
+        </button>
+        <button
+          type="button"
+          class="seg"
+          class:active={displayAsAges}
+          on:click={() => (displayAsAges = true)}
+        >
+          Age
+        </button>
+      </div>
     </div>
   </div>
-  <p>
-    Calculation completed in {calculationResults.timeElapsed().toFixed(2)} seconds
+  <p class="lede">
+    Every combination of lifespans has its own optimal filing strategy. The
+    <strong>Recommended Filing Ages</strong> above pick a single strategy
+    that works well across all of them; below, see what would be optimal at
+    each specific combination.
   </p>
-  <p>
-    Tables show optimal filing {displayAsAges ? 'ages' : 'dates'} for each recipient
-    across different death age combinations
+  <p class="caption">
+    Each cell shows the optimal filing {displayAsAges ? 'age' : 'date'} for a
+    specific Self/Spouse death-age pair. <em>Taller rows</em> and
+    <em>wider columns</em> mark more likely death ages.
   </p>
+  <HowToReadChart>
+    <ul>
+      <li>
+        <strong>Two matrices:</strong> the left one shows Self's optimal
+        filing {displayAsAges ? 'age' : 'date'}; the right one shows Spouse's.
+        Both depend on <em>both</em> death ages because of survivor benefits.
+      </li>
+      <li>
+        <strong>Row / column position:</strong> your death age on one axis,
+        your spouse's on the other. Each cell is one specific pair.
+      </li>
+      <li>
+        <strong>Row height &amp; column width:</strong> probability of that
+        death age. Big cells are likely outcomes; tiny cells are edge cases.
+      </li>
+      <li>
+        <strong>Cell color:</strong> similar strategies share a color, so
+        large bands of one color mean the same strategy is optimal across
+        many scenarios.
+      </li>
+      <li>
+        <strong>Click a cell</strong> to see the full month-by-month benefit
+        breakdown for that death-age pair.
+      </li>
+    </ul>
+    <p>
+      <strong>Takeaway:</strong> focus on the large, dense cells. Those are
+      the most likely outcomes and they drive the Recommended Filing Ages. A
+      single strategy usually covers most of the probability mass, which is
+      why one recommendation is useful even across many possible lifespans.
+    </p>
+  </HowToReadChart>
 
   {#if calculationResults.status() === CalculationStatus.Complete}
     <div class="matrices-container">
@@ -99,63 +139,70 @@ function handleHoverCell(detail: CellPosition | null) {
 
   .header-content h3 {
     margin: 0;
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #060606;
   }
 
-  .toggle-label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
+  .lede {
+    margin: 0.6rem 0 0;
+    font-size: 0.95rem;
+    color: #1f2937;
+    line-height: 1.5;
+  }
+
+  .caption {
+    margin: 0.35rem 0 0;
+    font-size: 0.85rem;
+    color: #6b7280;
+    line-height: 1.5;
+  }
+
+  .caption em {
+    font-style: normal;
+    color: #4b5563;
+    font-weight: 500;
+  }
+
+  .segmented {
+    display: inline-flex;
+    background: #eef1f5;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 3px;
     flex-shrink: 0;
-    margin: 0 0.25rem;
   }
 
-  .active {
-    font-weight: bold;
-    color: #007bff;
+  .seg {
+    font: inherit;
+    border: none;
+    background: transparent;
+    color: #4b5563;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.88rem;
+    font-weight: 500;
+    border-radius: 6px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
-  .inactive {
-    font-weight: normal;
-    color: #999;
-    opacity: 0.7;
+  .seg:hover:not(.active) {
+    color: #081d88;
   }
 
-  .toggle-checkbox {
-    display: none;
+  .seg.active {
+    background: #ffffff;
+    color: #081d88;
+    font-weight: 600;
+    box-shadow: 0 1px 2px rgba(11, 17, 48, 0.08);
   }
 
-  .toggle-slider {
-    position: relative;
-    width: 40px;
-    height: 20px;
-    background-color: #ccc;
-    border-radius: 20px;
-    transition: background-color 0.3s ease;
-  }
-
-  .toggle-slider::before {
-    content: '';
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 16px;
-    height: 16px;
-    background-color: white;
-    border-radius: 50%;
-    transition: transform 0.3s ease;
-  }
-
-  .toggle-checkbox:checked + .toggle-slider {
-    background-color: #007bff;
-  }
-
-  .toggle-checkbox:checked + .toggle-slider::before {
-    transform: translateX(20px);
+  .seg:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 2px;
   }
 
   .matrices-container {

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -218,7 +218,7 @@ function handleHoverCell(detail: CellPosition | null) {
       gap: 2rem;
     }
 
-    .header-content h3 {
+    .header-content {
       flex-direction: column;
       align-items: flex-start;
       gap: 0.5rem;

--- a/src/routes/strategy/components/StrategyOverview.svelte
+++ b/src/routes/strategy/components/StrategyOverview.svelte
@@ -183,7 +183,7 @@
                   <div class="period-info">
                     <span class="benefit-type">{period.type}</span>
                     <span class="period-dates"
-                      >{period.startFormatted} — {period.endFormatted}</span
+                      >{period.startFormatted} – {period.endFormatted}</span
                     >
                   </div>
                   <div class="benefit-amounts">
@@ -208,7 +208,7 @@
                   <div class="period-info">
                     <span class="benefit-type">{period.type}</span>
                     <span class="period-dates"
-                      >{period.startFormatted} — {period.endFormatted}</span
+                      >{period.startFormatted} – {period.endFormatted}</span
                     >
                   </div>
                   <div class="benefit-amounts">

--- a/src/routes/strategy/components/StrategyPlotSingle.svelte
+++ b/src/routes/strategy/components/StrategyPlotSingle.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import HowToReadChart from "$lib/components/HowToReadChart.svelte";
   import { MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import type { CalculationResults } from "$lib/strategy/ui";
@@ -637,23 +638,66 @@
 <div class="result-box">
   <div class="header-section">
     <div class="header-content">
-      <h3>
-        Optimal Strategy: Filing <span
+      <h3>How death age shapes the strategy</h3>
+      <div class="segmented" role="group" aria-label="Display filing as">
+        <button
+          type="button"
+          class="seg"
           class:active={!displayAsAges}
-          class:inactive={displayAsAges}>Date</span
-        ><label class="toggle-label">
-          <input
-            type="checkbox"
-            bind:checked={displayAsAges}
-            class="toggle-checkbox"
-          />
-          <span class="toggle-slider"></span>
-        </label><span
-          class:active={displayAsAges}
-          class:inactive={!displayAsAges}>Age</span
+          on:click={() => (displayAsAges = false)}
         >
-      </h3>
+          Date
+        </button>
+        <button
+          type="button"
+          class="seg"
+          class:active={displayAsAges}
+          on:click={() => (displayAsAges = true)}
+        >
+          Age
+        </button>
+      </div>
     </div>
+    <p class="lede">
+      Every death age has its own optimal filing. The
+      <strong>Recommended Filing</strong> above picks a single strategy that
+      works well across all of them; below, see what would be optimal at each
+      specific age.
+    </p>
+    <p class="caption">
+      The blue line shows the optimal filing {displayAsAges
+        ? "age"
+        : "date"} for each possible death age; the red line shows your cumulative
+      probability of dying by that age.
+    </p>
+    <HowToReadChart>
+      <ul>
+        <li>
+          <strong>X-axis (Death Age):</strong> a hypothetical age you live to.
+        </li>
+        <li>
+          <strong>Blue line (left axis):</strong> the filing {displayAsAges
+            ? "age"
+            : "date"} that would have maximized your lifetime benefits
+          <em>if</em> you knew you'd live exactly to that death age.
+        </li>
+        <li>
+          <strong>Red line (right axis):</strong> cumulative probability
+          you've died by that age. Steeper means a larger fraction of
+          outcomes fall in that range.
+        </li>
+        <li>
+          <strong>Hover the chart</strong> to see the values at each death
+          age.
+        </li>
+      </ul>
+      <p>
+        <strong>Takeaway:</strong> short lifespans favor filing early; long
+        lifespans favor delaying. The Recommended Filing picks the best
+        single date across the whole distribution, weighted by how likely
+        each lifespan is.
+      </p>
+    </HowToReadChart>
   </div>
 
   <div class="chart-container">
@@ -683,64 +727,74 @@
     padding-bottom: 1rem;
   }
 
+  .header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
   .header-content h3 {
     margin: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #060606;
   }
 
-  .toggle-label {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
+  .lede {
+    margin: 0.6rem 0 0;
+    font-size: 0.95rem;
+    color: #1f2937;
+    line-height: 1.5;
+  }
+
+  .caption {
+    margin: 0.35rem 0 0;
+    font-size: 0.85rem;
+    color: #6b7280;
+    line-height: 1.5;
+  }
+
+
+  .segmented {
+    display: inline-flex;
+    background: #eef1f5;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 3px;
     flex-shrink: 0;
-    margin: 0 0.25rem;
   }
 
-  .active {
-    font-weight: bold;
-    color: #007bff;
+  .seg {
+    font: inherit;
+    border: none;
+    background: transparent;
+    color: #4b5563;
+    padding: 0.35rem 0.9rem;
+    font-size: 0.88rem;
+    font-weight: 500;
+    border-radius: 6px;
+    cursor: pointer;
+    transition:
+      background-color 0.15s ease,
+      color 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
-  .inactive {
-    font-weight: normal;
-    color: #999;
-    opacity: 0.7;
+  .seg:hover:not(.active) {
+    color: #081d88;
   }
 
-  .toggle-checkbox {
-    display: none;
+  .seg.active {
+    background: #ffffff;
+    color: #081d88;
+    font-weight: 600;
+    box-shadow: 0 1px 2px rgba(11, 17, 48, 0.08);
   }
 
-  .toggle-slider {
-    position: relative;
-    width: 40px;
-    height: 20px;
-    background-color: #ccc;
-    border-radius: 20px;
-    transition: background-color 0.3s ease;
-  }
-
-  .toggle-slider::before {
-    content: "";
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 16px;
-    height: 16px;
-    background-color: white;
-    border-radius: 50%;
-    transition: transform 0.3s ease;
-  }
-
-  .toggle-checkbox:checked + .toggle-slider {
-    background-color: #007bff;
-  }
-
-  .toggle-checkbox:checked + .toggle-slider::before {
-    transform: translateX(20px);
+  .seg:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 2px;
   }
 
   .chart-container {

--- a/src/routes/strategy/components/TunableAssumptions.svelte
+++ b/src/routes/strategy/components/TunableAssumptions.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
   import type { Recipient } from "$lib/recipient";
   import DiscountRateInput from "./DiscountRateInput.svelte";
@@ -8,6 +9,8 @@
   export let discountRatePercent: number;
   export let onRecipientUpdate: () => void;
   export let onDiscountRateValidityChange: (valid: boolean) => void;
+  /** Parent signals when the sticky wrapper has pinned to the viewport. */
+  export let isStuck: boolean = false;
 
   function handleHealthChange(index: number, sliderValue: number) {
     // Slider [0.7, 2.5] maps to health [2.5, 0.7] — inverted so right = better.
@@ -38,22 +41,39 @@
     }
     return best.label;
   }
+
+  function getShortHealthCategory(multiplier: number): string {
+    return getHealthCategory(multiplier).replace(/\s*Health$/, "");
+  }
 </script>
 
-<div class="tunable-title"><strong>Tunable assumptions</strong></div>
+<div class="tunable-wrapper" class:is-compact={isStuck}>
+  <div class="tunable-title"><strong>Tunable assumptions</strong></div>
 
-<div class="health-cards" class:single={isSingle}>
+  <div class="health-cards" class:single={isSingle}>
   {#each recipients as recipient, i}
     {#if !isSingle || i === 0}
       <div class="health-card">
         <div class="row">
           <span>
-            <RecipientName r={recipient} apos /> health
+            <RecipientName r={recipient} apos>Your</RecipientName> health
+            <InfoTip label="About mortality and health assumptions">
+              Mortality assumptions use SSA cohort life tables. Adjust
+              relative health using this slider. Learn more in the <a
+                href="/guides/mortality"
+                target="_blank"
+                rel="noopener">mortality &amp; health adjustment guide</a
+              >.
+            </InfoTip>
           </span>
           <span class="value">
-            {getHealthCategory(recipient.healthMultiplier)} ({recipient.healthMultiplier.toFixed(
-              1
-            )}x)
+            <span class="value-full"
+              >{getHealthCategory(recipient.healthMultiplier)}</span
+            >
+            <span class="value-short"
+              >{getShortHealthCategory(recipient.healthMultiplier)}</span
+            >
+            ({recipient.healthMultiplier.toFixed(1)}x)
           </span>
         </div>
         <div class="endlabels">
@@ -76,26 +96,93 @@
 </div>
 
 <div class="discount-row">
-  <DiscountRateInput
-    bind:discountRatePercent
-    onValidityChange={onDiscountRateValidityChange}
-  />
+    <DiscountRateInput
+      bind:discountRatePercent
+      {isStuck}
+      onValidityChange={onDiscountRateValidityChange}
+    />
+  </div>
 </div>
 
-<p class="mortality-guide-note">
-  Mortality assumptions use SSA cohort life tables. Adjust relative health using
-  the sliders above. Learn more in the <a
-    href="/guides/mortality"
-    target="_blank"
-    rel="noopener">mortality &amp; health adjustment guide</a
-  >.
-</p>
-
 <style>
+  .tunable-wrapper {
+    transition: padding 0.15s ease;
+  }
+
   .tunable-title {
     font-size: 0.95rem;
     color: #333;
     margin: 1rem 0 0.5rem;
+    transition:
+      margin 0.15s ease,
+      font-size 0.15s ease,
+      opacity 0.15s ease;
+  }
+
+  .value-short {
+    display: none;
+  }
+
+  /* Compact (sticky) layout: fit health sliders + discount controls on one row. */
+  .tunable-wrapper.is-compact {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .tunable-wrapper.is-compact .tunable-title {
+    display: none;
+  }
+
+  .tunable-wrapper.is-compact .health-cards,
+  .tunable-wrapper.is-compact .health-cards.single {
+    display: flex;
+    flex: 1 1 auto;
+    margin: 0;
+    gap: 0.5rem;
+    grid-template-columns: none;
+    max-width: none;
+  }
+
+  .tunable-wrapper.is-compact .health-card {
+    display: flex;
+    align-items: center;
+    flex: 1 1 280px;
+    min-width: 0;
+    padding: 0.35rem 0.6rem;
+    gap: 0.6rem;
+  }
+
+  .tunable-wrapper.is-compact .row {
+    flex: 0 0 auto;
+    justify-content: flex-start;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+  }
+
+  .tunable-wrapper.is-compact .value-full {
+    display: none;
+  }
+
+  .tunable-wrapper.is-compact .value-short {
+    display: inline;
+  }
+
+  .tunable-wrapper.is-compact .endlabels {
+    display: none;
+  }
+
+  .tunable-wrapper.is-compact .health-card input[type="range"] {
+    flex: 1 1 auto;
+    min-width: 80px;
+    height: 1em;
+    margin: 0;
+  }
+
+  .tunable-wrapper.is-compact .discount-row {
+    padding: 0.35rem 0.6rem;
+    flex: 0 1 auto;
   }
   .health-cards {
     display: grid;
@@ -105,7 +192,6 @@
   }
   .health-cards.single {
     grid-template-columns: 1fr;
-    max-width: 600px;
   }
   .health-card {
     background: white;
@@ -142,18 +228,6 @@
     border: 1px solid #ddd;
     border-radius: 6px;
     padding: 0.5rem 0.9rem;
-  }
-  .mortality-guide-note {
-    margin-top: 1rem;
-    font-size: 0.9rem;
-    color: #444;
-  }
-  .mortality-guide-note a {
-    color: #0074d9;
-    text-decoration: none;
-  }
-  .mortality-guide-note a:hover {
-    text-decoration: underline;
   }
   @media (max-width: 768px) {
     .health-cards {


### PR DESCRIPTION
## Summary

A multi-iteration polish pass on the `/strategy` page, going stage by stage from the mode picker through the recommendation card, sticky tunables, and the exploration widgets.

**Form:**
- Refined input system (light borders, brand-blue focus, 6px radius)
- Reordered: name → gender → birthdate → PIA
- Single mode drops the Name field and uses "Your ..." labels
- InfoTip explanations on key fields; compact currency PIA input with calculator link
- Start over moved to form header, matching Edit-recipient-info position in LockedSummary
- `<form>` wrapper so Enter submits when valid

**Recommended Filing hero:**
- Elevated white card with display-size filing date (Lato 900) and date as the primary line
- Twin-card couple layout with Self/Spouse color accents
- ✓ RECOMMENDED FILING kicker in brand blue
- Explanation calls out both survival probability and discount rate

**Tunable assumptions:**
- Compact single-row discount rate; InfoTips on each slider + discount
- Sticky with single-row compact layout when scrolled; placeholder preserves document height (no scroll jump)

**Matrix / single plot:**
- Reframed as exploratory ("How death age(s) shape the strategy")
- Apple-style segmented Date/Age toggle; Age is now the default
- New collapsible `HowToReadChart` panel with per-widget reading guide
- Removed per-matrix "Size:" legend; merged into caption

**New shared components:**
- `InfoTip` — hoverable/clickable info bubble with a bridge so interactive content (links) stays reachable
- `HowToReadChart` — collapsible reading-guide panel for charts

**Other:**
- BirthdateInput modernized (propagates to `/calculator`)
- Global `<Header />` added to `/strategy`
- No em-dashes in prose; en-dashes for date ranges
- Fixed state leak + timezone off-by-one in form round-trip

## Test plan
- [x] `npm run quality` — 0 errors, 0 warnings
- [x] `npm test` — 1899/1899 passing
- [ ] Manual: walk single-user mode end-to-end
- [ ] Manual: walk couple mode end-to-end
- [ ] Manual: Enter-to-submit works; Start over and Edit-recipient-info work
- [ ] Manual: scroll past tunable section, confirm no jump and compact layout engages
- [ ] Manual: "How to read this chart" expands and link inside tooltip is clickable
- [ ] Manual: segmented Date/Age toggle switches correctly