### PR TITLE
copy(strategy): lead support prompt with "important decision" framing

### DIFF
--- a/src/lib/components/SupportPrompt.svelte
+++ b/src/lib/components/SupportPrompt.svelte
@@ -27,9 +27,10 @@
     <p class="kicker">Support this work</p>
   </header>
   <p class="copy">
-    Free, with no account or email, and your data never leaves your browser.
-    By comparison, Quicken's Social Security Optimizer is $50/year. Tips
-    keep ssa.tools free.
+    If it helped you with an important decision, consider supporting the
+    work. Free, no account, your data stays in your browser. By comparison,
+    Quicken's Social Security Optimizer is $50/year. Tips keep ssa.tools
+    free.
   </p>
   <p class="cta">
     <a


### PR DESCRIPTION
## Summary
- Reframe the /strategy `SupportPrompt` to lead with "If it helped you with an important decision, consider supporting the work." then back it up with the existing privacy + Quicken-price facts.
- Filing strategy is the highest-stakes decision on the site, so the emotional hook fits the page.
- No code or behavior changes — copy only.

## Test plan
- [x] `npm run quality` passes
- [ ] Manual: visit `/strategy`, confirm the support card reads correctly and the Ko-fi button still tracks