### PR TITLE
fix(strategy): scenario timeline uses expectedAge to match optimizer

### DIFF
--- a/src/routes/strategy/components/ScenarioDetail.svelte
+++ b/src/routes/strategy/components/ScenarioDetail.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
-  import { MonthDate, MonthDuration } from "$lib/month-time";
+  import type { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import { BenefitType } from "$lib/strategy/calculations/benefit-period";
   import { strategySumPeriodsCouple } from "$lib/strategy/calculations/strategy-calc";
@@ -39,13 +39,11 @@
   $: deathDate1 = recipients[0].birthdate.dateAtLayAge(expectedAge1);
   $: deathDate2 = recipients[1].birthdate.dateAtLayAge(expectedAge2);
 
+  // Use expectedAge (probability-weighted) so the timeline matches the death
+  // dates the optimizer used to compute totalBenefit and choose filingAge1/2.
   $: finalDates = [
-    recipients[0].birthdate.dateAtLayAge(
-      new MonthDuration(result.bucket1.midAge * 12)
-    ),
-    recipients[1].birthdate.dateAtLayAge(
-      new MonthDuration(result.bucket2.midAge * 12)
-    ),
+    recipients[0].birthdate.dateAtLayAge(result.bucket1.expectedAge),
+    recipients[1].birthdate.dateAtLayAge(result.bucket2.expectedAge),
   ] as [MonthDate, MonthDate];
 
   $: strats = [result.filingAge1, result.filingAge2] as [

--- a/src/routes/strategy/components/ScenarioDetailSingle.svelte
+++ b/src/routes/strategy/components/ScenarioDetailSingle.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
-  import { MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import { strategySumPeriodsSingle } from "$lib/strategy/calculations/strategy-calc";
   import type { StrategyResult } from "$lib/strategy/ui";
@@ -22,9 +21,9 @@
   $: expectedAge = result.bucket1.expectedAge;
   $: deathDate = recipient.birthdate.dateAtLayAge(expectedAge);
 
-  $: finalDate = recipient.birthdate.dateAtLayAge(
-    new MonthDuration(result.bucket1.midAge * 12)
-  );
+  // Use expectedAge (probability-weighted) so the timeline matches the death
+  // date the optimizer used to compute totalBenefit and choose filingAge1.
+  $: finalDate = recipient.birthdate.dateAtLayAge(result.bucket1.expectedAge);
 
   $: benefitPeriods = strategySumPeriodsSingle(
     recipient,

--- a/src/routes/strategy/components/StrategyOverview.svelte
+++ b/src/routes/strategy/components/StrategyOverview.svelte
@@ -37,14 +37,12 @@
       : null;
 
   // Calculate the benefit periods for the selected strategy
+  // Use expectedAge (probability-weighted) so the timeline matches the death
+  // dates the optimizer used to compute totalBenefit and choose filingAge1/2.
   $: finalDates = result
     ? ([
-        recipients[0].birthdate.dateAtLayAge(
-          new MonthDuration(result.bucket1.midAge * 12)
-        ),
-        recipients[1].birthdate.dateAtLayAge(
-          new MonthDuration(result.bucket2.midAge * 12)
-        ),
+        recipients[0].birthdate.dateAtLayAge(result.bucket1.expectedAge),
+        recipients[1].birthdate.dateAtLayAge(result.bucket2.expectedAge),
       ] as [MonthDate, MonthDate])
     : null;
 


### PR DESCRIPTION
## Summary
- The payment timeline in `ScenarioDetail`, `ScenarioDetailSingle`, and `StrategyOverview` was rendering benefit periods against a death date six months earlier than the death date in the header / used by the optimizer.
- Root cause: the timeline built `finalDates` from `bucket.midAge` (integer label, e.g. 84.0y) while the optimizer that produced `result.totalBenefit` and `result.filingAge1/2` used `bucket.expectedAge` (probability-weighted midpoint, e.g. 84.5y). All three components now use `expectedAge`, matching the header, the NPV card, and `AlternativeStrategiesGrid`.

## Test plan
- [x] `npm run quality` passes (Biome + svelte-check, 0 warnings)
- [x] `npm test` passes (1903/1903)
- [ ] Manual: open `/strategy`, drill into a scenario, confirm timeline bars now end on the same month as the header's death date and add up to the displayed NPV