### PR TITLE
feat(calculator): rename Filing Date to Filing Strategy, move CTA into section

### DIFF
--- a/src/lib/components/CombinedChart.svelte
+++ b/src/lib/components/CombinedChart.svelte
@@ -450,36 +450,6 @@
     </div>
   </div>
 
-  {#if !$activeIntegration}
-    <p>
-      Choosing a filing date is a complex and personal decision. It often
-      depends on your health, your financial situation, and your plans for
-      retirement. There can be no one-size-fits-all answer.
-    </p>
-    <p>
-      That said, some prefer to calculate a strategy based on maximizing your
-      total actuarial lifetime benefits. A recommended free tool for doing this
-      is Open Social Security. The following link will open pre-populated with
-      the information you've already entered here:
-    </p>
-    <p>
-      <a
-        href="https://opensocialsecurity.com/?marital=married&aDOBm={recipientCtx_.r.birthdate.layBirthMonth() +
-          1}&aDOBd={recipientCtx_.r.birthdate.layBirthDayOfMonth()}&aDOBy={recipientCtx_.r.birthdate.layBirthYear()}&aPIA={recipientCtx_.r
-          .pia()
-          .primaryInsuranceAmount()
-          .roundToDollar()
-          .value()}&bPIA={spouseCtx_.r
-          .pia()
-          .primaryInsuranceAmount()
-          .roundToDollar()
-          .value()}&bDOBm={spouseCtx_.r.birthdate.layBirthMonth() +
-          1}&bDOBd={spouseCtx_.r.birthdate.layBirthDayOfMonth()}&bDOBy={spouseCtx_.r.birthdate.layBirthYear()}
-"
-        target="_blank">Open Social Security (populated with my information)</a
-      >
-    </p>
-  {/if}
 </div>
 
 <style>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,77 +1,125 @@
 <script lang="ts">
 export let active = 'none';
 
-let navOptions = [
-  { name: 'Calculator', link: 'calculator', active: false },
-  { name: 'Guides', link: 'guides', active: false },
-  { name: 'About', link: 'about', active: false },
-  { name: 'Contact', link: 'contact', active: false },
+const flowNav = [
+  { name: 'Calculator', link: 'calculator' },
+  { name: 'Strategy', link: 'strategy' },
 ];
-$: active && navOptions.forEach((o) => (o.active = o.name === active));
+
+const mainNav = [
+  { name: 'Guides', link: 'guides' },
+  { name: 'About', link: 'about' },
+  { name: 'Contact', link: 'contact' },
+];
 </script>
 
 <div class="header">
   <h3><a href="/">SSA.tools</a></h3>
 
-  <div class="navpills" style:--pill-count={navOptions.length.toString()}>
-    {#each navOptions as option}
-      <div class="pill noprint" class:active={option.active}>
-        <a href="/{option.link}">{option.name}</a>
-      </div>
-    {/each}
-  </div>
+  <nav class="navpills noprint">
+    <div class="flow-group">
+      {#each flowNav as option, i}
+        {#if i > 0}
+          <svg
+            class="flow-arrow"
+            viewBox="0 0 16 16"
+            width="10"
+            height="10"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 3l6 5-6 5" />
+          </svg>
+        {/if}
+        <div class="pill" class:active={option.name === active}>
+          <a href="/{option.link}">{option.name}</a>
+        </div>
+      {/each}
+    </div>
+
+    <div class="main-group">
+      {#each mainNav as option}
+        <div class="pill" class:active={option.name === active}>
+          <a href="/{option.link}">{option.name}</a>
+        </div>
+      {/each}
+    </div>
+  </nav>
+
   <div class="onlyprint printurl">https://ssa.tools/</div>
 </div>
 
 <style>
-  /* Page Header with title and static links */
   .header {
     display: grid;
     grid-template-columns: 1fr auto;
-    align-items: center; /* Added for vertical alignment */
+    align-items: center;
     width: 100%;
     border-bottom: 1px solid #c5c5c5;
-    margin-bottom: 1.5em; /* Adjusted for better spacing */
+    margin-bottom: 1.5em;
   }
 
   h3 {
     margin: 0;
-    /* Removed line-height: 40px; as align-items handles vertical centering */
-    color: #333; /* Made title more prominent */
+    color: #333;
     font-weight: 500;
-    font-size: 28px; /* Increased font size */
-    padding-left: 1em; /* Adjusted padding */
+    font-size: 28px;
+    padding-left: 1em;
     white-space: nowrap;
   }
   h3 a {
-    color: #333; /* Made title more prominent */
-    text-decoration: none; /* Remove underline */
+    color: #333;
+    text-decoration: none;
   }
+
   .printurl {
     margin: 0 1em;
     line-height: 40px;
     color: rgb(50, 50, 50);
     font-weight: 900;
     font-size: 20px;
-    display: none; /* Hidden by default, shown only in print */
+    display: none;
   }
-
   @media print {
     .printurl {
-      display: block; /* Show in print */
+      display: block;
     }
   }
 
-  /* Navigation Pills */
   .navpills {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0.5em 1em;
     font-size: 14px;
-    display: grid !important;
-    grid-template-columns: repeat(var(--pill-count), auto);
-    column-gap: 10px;
-    margin: 0.5em 1em; /* Adjusted margin */
   }
+
+  .flow-group {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .main-group {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 10px;
+    padding-left: 10px;
+    border-left: 1px solid #e0e0e0;
+  }
+
+  .flow-arrow {
+    color: #bbb;
+    flex-shrink: 0;
+    margin: 0 1px;
+  }
+
   .pill {
-    /** Vertically aligns he pill */
     display: flex;
   }
   .pill a {
@@ -80,22 +128,18 @@ $: active && navOptions.forEach((o) => (o.active = o.name === active));
     padding: 10px 15px;
     text-decoration: none;
     vertical-align: middle;
+    color: inherit;
   }
   .pill a:hover {
-    background-color: #f0f0f0; /* Added hover effect */
+    background-color: #f0f0f0;
   }
   .pill.active a {
-    /* Changed from span to a */
     color: #fff;
     background-color: #337ab7;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2); /* Added subtle shadow */
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   }
 
   @media screen and (max-width: 675px) {
-    /**
-    * Below 650px the pills and header start to collide, so
-    * we move them to separate lines and center.
-    */
     .header {
       grid-template-columns: 1fr;
       justify-items: center;

--- a/src/lib/components/StrategyPromo.svelte
+++ b/src/lib/components/StrategyPromo.svelte
@@ -47,12 +47,7 @@
 </script>
 
 <div class="pageBreakAvoid">
-  <p class="intro">
-    Now that you know your Primary Insurance Amount{spouse ? "s" : ""}, use
-    the SSA.tools <strong>Strategy Optimizer</strong> to find the filing
-    date{spouse ? "s" : ""} that maximize{spouse ? "" : "s"} your lifetime
-    benefits.
-  </p>
+  <h3 class="subheading">Strategy Optimizer</h3>
   {#if spouse}
     <p class="pia-summary">
       Your PIAs are <strong>{formatPia(recipient)}</strong> for
@@ -86,9 +81,11 @@
 </div>
 
 <style>
-  .intro {
-    margin: 0 0.5rem 0.75rem;
-    line-height: 1.5;
+  .subheading {
+    margin: 0.75rem 0.5rem 0.4rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #0b0c0c;
   }
 
   .pia-summary {

--- a/src/routes/calculator/+page.svelte
+++ b/src/routes/calculator/+page.svelte
@@ -203,8 +203,11 @@ async function loadIntegrationComponents(
           <SidebarSection label="Normal Retirement Age" underSticky>
             <NormalRetirementAgeReport recipient={$recipient} />
           </SidebarSection>
-          <SidebarSection label="Filing Date" underSticky>
+          <SidebarSection label="Filing Strategy" underSticky>
             <FilingDateReport recipient={$recipient} />
+            {#if !$activeIntegration && !$spouse}
+              <StrategyPromo recipient={$recipient} spouse={null} />
+            {/if}
           </SidebarSection>
         {:else}
           <SidebarSection label="Primary Insurance Amount" underSticky>
@@ -218,8 +221,11 @@ async function loadIntegrationComponents(
           <SidebarSection label="Normal Retirement Age">
             <NormalRetirementAgeReport recipient={$recipient} />
           </SidebarSection>
-          <SidebarSection label="Filing Date">
+          <SidebarSection label="Filing Strategy">
             <FilingDateReport recipient={$recipient} />
+            {#if !$activeIntegration && !$spouse}
+              <StrategyPromo recipient={$recipient} spouse={null} />
+            {/if}
           </SidebarSection>
         {/if}
       </div>
@@ -273,11 +279,14 @@ async function loadIntegrationComponents(
             spouse={$spouse}
           />
         </SidebarSection>
-        <SidebarSection label="Filing Dates">
+        <SidebarSection label="Filing Strategy">
           <CombinedChart
             recipient={$recipient}
             spouse={$spouse}
           />
+          {#if !$activeIntegration}
+            <StrategyPromo recipient={$recipient} spouse={$spouse} />
+          {/if}
         </SidebarSection>
         <SidebarSection label="Survivor Benefit">
           <SurvivorReport
@@ -286,11 +295,7 @@ async function loadIntegrationComponents(
           />
         </SidebarSection>
       {/if}
-      {#if !$activeIntegration}
-        <SidebarSection label="Strategy Optimizer">
-          <StrategyPromo recipient={$recipient} spouse={$spouse} />
-        </SidebarSection>
-      {:else if ReportEndComponent && integrationComponentsLoaded}
+      {#if $activeIntegration && ReportEndComponent && integrationComponentsLoaded}
         <SidebarSection
           label={$activeIntegration.reportEndLabel}
           integration={true}

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -595,7 +595,7 @@
   />
 </svelte:head>
 
-<Header />
+<Header active="Strategy" />
 
 <main>
   <div class="limited-width">


### PR DESCRIPTION
## Summary

- Renames the "Filing Date" sidebar section to "Filing Strategy" for both single and couple calculator flows
- Moves the Strategy Optimizer CTA (introduced in #542) inside the "Filing Strategy" section rather than a separate top-level section, so it appears naturally at the end of the filing date chart

## Test plan

- [ ] Single recipient: sidebar shows "Filing Strategy", CTA button appears below the filing date chart
- [ ] Couple: sidebar shows "Filing Strategy", CTA appears below the combined chart
- [ ] Integration flow: no StrategyPromo shown when an active integration is present