### PR TITLE
fix(strategy): abbreviate filing dates when headline is narrow

### DIFF
--- a/src/routes/strategy/components/OptimalStrategyHeadline.svelte
+++ b/src/routes/strategy/components/OptimalStrategyHeadline.svelte
@@ -30,6 +30,14 @@
     return `${date.monthFullName()} ${date.year()}`;
   }
 
+  function formatFilingDateShort(
+    recipient: Recipient,
+    age: MonthDuration
+  ): string {
+    const date = recipient.birthdate.dateAtLayAge(age);
+    return `${date.monthName()} ${date.year()}`;
+  }
+
   function formatMoney(cents: number): string {
     return Money.fromCents(Math.round(cents)).wholeDollars();
   }
@@ -73,7 +81,12 @@
           </div>
           <div class="prefix">File in</div>
           <div class="date-big">
-            {formatFilingDateFull(recipients[0], coupleResult.filingAges[0])}
+            <span class="date-full"
+              >{formatFilingDateFull(recipients[0], coupleResult.filingAges[0])}</span
+            >
+            <span class="date-short"
+              >{formatFilingDateShort(recipients[0], coupleResult.filingAges[0])}</span
+            >
           </div>
           <div class="age-sub">
             at age {formatAge(coupleResult.filingAges[0])}
@@ -86,7 +99,12 @@
           </div>
           <div class="prefix">File in</div>
           <div class="date-big">
-            {formatFilingDateFull(recipients[1], coupleResult.filingAges[1])}
+            <span class="date-full"
+              >{formatFilingDateFull(recipients[1], coupleResult.filingAges[1])}</span
+            >
+            <span class="date-short"
+              >{formatFilingDateShort(recipients[1], coupleResult.filingAges[1])}</span
+            >
           </div>
           <div class="age-sub">
             at age {formatAge(coupleResult.filingAges[1])}
@@ -138,6 +156,11 @@
     text-align: center;
     background: #f7f8fd;
     border-radius: 14px;
+    container-type: inline-size;
+  }
+
+  .date-short {
+    display: none;
   }
 
   .kicker {
@@ -247,6 +270,15 @@
     margin: 0.5rem auto 0;
     line-height: 1.45;
     max-width: 52ch;
+  }
+
+  @container (max-width: 440px) {
+    .couple-results .date-full {
+      display: none;
+    }
+    .couple-results .date-short {
+      display: inline;
+    }
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- On iPad portrait the recommended-filing-ages headline shares a flex row with the support-prompt card, squeezing the headline to ~380px wide. At that width the couple's two filing dates ("January 2050" / "December 2044") overlap visually — the grid columns are narrower than the date text, and `white-space: nowrap` + `min-width: 0` lets the text bleed out of its track.
- Render both the full month name and the 3-char abbreviation as sibling spans, then toggle between them with a container query on `.headline` so the swap reacts to the headline's actual width (not the viewport, which was lying — the headline shares a row with `<SupportPrompt />`).
- Threshold is `@container (max-width: 440px)`. `inline-size` queries the content box, so the trigger fires on iPad portrait/landscape but leaves desktop showing the full month name.

## Verified viewports
| Viewport | Headline content-box | Display |
|---|---|---|
| Desktop 1440px | 512px | "January 2053" / "June 2044" |
| iPad landscape 1024px | 417px | "Jan 2053" / "Jun 2044" |
| iPad portrait 820px | 315px | "Jan 2053" / "Jun 2044" — no overlap |
| Mobile 375px | n/a | abbreviated, single-column stacked |

## Test plan
- [x] `npm run quality` (lint + svelte-check) clean
- [x] Visual verification at 1440 / 1024 / 820 / 375 viewports
- [ ] Eyeball on a real iPad after deploy preview