### PR TITLE
fix(strategy): disable sticky tunables on mobile + touch-aware copy

### DIFF
--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, tick } from "svelte";
+  import { onDestroy, onMount, tick } from "svelte";
   import { slide } from "svelte/transition";
   import { cubicOut } from "svelte/easing";
   import Header from "$lib/components/Header.svelte";
@@ -80,6 +80,15 @@
   let tunableObserver: IntersectionObserver | null = null;
   let widgetEndObserver: IntersectionObserver | null = null;
   let tunableResizeObserver: ResizeObserver | null = null;
+  // The sticky compact bar overflows on narrow viewports and the placeholder
+  // it reserves leaves a visible gap. Disable the sticky behavior below this
+  // breakpoint and let the tunables flow normally.
+  let tunableMobileMq: MediaQueryList | null = null;
+  let tunableMobile = false;
+  const handleTunableMqChange = (e: MediaQueryListEvent | MediaQueryList) => {
+    tunableMobile = e.matches;
+    if (tunableMobile) tunableIsStuck = false;
+  };
 
   let widgetAnchorEl: HTMLDivElement | null = null;
   let scenarioAnchorEl: HTMLElement | null = null;
@@ -96,7 +105,7 @@
     tunableObserver = new IntersectionObserver(
       (entries) => {
         if (entries.length === 0) return;
-        tunableIsStuck = !entries[0].isIntersecting;
+        tunableIsStuck = !entries[0].isIntersecting && !tunableMobile;
       },
       { threshold: 0 }
     );
@@ -138,10 +147,17 @@
     tunableResizeObserver.observe(el);
   }
 
+  onMount(() => {
+    tunableMobileMq = window.matchMedia("(max-width: 768px)");
+    handleTunableMqChange(tunableMobileMq);
+    tunableMobileMq.addEventListener("change", handleTunableMqChange);
+  });
+
   onDestroy(() => {
     tunableObserver?.disconnect();
     widgetEndObserver?.disconnect();
     tunableResizeObserver?.disconnect();
+    tunableMobileMq?.removeEventListener("change", handleTunableMqChange);
     if (debounceTimer !== null) clearTimeout(debounceTimer);
     if (backToMatrixTimer !== null) clearTimeout(backToMatrixTimer);
   });

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -302,7 +302,8 @@
           {#if isPinned}
             Pinned cell
           {:else}
-            Hover any cell
+            <span class="hover-only">Hover any cell</span>
+            <span class="touch-only">Tap any cell</span>
           {/if}
         </span>
         {#if isPinned}
@@ -521,6 +522,18 @@
     color: #6b7280;
     letter-spacing: 0.06em;
     text-transform: uppercase;
+  }
+
+  .touch-only {
+    display: none;
+  }
+  @media (hover: none) {
+    .hover-only {
+      display: none;
+    }
+    .touch-only {
+      display: inline;
+    }
   }
 
   .info-hint-pin {

--- a/src/routes/strategy/components/ScenarioDetail.svelte
+++ b/src/routes/strategy/components/ScenarioDetail.svelte
@@ -205,7 +205,12 @@
     <p class="section-lede">
       Each cell is one filing-age combination. Color shows how its NPV
       compares to the optimal (green) all the way to a poor outcome (red).
-      Hover or tap any cell to see the dollar gap from the optimal strategy.
+      <span class="hover-only"
+        >Hover any cell to see the dollar gap from the optimal strategy.</span
+      >
+      <span class="touch-only"
+        >Tap any cell to see the dollar gap from the optimal strategy.</span
+      >
     </p>
     <AlternativeStrategiesGrid
       {recipients}
@@ -304,6 +309,18 @@
     font-size: 0.9rem;
     color: #4b5563;
     line-height: 1.5;
+  }
+
+  .touch-only {
+    display: none;
+  }
+  @media (hover: none) {
+    .hover-only {
+      display: none;
+    }
+    .touch-only {
+      display: inline;
+    }
   }
 
   .filing-grid {

--- a/src/routes/strategy/components/StrategyPlotSingle.svelte
+++ b/src/routes/strategy/components/StrategyPlotSingle.svelte
@@ -681,8 +681,13 @@
         outcomes fall in that range.
       </li>
       <li>
-        <strong>Hover the chart</strong> to see the values at each death
-        age.
+        <span class="hover-only"
+          ><strong>Hover the chart</strong> to see the values at each death
+          age.</span
+        >
+        <span class="touch-only"
+          ><strong>Tap the chart</strong> to see the values at each death age.</span
+        >
       </li>
     </ul>
     <p>
@@ -729,6 +734,18 @@
 </div>
 
 <style>
+  .touch-only {
+    display: none;
+  }
+  @media (hover: none) {
+    .hover-only {
+      display: none;
+    }
+    .touch-only {
+      display: inline;
+    }
+  }
+
   .result-box {
     max-width: 800px;
     margin: 0.75rem auto 2rem;


### PR DESCRIPTION
## Summary
Two related mobile/tablet fixes from the audit:

1. **Sticky tunables broken on mobile.** At ≤768px the compact bar's `scrollWidth` was 536px in a 375px viewport with `overflow-x: visible` — content silently clipped, hiding the discount-rate input. The placeholder it reserves also took ~430px even when the visible compact bar was tiny, leaving a big empty band. The fix gates the sticky behavior on `matchMedia('(max-width: 768px)')` and lets the tunables flow naturally on mobile.
2. **"Hover" copy on touch devices.** The alternatives panel eyebrow ("Hover any cell"), the scenario detail lede ("Hover or tap any cell …"), and the single-mode plot caption ("Hover the chart …") now swap to "Tap …" via a `@media (hover: none)` CSS rule.

No logic changes outside the tunables stuck-state and copy.

## Test plan
- [x] `npm run quality` passes
- [x] `npm test` passes (1903/1903)
- [x] Manual on dev server at iPhone-14 viewport: discount-rate input visible without scroll, no empty band between recipient info and matrix
- [ ] Manual on a real touch device: confirm "Tap …" copy renders in the three places listed above