### PR TITLE
fix(seo): allow crawling of /strategy page

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Allow: /
-Disallow: /strategy
 
 Sitemap: https://ssa.tools/sitemap.xml


### PR DESCRIPTION
## Summary
- Removes `Disallow: /strategy` from `robots.txt` so search engines can index the Strategy Optimizer page.

## Test plan
- [ ] Verify `robots.txt` no longer blocks `/strategy`
- [ ] Confirm no other routes are inadvertently affected