### PR TITLE
fix(strategy): allow any PIA value in the form input (drop step=100)

### DIFF
--- a/src/routes/strategy/components/RecipientInputs.svelte
+++ b/src/routes/strategy/components/RecipientInputs.svelte
@@ -256,9 +256,9 @@
               id="pia{i}"
               class="pia-input"
               type="number"
-              step="100"
+              step="any"
               min="0"
-              inputmode="numeric"
+              inputmode="decimal"
               value={piaValues[i] ?? ""}
               class:invalid={piaValues[i] !== null && !piaValidity[i]}
               on:input={(event) =>


### PR DESCRIPTION
## Summary
- The /strategy form's PIA `<input type="number">` had `step="100"`, which made the browser flag any value not divisible by 100 as invalid (red ring + native submit tooltip). The custom `validatePia()` never enforced this, so the constraint was entirely browser-side.
- Switch to `step="any"` so cents and arbitrary whole-dollar amounts are both accepted, and `inputmode="decimal"` so mobile shows the right keypad.
- This is the only PIA `<input>` in the codebase — `/calculator` derives PIA from earnings paste rather than direct entry.

## Test plan
- [x] `npm run quality` passes
- [ ] Manual: type `2347` and `2347.50` on `/strategy`, confirm no red ring and no native validation tooltip on submit