### PR TITLE
feat(strategy): add URL hash pre-fill and share link

### DIFF
--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -266,22 +266,12 @@ export class UrlParams {
     return this.getSpouseEarnings() !== null && this.getSpouseDob() !== null;
   }
 
-  /**
-   * Get recipient (person 1) gender parameter.
-   * Returns 'blended' if not present or unrecognized.
-   *
-   * Example: #gender1=male
-   */
+  // Returns 'blended' when absent or unrecognized. Example: #gender1=male
   getRecipientGender(): Gender {
     return UrlParams.parseGender(this.params.get('gender1'));
   }
 
-  /**
-   * Get spouse (person 2) gender parameter.
-   * Returns 'blended' if not present or unrecognized.
-   *
-   * Example: #gender2=female
-   */
+  // Returns 'blended' when absent or unrecognized. Example: #gender2=female
   getSpouseGender(): Gender {
     return UrlParams.parseGender(this.params.get('gender2'));
   }
@@ -291,14 +281,6 @@ export class UrlParams {
       return value;
     }
     return 'blended';
-  }
-
-  /**
-   * Check if valid strategy params are present for the primary recipient.
-   * Both PIA and DOB are required.
-   */
-  hasValidStrategyParams(): boolean {
-    return this.hasValidRecipientParams();
   }
 
   /**
@@ -322,10 +304,7 @@ export interface StrategyHashParams {
   gender2?: Gender;
 }
 
-/**
- * Build a URL hash string for the /strategy page pre-fill.
- * Only includes gender when non-default (blended) to keep URLs short.
- */
+// Omits gender params when blended (the default) to keep URLs short.
 export function buildStrategyHash(p: StrategyHashParams): string {
   const parts: string[] = [`pia1=${Math.round(p.pia1)}`, `dob1=${p.dob1}`];
   if (p.name1) parts.push(`name1=${encodeURIComponent(p.name1)}`);

--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -12,6 +12,8 @@
  * server-side processing and maintain client-side privacy.
  */
 
+export type Gender = 'male' | 'female' | 'blended';
+
 /**
  * Parsed recipient or spouse data from URL parameters.
  */
@@ -265,10 +267,76 @@ export class UrlParams {
   }
 
   /**
+   * Get recipient (person 1) gender parameter.
+   * Returns 'blended' if not present or unrecognized.
+   *
+   * Example: #gender1=male
+   */
+  getRecipientGender(): Gender {
+    return UrlParams.parseGender(this.params.get('gender1'));
+  }
+
+  /**
+   * Get spouse (person 2) gender parameter.
+   * Returns 'blended' if not present or unrecognized.
+   *
+   * Example: #gender2=female
+   */
+  getSpouseGender(): Gender {
+    return UrlParams.parseGender(this.params.get('gender2'));
+  }
+
+  private static parseGender(value: string | null): Gender {
+    if (value === 'male' || value === 'female' || value === 'blended') {
+      return value;
+    }
+    return 'blended';
+  }
+
+  /**
+   * Check if valid strategy params are present for the primary recipient.
+   * Both PIA and DOB are required.
+   */
+  hasValidStrategyParams(): boolean {
+    return this.hasValidRecipientParams();
+  }
+
+  /**
    * Get the raw URLSearchParams instance for advanced use cases.
    * Use sparingly - prefer typed methods above.
    */
   getRaw(): URLSearchParams {
     return this.params;
   }
+}
+
+export interface StrategyHashParams {
+  isSingle: boolean;
+  pia1: number;
+  dob1: string;
+  name1?: string;
+  gender1?: Gender;
+  pia2?: number;
+  dob2?: string;
+  name2?: string;
+  gender2?: Gender;
+}
+
+/**
+ * Build a URL hash string for the /strategy page pre-fill.
+ * Only includes gender when non-default (blended) to keep URLs short.
+ */
+export function buildStrategyHash(p: StrategyHashParams): string {
+  const parts: string[] = [`pia1=${Math.round(p.pia1)}`, `dob1=${p.dob1}`];
+  if (p.name1) parts.push(`name1=${encodeURIComponent(p.name1)}`);
+  if (p.gender1 && p.gender1 !== 'blended') parts.push(`gender1=${p.gender1}`);
+
+  if (!p.isSingle && p.pia2 !== undefined && p.dob2) {
+    parts.push(`pia2=${Math.round(p.pia2)}`, `dob2=${p.dob2}`);
+    if (p.name2) parts.push(`name2=${encodeURIComponent(p.name2)}`);
+    if (p.gender2 && p.gender2 !== 'blended')
+      parts.push(`gender2=${p.gender2}`);
+  }
+
+  return `#${parts.join('&')}`;
 }

--- a/src/routes/guides/url-parameters/+page.svelte
+++ b/src/routes/guides/url-parameters/+page.svelte
@@ -8,7 +8,7 @@ const title = 'Sharing Social Security Scenarios with URL Parameters';
 const description =
   'Learn how to use URL parameters to link directly to the SSA.tools calculator with preloaded scenarios. Perfect for financial advisors, educators, or sharing examples with family and friends.';
 const publishDate = new Date('2025-10-07T00:00:00+00:00');
-const updateDate = new Date('2025-10-07T00:00:00+00:00');
+const updateDate = new Date('2026-05-01T00:00:00+00:00');
 
 let schema: GuidesSchema = new GuidesSchema();
 schema.url = 'https://ssa.tools/guides/url-parameters';
@@ -343,6 +343,100 @@ schema.tags = [
       educational settings.
     </li>
   </ul>
+
+  <h2>Strategy Optimizer Parameters</h2>
+
+  <p>
+    The <a href="/strategy">Strategy Optimizer</a> also supports URL parameters to
+    pre-fill recipient information. Parameters are added as a hash fragment to
+    <code>https://ssa.tools/strategy</code>:
+  </p>
+
+  <pre><code>https://ssa.tools/strategy#pia1=VALUE&dob1=DATE</code></pre>
+
+  <p>
+    The page will open with the form pre-filled. You can review and adjust the values
+    before running the optimization.
+  </p>
+
+  <h3>Strategy Parameters</h3>
+
+  <h4>Primary Recipient (required)</h4>
+
+  <ul>
+    <li>
+      <code>pia1</code> - Primary Insurance Amount in whole dollars (required)
+    </li>
+    <li>
+      <code>dob1</code> - Date of birth in YYYY-MM-DD format (required)
+    </li>
+    <li>
+      <code>name1</code> - Name for display (optional)
+    </li>
+    <li>
+      <code>gender1</code> - One of <code>male</code>, <code>female</code>, or
+      <code>blended</code> (optional, defaults to <code>blended</code>)
+    </li>
+  </ul>
+
+  <h4>Spouse (optional — omit for single-person analysis)</h4>
+
+  <ul>
+    <li>
+      <code>pia2</code> - Spouse's Primary Insurance Amount in whole dollars
+    </li>
+    <li>
+      <code>dob2</code> - Spouse's date of birth in YYYY-MM-DD format
+    </li>
+    <li>
+      <code>name2</code> - Spouse's name for display (optional)
+    </li>
+    <li>
+      <code>gender2</code> - One of <code>male</code>, <code>female</code>, or
+      <code>blended</code> (optional, defaults to <code>blended</code>)
+    </li>
+  </ul>
+
+  <p>
+    When both <code>pia2</code> and <code>dob2</code> are present, the optimizer
+    runs in couple mode. When only recipient 1 parameters are provided, it runs
+    in single-person mode.
+  </p>
+
+  <h3>Strategy Examples</h3>
+
+  <h4>Single Person</h4>
+
+  <p>Alex, born September 21, 1965, male, with a PIA of $2,400:</p>
+
+  <pre><code>https://ssa.tools/strategy#pia1=2400&dob1=1965-09-21&name1=Alex&gender1=male</code></pre>
+
+  <p>
+    <a
+      href="/strategy#pia1=2400&dob1=1965-09-21&name1=Alex&gender1=male"
+      target="_blank"
+      rel="noopener noreferrer">Try this example →</a
+    >
+  </p>
+
+  <h4>Couple</h4>
+
+  <p>Alex and Casey, born in 1960 and 1962, with different PIAs:</p>
+
+  <pre><code>https://ssa.tools/strategy#pia1=2400&dob1=1960-03-15&name1=Alex&gender1=male&pia2=1800&dob2=1962-07-22&name2=Casey&gender2=female</code></pre>
+
+  <p>
+    <a
+      href="/strategy#pia1=2400&dob1=1960-03-15&name1=Alex&gender1=male&pia2=1800&dob2=1962-07-22&name2=Casey&gender2=female"
+      target="_blank"
+      rel="noopener noreferrer">Try this example →</a
+    >
+  </p>
+
+  <p>
+    The strategy page also has a <em>Copy share link</em> button once results are
+    displayed, which generates these URLs automatically.
+  </p>
 
   <h2>Related Resources</h2>
 

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -4,6 +4,7 @@
   import { cubicOut } from "svelte/easing";
   import Header from "$lib/components/Header.svelte";
   import { getDeathProbabilityDistribution } from "$lib/life-tables";
+  import { Birthdate } from "$lib/birthday";
   import { Money } from "$lib/money";
   import { MonthDate } from "$lib/month-time";
   import { Recipient } from "$lib/recipient";
@@ -174,6 +175,11 @@
     hydrateFromHash();
   });
 
+  function parseBirthdate(dateStr: string): Birthdate {
+    const [yearStr, monthStr, dayStr] = dateStr.split("-");
+    return Birthdate.FromYMD(Number(yearStr), Number(monthStr) - 1, Number(dayStr));
+  }
+
   function hydrateFromHash() {
     const params = new UrlParams(window.location.hash);
     if (!params.hasValidStrategyParams()) return;
@@ -194,6 +200,7 @@
     birthdateInputs[0] = dob1;
     piaValues[0] = pia1;
     recipients[0].setPia(Money.from(pia1));
+    recipients[0].birthdate = parseBirthdate(dob1);
     if (params.getRecipientName()) recipients[0].name = params.getRecipientName()!;
     recipients[0].gender = params.getRecipientGender();
 
@@ -203,6 +210,7 @@
       birthdateInputs[1] = dob2;
       piaValues[1] = pia2;
       recipients[1].setPia(Money.from(pia2));
+      recipients[1].birthdate = parseBirthdate(dob2);
       if (params.getSpouseName()) recipients[1].name = params.getSpouseName()!;
       recipients[1].gender = params.getSpouseGender();
     }

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -175,50 +175,69 @@
     hydrateFromHash();
   });
 
-  function parseBirthdate(dateStr: string): Birthdate {
-    const [yearStr, monthStr, dayStr] = dateStr.split("-");
-    return Birthdate.FromYMD(Number(yearStr), Number(monthStr) - 1, Number(dayStr));
+  function parseBirthdate(dateStr: string): Birthdate | null {
+    const parts = dateStr.split("-");
+    if (parts.length !== 3) return null;
+    const year = Number(parts[0]);
+    const month = Number(parts[1]) - 1;
+    const day = Number(parts[2]);
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+    try {
+      return Birthdate.FromYMD(year, month, day);
+    } catch {
+      return null;
+    }
   }
 
   function hydrateFromHash() {
     const params = new UrlParams(window.location.hash);
-    if (!params.hasValidStrategyParams()) return;
+    if (!params.hasValidRecipientParams()) return;
 
-    const hasSpouse =
-      params.getSpousePia() !== null && params.getSpouseDob() !== null;
-    isSingle = !hasSpouse;
+    try {
+      const dob1 = params.getRecipientDob()!;
+      const bd1 = parseBirthdate(dob1);
+      if (!bd1) return;
 
-    // Mirror handleModeSelect: couple mode needs markFirst/markSecond so
-    // RecipientName renders colored names.
-    if (!isSingle) {
-      recipients[0].markFirst();
-      recipients[1].markSecond();
+      const hasSpouse =
+        params.getSpousePia() !== null && params.getSpouseDob() !== null;
+      isSingle = !hasSpouse;
+
+      // Mirror handleModeSelect: couple mode needs markFirst/markSecond so
+      // RecipientName renders colored names.
+      if (!isSingle) {
+        recipients[0].markFirst();
+        recipients[1].markSecond();
+      }
+
+      const pia1 = params.getRecipientPia()!;
+      birthdateInputs[0] = dob1;
+      piaValues[0] = pia1;
+      recipients[0].setPia(Money.from(pia1));
+      recipients[0].birthdate = bd1;
+      if (params.getRecipientName()) recipients[0].name = params.getRecipientName()!;
+      recipients[0].gender = params.getRecipientGender();
+
+      if (!isSingle) {
+        const dob2 = params.getSpouseDob()!;
+        const bd2 = parseBirthdate(dob2);
+        if (!bd2) { isSingle = true; } else {
+          const pia2 = params.getSpousePia()!;
+          birthdateInputs[1] = dob2;
+          piaValues[1] = pia2;
+          recipients[1].setPia(Money.from(pia2));
+          recipients[1].birthdate = bd2;
+          if (params.getSpouseName()) recipients[1].name = params.getSpouseName()!;
+          recipients[1].gender = params.getSpouseGender();
+        }
+      }
+
+      birthdateInputs = [...birthdateInputs];
+      piaValues = [...piaValues];
+      recipients = [...recipients];
+      stage = "form";
+    } catch {
+      // Invalid URL params — leave the page at the mode-picker stage
     }
-
-    const dob1 = params.getRecipientDob()!;
-    const pia1 = params.getRecipientPia()!;
-    birthdateInputs[0] = dob1;
-    piaValues[0] = pia1;
-    recipients[0].setPia(Money.from(pia1));
-    recipients[0].birthdate = parseBirthdate(dob1);
-    if (params.getRecipientName()) recipients[0].name = params.getRecipientName()!;
-    recipients[0].gender = params.getRecipientGender();
-
-    if (!isSingle) {
-      const dob2 = params.getSpouseDob()!;
-      const pia2 = params.getSpousePia()!;
-      birthdateInputs[1] = dob2;
-      piaValues[1] = pia2;
-      recipients[1].setPia(Money.from(pia2));
-      recipients[1].birthdate = parseBirthdate(dob2);
-      if (params.getSpouseName()) recipients[1].name = params.getSpouseName()!;
-      recipients[1].gender = params.getSpouseGender();
-    }
-
-    birthdateInputs = [...birthdateInputs];
-    piaValues = [...piaValues];
-    recipients = [...recipients];
-    stage = "form";
   }
 
   onDestroy(() => {
@@ -245,14 +264,14 @@
       isSingle: single,
       pia1: pias[0],
       dob1: dobs[0],
-      name1: rs[0].name || undefined,
+      name1: rs[0].name && rs[0].name !== "Self" ? rs[0].name : undefined,
       gender1: rs[0].gender,
       ...(
         !single && pias[1] !== null && dobs[1]
           ? {
               pia2: pias[1],
               dob2: dobs[1],
-              name2: rs[1].name || undefined,
+              name2: rs[1].name && rs[1].name !== "Spouse" ? rs[1].name : undefined,
               gender2: rs[1].gender,
             }
           : {}

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -18,6 +18,7 @@
     generateThreeYearBuckets,
   } from "$lib/strategy/ui";
   import { writable } from "svelte/store";
+  import { UrlParams, buildStrategyHash } from "$lib/url-params";
   import LockedSummary from "./components/LockedSummary.svelte";
   import ModePicker from "./components/ModePicker.svelte";
   import RecipientInputs from "./components/RecipientInputs.svelte";
@@ -169,7 +170,48 @@
     tunableMobileMq = window.matchMedia("(max-width: 768px)");
     handleTunableMqChange(tunableMobileMq);
     tunableMobileMq.addEventListener("change", handleTunableMqChange);
+
+    hydrateFromHash();
   });
+
+  function hydrateFromHash() {
+    const params = new UrlParams(window.location.hash);
+    if (!params.hasValidStrategyParams()) return;
+
+    const hasSpouse =
+      params.getSpousePia() !== null && params.getSpouseDob() !== null;
+    isSingle = !hasSpouse;
+
+    // Mirror handleModeSelect: couple mode needs markFirst/markSecond so
+    // RecipientName renders colored names.
+    if (!isSingle) {
+      recipients[0].markFirst();
+      recipients[1].markSecond();
+    }
+
+    const dob1 = params.getRecipientDob()!;
+    const pia1 = params.getRecipientPia()!;
+    birthdateInputs[0] = dob1;
+    piaValues[0] = pia1;
+    recipients[0].setPia(Money.from(pia1));
+    if (params.getRecipientName()) recipients[0].name = params.getRecipientName()!;
+    recipients[0].gender = params.getRecipientGender();
+
+    if (!isSingle) {
+      const dob2 = params.getSpouseDob()!;
+      const pia2 = params.getSpousePia()!;
+      birthdateInputs[1] = dob2;
+      piaValues[1] = pia2;
+      recipients[1].setPia(Money.from(pia2));
+      if (params.getSpouseName()) recipients[1].name = params.getSpouseName()!;
+      recipients[1].gender = params.getSpouseGender();
+    }
+
+    birthdateInputs = [...birthdateInputs];
+    piaValues = [...piaValues];
+    recipients = [...recipients];
+    stage = "form";
+  }
 
   onDestroy(() => {
     tunableObserver?.disconnect();
@@ -182,6 +224,34 @@
 
   $: formIsValid = recipientInputsValid && discountRateValid;
   $: discountRate = discountRatePercent / 100;
+  $: shareUrl = buildShareUrl(recipients, isSingle, piaValues, birthdateInputs);
+
+  function buildShareUrl(
+    rs: [typeof recipients[0], typeof recipients[1]],
+    single: boolean,
+    pias: [number | null, number | null],
+    dobs: [string, string]
+  ): string {
+    if (!dobs[0] || pias[0] === null) return "";
+    const hash = buildStrategyHash({
+      isSingle: single,
+      pia1: pias[0],
+      dob1: dobs[0],
+      name1: rs[0].name || undefined,
+      gender1: rs[0].gender,
+      ...(
+        !single && pias[1] !== null && dobs[1]
+          ? {
+              pia2: pias[1],
+              dob2: dobs[1],
+              name2: rs[1].name || undefined,
+              gender2: rs[1].gender,
+            }
+          : {}
+      ),
+    });
+    return `https://ssa.tools/strategy${hash}`;
+  }
 
   $: maybeScheduleReactiveRecompute(
     recipients[0].healthMultiplier,
@@ -553,7 +623,7 @@
         class="stage-section"
         transition:slide={{ duration: 320, easing: cubicOut }}
       >
-        <LockedSummary {recipients} {isSingle} onedit={handleEdit} />
+        <LockedSummary {recipients} {isSingle} {shareUrl} onedit={handleEdit} />
       </section>
     {/if}
   </div>

--- a/src/routes/strategy/components/LockedSummary.svelte
+++ b/src/routes/strategy/components/LockedSummary.svelte
@@ -4,7 +4,26 @@
 
   export let recipients: [Recipient, Recipient];
   export let isSingle: boolean;
+  export let shareUrl: string = "";
   export let onedit: () => void;
+
+  let copied = false;
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function handleCopy() {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      copied = true;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => {
+        copied = false;
+        copyTimer = null;
+      }, 2000);
+    } catch {
+      // Fallback: select a temporary input
+    }
+  }
 
   function formatBirthdate(recipient: Recipient): string {
     const bd = recipient.birthdate;
@@ -33,23 +52,41 @@
 <section class="locked">
   <header class="section-header">
     <p class="section-kicker">Recipient information</p>
-    <button type="button" class="edit-btn" on:click={onedit}>
-      <svg
-        class="edit-arrow"
-        viewBox="0 0 16 16"
-        width="14"
-        height="14"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.75"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
-      >
-        <path d="M10 3 5 8l5 5" />
-      </svg>
-      Edit recipient info
-    </button>
+    <div class="header-actions">
+      {#if shareUrl}
+        <button type="button" class="share-btn" on:click={handleCopy}>
+          {#if copied}
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M2 8l4 4 8-8" />
+            </svg>
+            Copied!
+          {:else}
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="5" y="2" width="9" height="11" rx="1.5" />
+              <path d="M11 2V1a1 1 0 00-1-1H2a1 1 0 00-1 1v11a1 1 0 001 1h1" />
+            </svg>
+            Copy share link
+          {/if}
+        </button>
+      {/if}
+      <button type="button" class="edit-btn" on:click={onedit}>
+        <svg
+          class="edit-arrow"
+          viewBox="0 0 16 16"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.75"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10 3 5 8l5 5" />
+        </svg>
+        Edit recipient info
+      </button>
+    </div>
   </header>
 
   <div class="rows" class:single={isSingle}>
@@ -68,6 +105,12 @@
       {/if}
     {/each}
   </div>
+  {#if shareUrl && copied}
+    <p class="share-disclosure">
+      Link copied. Note: the link contains your birthdate and PIA — only share
+      it with people you trust.
+    </p>
+  {/if}
 </section>
 
 <style>
@@ -83,6 +126,46 @@
     padding-bottom: 0.5rem;
     margin-bottom: 0.6rem;
     border-bottom: 1px solid #e5e7eb;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 0 0 auto;
+  }
+
+  .share-btn {
+    background: transparent;
+    border: 1px solid #d1d5db;
+    color: #4b5563;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .share-btn:hover,
+  .share-btn:focus-visible {
+    color: #081d88;
+    border-color: #081d88;
+    outline: none;
+  }
+  .share-btn:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 2px;
+  }
+
+  .share-disclosure {
+    margin: 0.5rem 0 0;
+    font-size: 0.8rem;
+    color: #6b7280;
+    line-height: 1.45;
   }
 
   .section-kicker {

--- a/src/routes/strategy/components/LockedSummary.svelte
+++ b/src/routes/strategy/components/LockedSummary.svelte
@@ -8,10 +8,12 @@
   export let onedit: () => void;
 
   let copied = false;
+  let copyError = false;
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
 
   async function handleCopy() {
     if (!shareUrl) return;
+    copyError = false;
     try {
       await navigator.clipboard.writeText(shareUrl);
       copied = true;
@@ -21,7 +23,7 @@
         copyTimer = null;
       }, 2000);
     } catch {
-      // Fallback: select a temporary input
+      copyError = true;
     }
   }
 
@@ -52,41 +54,23 @@
 <section class="locked">
   <header class="section-header">
     <p class="section-kicker">Recipient information</p>
-    <div class="header-actions">
-      {#if shareUrl}
-        <button type="button" class="share-btn" on:click={handleCopy}>
-          {#if copied}
-            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M2 8l4 4 8-8" />
-            </svg>
-            Copied!
-          {:else}
-            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <rect x="5" y="2" width="9" height="11" rx="1.5" />
-              <path d="M11 2V1a1 1 0 00-1-1H2a1 1 0 00-1 1v11a1 1 0 001 1h1" />
-            </svg>
-            Copy share link
-          {/if}
-        </button>
-      {/if}
-      <button type="button" class="edit-btn" on:click={onedit}>
-        <svg
-          class="edit-arrow"
-          viewBox="0 0 16 16"
-          width="14"
-          height="14"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="1.75"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <path d="M10 3 5 8l5 5" />
-        </svg>
-        Edit recipient info
-      </button>
-    </div>
+    <button type="button" class="edit-btn" on:click={onedit}>
+      <svg
+        class="edit-arrow"
+        viewBox="0 0 16 16"
+        width="14"
+        height="14"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.75"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M10 3 5 8l5 5" />
+      </svg>
+      Edit recipient info
+    </button>
   </header>
 
   <div class="rows" class:single={isSingle}>
@@ -105,11 +89,32 @@
       {/if}
     {/each}
   </div>
-  {#if shareUrl && copied}
-    <p class="share-disclosure">
-      Link copied. Note: the link contains your birthdate and PIA — only share
-      it with people you trust.
-    </p>
+
+  {#if shareUrl}
+    <div class="share-row">
+      <button type="button" class="share-btn" on:click={handleCopy}>
+        {#if copied}
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M2 8l4 4 8-8" />
+          </svg>
+          Copied!
+        {:else}
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="5" y="2" width="9" height="11" rx="1.5" />
+            <path d="M11 2V1a1 1 0 00-1-1H2a1 1 0 00-1 1v11a1 1 0 001 1h1" />
+          </svg>
+          Copy share link
+        {/if}
+      </button>
+      {#if copied}
+        <p class="share-disclosure">
+          Link copied. Note: the link contains your birthdate and PIA — only share
+          it with people you trust.
+        </p>
+      {:else if copyError}
+        <p class="share-error">Could not copy — please copy the URL from your browser's address bar.</p>
+      {/if}
+    </div>
   {/if}
 </section>
 
@@ -128,11 +133,12 @@
     border-bottom: 1px solid #e5e7eb;
   }
 
-  .header-actions {
+  .share-row {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex: 0 0 auto;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-top: 0.6rem;
+    flex-wrap: wrap;
   }
 
   .share-btn {
@@ -162,9 +168,16 @@
   }
 
   .share-disclosure {
-    margin: 0.5rem 0 0;
+    margin: 0;
     font-size: 0.8rem;
     color: #6b7280;
+    line-height: 1.45;
+  }
+
+  .share-error {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #d4351c;
     line-height: 1.45;
   }
 

--- a/src/test/url-params.test.ts
+++ b/src/test/url-params.test.ts
@@ -569,171 +569,6 @@ describe('UrlParams', () => {
       });
     });
 
-    describe('Gender Parameters', () => {
-      it('should parse recipient gender male', () => {
-        const params = new UrlParams('#gender1=male');
-        expect(params.getRecipientGender()).toBe('male');
-      });
-
-      it('should parse recipient gender female', () => {
-        const params = new UrlParams('#gender1=female');
-        expect(params.getRecipientGender()).toBe('female');
-      });
-
-      it('should parse recipient gender blended', () => {
-        const params = new UrlParams('#gender1=blended');
-        expect(params.getRecipientGender()).toBe('blended');
-      });
-
-      it('should default to blended for missing gender1', () => {
-        const params = new UrlParams('#pia1=3000&dob1=1965-09-21');
-        expect(params.getRecipientGender()).toBe('blended');
-      });
-
-      it('should default to blended for unrecognized gender1', () => {
-        const params = new UrlParams('#gender1=other');
-        expect(params.getRecipientGender()).toBe('blended');
-      });
-
-      it('should parse spouse gender', () => {
-        const params = new UrlParams('#gender2=female');
-        expect(params.getSpouseGender()).toBe('female');
-      });
-
-      it('should default to blended for missing gender2', () => {
-        const params = new UrlParams('#pia2=1000&dob2=1965-09-21');
-        expect(params.getSpouseGender()).toBe('blended');
-      });
-    });
-
-    describe('buildStrategyHash', () => {
-      it('should build single-person hash with required fields', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1965-09-21',
-        });
-        expect(hash).toBe('#pia1=2400&dob1=1965-09-21');
-      });
-
-      it('should include name1 when provided', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1965-09-21',
-          name1: 'Alex',
-        });
-        expect(hash).toContain('name1=Alex');
-      });
-
-      it('should include gender1 when not blended', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1965-09-21',
-          gender1: 'male',
-        });
-        expect(hash).toContain('gender1=male');
-      });
-
-      it('should omit gender1 when blended', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1965-09-21',
-          gender1: 'blended',
-        });
-        expect(hash).not.toContain('gender1');
-      });
-
-      it('should round PIA to nearest integer', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400.75,
-          dob1: '1965-09-21',
-        });
-        expect(hash).toContain('pia1=2401');
-      });
-
-      it('should build couple hash with spouse fields', () => {
-        const hash = buildStrategyHash({
-          isSingle: false,
-          pia1: 2400,
-          dob1: '1960-03-15',
-          name1: 'Alex',
-          gender1: 'male',
-          pia2: 1800,
-          dob2: '1962-07-22',
-          name2: 'Casey',
-          gender2: 'female',
-        });
-        expect(hash).toContain('pia1=2400');
-        expect(hash).toContain('dob1=1960-03-15');
-        expect(hash).toContain('name1=Alex');
-        expect(hash).toContain('gender1=male');
-        expect(hash).toContain('pia2=1800');
-        expect(hash).toContain('dob2=1962-07-22');
-        expect(hash).toContain('name2=Casey');
-        expect(hash).toContain('gender2=female');
-      });
-
-      it('should exclude spouse fields for isSingle=true even if provided', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1960-03-15',
-          pia2: 1800,
-          dob2: '1962-07-22',
-        });
-        expect(hash).not.toContain('pia2');
-        expect(hash).not.toContain('dob2');
-      });
-
-      it('should include names with special characters', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1965-09-21',
-          name1: "O'Brien",
-        });
-        // encodeURIComponent leaves apostrophe unencoded (unreserved char per RFC)
-        expect(hash).toContain("name1=O'Brien");
-      });
-
-      it('should URL-encode spaces in names', () => {
-        const hash = buildStrategyHash({
-          isSingle: true,
-          pia1: 2400,
-          dob1: '1965-09-21',
-          name1: 'Alex Smith',
-        });
-        expect(hash).toContain('name1=Alex%20Smith');
-      });
-
-      it('round-trip: hash can be re-parsed by UrlParams', () => {
-        const hash = buildStrategyHash({
-          isSingle: false,
-          pia1: 2400,
-          dob1: '1960-03-15',
-          name1: 'Alex',
-          gender1: 'male',
-          pia2: 1800,
-          dob2: '1962-07-22',
-          name2: 'Casey',
-          gender2: 'female',
-        });
-        const params = new UrlParams(hash);
-        expect(params.getRecipientPia()).toBe(2400);
-        expect(params.getRecipientDob()).toBe('1960-03-15');
-        expect(params.getRecipientName()).toBe('Alex');
-        expect(params.getRecipientGender()).toBe('male');
-        expect(params.getSpousePia()).toBe(1800);
-        expect(params.getSpouseDob()).toBe('1962-07-22');
-        expect(params.getSpouseName()).toBe('Casey');
-        expect(params.getSpouseGender()).toBe('female');
-      });
-    });
-
     describe('Real-World Earnings Examples', () => {
       it('should parse typical career progression', () => {
         const params = new UrlParams(
@@ -766,6 +601,171 @@ describe('UrlParams', () => {
         expect(recipientEarnings?.length).toBe(6);
         expect(spouseEarnings?.length).toBe(3);
       });
+    });
+  });
+
+  describe('Gender Parameters', () => {
+    it('should parse recipient gender male', () => {
+      const params = new UrlParams('#gender1=male');
+      expect(params.getRecipientGender()).toBe('male');
+    });
+
+    it('should parse recipient gender female', () => {
+      const params = new UrlParams('#gender1=female');
+      expect(params.getRecipientGender()).toBe('female');
+    });
+
+    it('should parse recipient gender blended', () => {
+      const params = new UrlParams('#gender1=blended');
+      expect(params.getRecipientGender()).toBe('blended');
+    });
+
+    it('should default to blended for missing gender1', () => {
+      const params = new UrlParams('#pia1=3000&dob1=1965-09-21');
+      expect(params.getRecipientGender()).toBe('blended');
+    });
+
+    it('should default to blended for unrecognized gender1', () => {
+      const params = new UrlParams('#gender1=other');
+      expect(params.getRecipientGender()).toBe('blended');
+    });
+
+    it('should parse spouse gender', () => {
+      const params = new UrlParams('#gender2=female');
+      expect(params.getSpouseGender()).toBe('female');
+    });
+
+    it('should default to blended for missing gender2', () => {
+      const params = new UrlParams('#pia2=1000&dob2=1965-09-21');
+      expect(params.getSpouseGender()).toBe('blended');
+    });
+  });
+
+  describe('buildStrategyHash', () => {
+    it('should build single-person hash with required fields', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1965-09-21',
+      });
+      expect(hash).toBe('#pia1=2400&dob1=1965-09-21');
+    });
+
+    it('should include name1 when provided', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1965-09-21',
+        name1: 'Alex',
+      });
+      expect(hash).toContain('name1=Alex');
+    });
+
+    it('should include gender1 when not blended', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1965-09-21',
+        gender1: 'male',
+      });
+      expect(hash).toContain('gender1=male');
+    });
+
+    it('should omit gender1 when blended', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1965-09-21',
+        gender1: 'blended',
+      });
+      expect(hash).not.toContain('gender1');
+    });
+
+    it('should round PIA to nearest integer', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400.75,
+        dob1: '1965-09-21',
+      });
+      expect(hash).toContain('pia1=2401');
+    });
+
+    it('should build couple hash with spouse fields', () => {
+      const hash = buildStrategyHash({
+        isSingle: false,
+        pia1: 2400,
+        dob1: '1960-03-15',
+        name1: 'Alex',
+        gender1: 'male',
+        pia2: 1800,
+        dob2: '1962-07-22',
+        name2: 'Casey',
+        gender2: 'female',
+      });
+      expect(hash).toContain('pia1=2400');
+      expect(hash).toContain('dob1=1960-03-15');
+      expect(hash).toContain('name1=Alex');
+      expect(hash).toContain('gender1=male');
+      expect(hash).toContain('pia2=1800');
+      expect(hash).toContain('dob2=1962-07-22');
+      expect(hash).toContain('name2=Casey');
+      expect(hash).toContain('gender2=female');
+    });
+
+    it('should exclude spouse fields for isSingle=true even if provided', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1960-03-15',
+        pia2: 1800,
+        dob2: '1962-07-22',
+      });
+      expect(hash).not.toContain('pia2');
+      expect(hash).not.toContain('dob2');
+    });
+
+    it('should include names with special characters', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1965-09-21',
+        name1: "O'Brien",
+      });
+      // encodeURIComponent leaves apostrophe unencoded (unreserved char per RFC)
+      expect(hash).toContain("name1=O'Brien");
+    });
+
+    it('should URL-encode spaces in names', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2400,
+        dob1: '1965-09-21',
+        name1: 'Alex Smith',
+      });
+      expect(hash).toContain('name1=Alex%20Smith');
+    });
+
+    it('round-trip: hash can be re-parsed by UrlParams', () => {
+      const hash = buildStrategyHash({
+        isSingle: false,
+        pia1: 2400,
+        dob1: '1960-03-15',
+        name1: 'Alex',
+        gender1: 'male',
+        pia2: 1800,
+        dob2: '1962-07-22',
+        name2: 'Casey',
+        gender2: 'female',
+      });
+      const params = new UrlParams(hash);
+      expect(params.getRecipientPia()).toBe(2400);
+      expect(params.getRecipientDob()).toBe('1960-03-15');
+      expect(params.getRecipientName()).toBe('Alex');
+      expect(params.getRecipientGender()).toBe('male');
+      expect(params.getSpousePia()).toBe(1800);
+      expect(params.getSpouseDob()).toBe('1962-07-22');
+      expect(params.getSpouseName()).toBe('Casey');
+      expect(params.getSpouseGender()).toBe('female');
     });
   });
 });

--- a/src/test/url-params.test.ts
+++ b/src/test/url-params.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { UrlParams } from '$lib/url-params';
+import { buildStrategyHash, UrlParams } from '$lib/url-params';
 
 describe('UrlParams', () => {
   describe('Constructor', () => {
@@ -566,6 +566,171 @@ describe('UrlParams', () => {
         expect(earnings?.length).toBe(40);
         expect(earnings?.[0]).toEqual({ year: 1985, amount: 30000 });
         expect(earnings?.[39]).toEqual({ year: 2024, amount: 69000 });
+      });
+    });
+
+    describe('Gender Parameters', () => {
+      it('should parse recipient gender male', () => {
+        const params = new UrlParams('#gender1=male');
+        expect(params.getRecipientGender()).toBe('male');
+      });
+
+      it('should parse recipient gender female', () => {
+        const params = new UrlParams('#gender1=female');
+        expect(params.getRecipientGender()).toBe('female');
+      });
+
+      it('should parse recipient gender blended', () => {
+        const params = new UrlParams('#gender1=blended');
+        expect(params.getRecipientGender()).toBe('blended');
+      });
+
+      it('should default to blended for missing gender1', () => {
+        const params = new UrlParams('#pia1=3000&dob1=1965-09-21');
+        expect(params.getRecipientGender()).toBe('blended');
+      });
+
+      it('should default to blended for unrecognized gender1', () => {
+        const params = new UrlParams('#gender1=other');
+        expect(params.getRecipientGender()).toBe('blended');
+      });
+
+      it('should parse spouse gender', () => {
+        const params = new UrlParams('#gender2=female');
+        expect(params.getSpouseGender()).toBe('female');
+      });
+
+      it('should default to blended for missing gender2', () => {
+        const params = new UrlParams('#pia2=1000&dob2=1965-09-21');
+        expect(params.getSpouseGender()).toBe('blended');
+      });
+    });
+
+    describe('buildStrategyHash', () => {
+      it('should build single-person hash with required fields', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1965-09-21',
+        });
+        expect(hash).toBe('#pia1=2400&dob1=1965-09-21');
+      });
+
+      it('should include name1 when provided', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1965-09-21',
+          name1: 'Alex',
+        });
+        expect(hash).toContain('name1=Alex');
+      });
+
+      it('should include gender1 when not blended', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1965-09-21',
+          gender1: 'male',
+        });
+        expect(hash).toContain('gender1=male');
+      });
+
+      it('should omit gender1 when blended', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1965-09-21',
+          gender1: 'blended',
+        });
+        expect(hash).not.toContain('gender1');
+      });
+
+      it('should round PIA to nearest integer', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400.75,
+          dob1: '1965-09-21',
+        });
+        expect(hash).toContain('pia1=2401');
+      });
+
+      it('should build couple hash with spouse fields', () => {
+        const hash = buildStrategyHash({
+          isSingle: false,
+          pia1: 2400,
+          dob1: '1960-03-15',
+          name1: 'Alex',
+          gender1: 'male',
+          pia2: 1800,
+          dob2: '1962-07-22',
+          name2: 'Casey',
+          gender2: 'female',
+        });
+        expect(hash).toContain('pia1=2400');
+        expect(hash).toContain('dob1=1960-03-15');
+        expect(hash).toContain('name1=Alex');
+        expect(hash).toContain('gender1=male');
+        expect(hash).toContain('pia2=1800');
+        expect(hash).toContain('dob2=1962-07-22');
+        expect(hash).toContain('name2=Casey');
+        expect(hash).toContain('gender2=female');
+      });
+
+      it('should exclude spouse fields for isSingle=true even if provided', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1960-03-15',
+          pia2: 1800,
+          dob2: '1962-07-22',
+        });
+        expect(hash).not.toContain('pia2');
+        expect(hash).not.toContain('dob2');
+      });
+
+      it('should include names with special characters', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1965-09-21',
+          name1: "O'Brien",
+        });
+        // encodeURIComponent leaves apostrophe unencoded (unreserved char per RFC)
+        expect(hash).toContain("name1=O'Brien");
+      });
+
+      it('should URL-encode spaces in names', () => {
+        const hash = buildStrategyHash({
+          isSingle: true,
+          pia1: 2400,
+          dob1: '1965-09-21',
+          name1: 'Alex Smith',
+        });
+        expect(hash).toContain('name1=Alex%20Smith');
+      });
+
+      it('round-trip: hash can be re-parsed by UrlParams', () => {
+        const hash = buildStrategyHash({
+          isSingle: false,
+          pia1: 2400,
+          dob1: '1960-03-15',
+          name1: 'Alex',
+          gender1: 'male',
+          pia2: 1800,
+          dob2: '1962-07-22',
+          name2: 'Casey',
+          gender2: 'female',
+        });
+        const params = new UrlParams(hash);
+        expect(params.getRecipientPia()).toBe(2400);
+        expect(params.getRecipientDob()).toBe('1960-03-15');
+        expect(params.getRecipientName()).toBe('Alex');
+        expect(params.getRecipientGender()).toBe('male');
+        expect(params.getSpousePia()).toBe(1800);
+        expect(params.getSpouseDob()).toBe('1962-07-22');
+        expect(params.getSpouseName()).toBe('Casey');
+        expect(params.getSpouseGender()).toBe('female');
       });
     });
 


### PR DESCRIPTION
## Summary

- Extends `UrlParams` with `getRecipientGender()` / `getSpouseGender()` methods and a `buildStrategyHash()` serializer that produces hash strings like `#pia1=2400&dob1=1960-03-15&gender1=male&...`
- On mount, `/strategy` reads `window.location.hash` — if valid `pia1`+`dob1` params are present, populates the form and skips the mode-picker directly to the form stage. Couple mode is inferred from presence of `pia2`+`dob2`.
- Adds a **Copy share link** button to the results `LockedSummary` bar (next to "Edit recipient info"). An inline disclosure — *"Link copied. Note: the link contains your birthdate and PIA — only share it with people you trust."* — appears on successful copy.
- Documents the new strategy params in `/guides/url-parameters` with single and couple examples.
- 100% round-trip tested: `buildStrategyHash` output re-parses correctly through `UrlParams`.

## Test plan

- [ ] Visit `/strategy#pia1=2400&dob1=1965-09-21&name1=Alex&gender1=male` — should land on pre-filled form in single mode
- [ ] Visit `/strategy#pia1=2400&dob1=1960-03-15&name1=Alex&gender1=male&pia2=1800&dob2=1962-07-22&name2=Casey&gender2=female` — should land on pre-filled form in couple mode
- [ ] Run through to results, click "Copy share link" — copied URL should re-open with identical pre-filled form
- [ ] Verify privacy disclosure appears after clicking Copy
- [ ] Visit `/guides/url-parameters` and confirm new Strategy Optimizer section + working example links
- [ ] All 1920 tests pass (`npm run test`)