### PR TITLE
fix(strategy): refresh grid borders when discount rate changes

### DIFF
--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -189,11 +189,9 @@ $: cellDimensions = rowBuckets.map((_, i) =>
   }))
 );
 
-// Calculate cell styles including background color and border removal.
-// Dependencies are passed as parameters so callers (the reactive $: block
-// below) make Svelte's static dependency tracking see them — otherwise
-// inline calls like cellStyle={getCellStyle(i, j)} only track i/j and
-// won't re-evaluate when calculationResults or borderRemovalFuncs change.
+// Dependencies are passed as parameters so Svelte's static reactive
+// tracking sees them in the calling $: block. Closure-captured reactive
+// state is invisible to the compiler and won't trigger re-evaluation.
 function getCellStyle(
   i: number,
   j: number,
@@ -245,9 +243,6 @@ function getCellStyle(
   return style;
 }
 
-// Reactively precompute every cell's style. Mirrors the cellDimensions
-// pattern above so border/background updates flow through when
-// calculationResults or borderRemovalFuncs change (e.g. discount rate edits).
 $: cellStyles = rowBuckets.map((_, i) =>
   colBuckets.map((_, j) =>
     getCellStyle(i, j, calculationResults, borderRemovalFuncs, recipientIndex)

--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -189,14 +189,23 @@ $: cellDimensions = rowBuckets.map((_, i) =>
   }))
 );
 
-// Calculate cell styles including background color and border removal
-function getCellStyle(i: number, j: number): string {
+// Calculate cell styles including background color and border removal.
+// Dependencies are passed as parameters so callers (the reactive $: block
+// below) make Svelte's static dependency tracking see them — otherwise
+// inline calls like cellStyle={getCellStyle(i, j)} only track i/j and
+// won't re-evaluate when calculationResults or borderRemovalFuncs change.
+function getCellStyle(
+  i: number,
+  j: number,
+  results: CalculationResults,
+  borderFns: ReturnType<typeof createBorderRemovalFunctions>,
+  recipientIdx: number
+): string {
   let style = '';
 
-  // Add background color based on filing date
-  const cell = calculationResults.get(i, j);
+  const cell = results.get(i, j);
   if (cell) {
-    const filingAge: MonthDuration = cell[`filingAge${recipientIndex + 1}`];
+    const filingAge: MonthDuration = cell[`filingAge${recipientIdx + 1}`];
     const backgroundColor = getMonthYearColor(
       filingAge.asMonths(),
       MonthDuration.initFromYearsMonths({
@@ -211,32 +220,39 @@ function getCellStyle(i: number, j: number): string {
     style += `background-color: ${backgroundColor}; `;
   }
 
-  // Apply border removal logic
   let bordersRemoved = 0;
-  if (borderRemovalFuncs.right(i, j)) {
+  if (borderFns.right(i, j)) {
     style += 'border-right: none; ';
     bordersRemoved++;
   }
-  if (borderRemovalFuncs.bottom(i, j)) {
+  if (borderFns.bottom(i, j)) {
     style += 'border-bottom: none; ';
     bordersRemoved++;
   }
-  if (borderRemovalFuncs.left(i, j)) {
+  if (borderFns.left(i, j)) {
     style += 'border-left: none; ';
     bordersRemoved++;
   }
-  if (borderRemovalFuncs.top(i, j)) {
+  if (borderFns.top(i, j)) {
     style += 'border-top: none; ';
     bordersRemoved++;
   }
 
-  // Add subtle visual indicator when borders are removed
   if (bordersRemoved > 0) {
     style += 'box-shadow: inset 0 0 2px rgba(0, 123, 255, 0.3); ';
   }
 
   return style;
 }
+
+// Reactively precompute every cell's style. Mirrors the cellDimensions
+// pattern above so border/background updates flow through when
+// calculationResults or borderRemovalFuncs change (e.g. discount rate edits).
+$: cellStyles = rowBuckets.map((_, i) =>
+  colBuckets.map((_, j) =>
+    getCellStyle(i, j, calculationResults, borderRemovalFuncs, recipientIndex)
+  )
+);
 
 // Handle events
 function handleCellHover(position: CellPosition) {
@@ -407,7 +423,7 @@ function handleCellSelect(position: CellPosition) {
               isSelected={calculationResults.isSelected(i, j)}
               cellWidth={cellDimensions[i]?.[j]?.width || 0}
               cellHeight={cellDimensions[i]?.[j]?.height || 0}
-              cellStyle={getCellStyle(i, j)}
+              cellStyle={cellStyles[i]?.[j] || ''}
               onhover={handleCellHover}
               onhoverout={handleCellHoverOut}
               onselect={handleCellSelect}


### PR DESCRIPTION
## Summary
- In the 2-recipient `/strategy` matrix, changing the discount rate updated the cell values but left the borders separating equal-value regions (and the background colors) stale.
- Root cause: `cellStyle={getCellStyle(i, j)}` was an inline function call. Svelte 4's static dependency tracking only sees identifiers named in the expression itself — it does not peer into function bodies — so `borderRemovalFuncs` and `calculationResults` (read via closure) weren't tracked. Meanwhile `calculationResult={calculationResults.get(i, j)}` *did* update because `calculationResults` is named directly, which is why values refreshed but styles didn't.
- Fix: refactor `getCellStyle` to take its dependencies as parameters, then precompute a 2D `cellStyles` array in a `$:` block — mirroring the existing `cellDimensions` pattern in the same file. Svelte now sees `calculationResults`, `borderRemovalFuncs`, and `recipientIndex` as visible identifiers and reactively recomputes.

## Test plan
- [x] `npm run quality` (biome + svelte-check) clean
- [x] `npm test` — all 1903 tests pass
- [ ] Manual: load `/strategy` with two recipients, change the discount rate, confirm the region borders shift along with the cell values