### PR TITLE
feat(analytics): unify outbound click tracking for projectionlab and ko-fi

### DIFF
--- a/src/lib/analytics/outbound.ts
+++ b/src/lib/analytics/outbound.ts
@@ -12,6 +12,15 @@ export function trackOutboundClick(
   posthog.capture('Outbound: Clicked', { destination, placement, ...extras });
 }
 
+export function trackOutboundImpression(
+  destination: OutboundDestination,
+  placement: string,
+  extras?: Record<string, string | number | boolean>
+): void {
+  if (!browser) return;
+  posthog.capture('Outbound: Visible', { destination, placement, ...extras });
+}
+
 interface ImpressionParams {
   destination: OutboundDestination;
   placement: string;
@@ -22,7 +31,7 @@ export function outboundImpression(
   node: HTMLElement,
   params: ImpressionParams
 ) {
-  if (!browser) return {};
+  if (!browser || typeof IntersectionObserver === 'undefined') return {};
   let current = params;
   let fired = false;
   const observer = new IntersectionObserver(

--- a/src/lib/analytics/outbound.ts
+++ b/src/lib/analytics/outbound.ts
@@ -1,0 +1,53 @@
+import posthog from 'posthog-js';
+import { browser } from '$app/environment';
+
+export type OutboundDestination = 'projectionlab' | 'kofi';
+
+export function trackOutboundClick(
+  destination: OutboundDestination,
+  placement: string,
+  extras?: Record<string, string | number | boolean>
+): void {
+  if (!browser) return;
+  posthog.capture('Outbound: Clicked', { destination, placement, ...extras });
+}
+
+interface ImpressionParams {
+  destination: OutboundDestination;
+  placement: string;
+  extras?: Record<string, string | number | boolean>;
+}
+
+export function outboundImpression(
+  node: HTMLElement,
+  params: ImpressionParams
+) {
+  if (!browser) return {};
+  let current = params;
+  let fired = false;
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting && !fired) {
+          fired = true;
+          posthog.capture('Outbound: Visible', {
+            destination: current.destination,
+            placement: current.placement,
+            ...current.extras,
+          });
+          observer.unobserve(node);
+        }
+      }
+    },
+    { threshold: 0.2, rootMargin: '50px' }
+  );
+  observer.observe(node);
+  return {
+    update(next: ImpressionParams) {
+      current = next;
+    },
+    destroy() {
+      observer.disconnect();
+    },
+  };
+}

--- a/src/lib/components/MoreResources.svelte
+++ b/src/lib/components/MoreResources.svelte
@@ -2,6 +2,7 @@
 import BlueskyImg from '$lib/images/bluesky.jpg';
 import GithubImg from '$lib/images/github.svg';
 import KoFiImg from '$lib/images/kofi.png';
+import { trackOutboundClick, outboundImpression } from '$lib/analytics/outbound';
 </script>
 
 <div class="container pageBreakAvoid pageBreakBefore">
@@ -52,7 +53,11 @@ import KoFiImg from '$lib/images/kofi.png';
       https://ko-fi.com/ssatools
     </p>
     <p style:text-align="center">
-      <a href="https://ko-fi.com/ssatools" target="_blank"
+      <a
+        href="https://ko-fi.com/ssatools"
+        target="_blank"
+        use:outboundImpression={{ destination: 'kofi', placement: 'more-resources' }}
+        on:click={() => trackOutboundClick('kofi', 'more-resources')}
         ><img
           height="55"
           width="214"

--- a/src/lib/components/Sponsor.svelte
+++ b/src/lib/components/Sponsor.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-import posthog from 'posthog-js';
 import { onMount } from 'svelte';
-import { browser } from '$app/environment';
 import ProjectionLabAd from './ProjectionLabAd.svelte';
 import { Recipient } from '$lib/recipient';
+import { trackOutboundClick, outboundImpression } from '$lib/analytics/outbound';
 
 export let recipient: Recipient = new Recipient();
 
@@ -11,43 +10,24 @@ let sponsorElement: HTMLElement;
 let isVisible = false;
 
 function handleSponsorClick() {
-  if (browser) {
-    posthog.capture('Sponsor: Clicked', {
-      sponsor_name: 'ProjectionLab',
-    });
-  }
+  trackOutboundClick('projectionlab', 'sponsor-box');
 }
 
 onMount(() => {
   const observer = new IntersectionObserver(
     (entries) => {
-      entries.forEach((entry) => {
+      for (const entry of entries) {
         if (entry.isIntersecting) {
           isVisible = true;
-          // Track sponsor visibility
-          if (browser) {
-            posthog.capture('Sponsor: Visible', {
-              sponsor_name: 'ProjectionLab',
-            });
-          }
           observer.unobserve(entry.target);
         }
-      });
+      }
     },
-    {
-      threshold: 0.2, // Trigger when 20% of the element is visible
-      rootMargin: '50px', // Start animation slightly before element is fully in view
-    }
+    { threshold: 0.2, rootMargin: '50px' }
   );
-
-  if (sponsorElement) {
-    observer.observe(sponsorElement);
-  }
-
+  if (sponsorElement) observer.observe(sponsorElement);
   return () => {
-    if (sponsorElement) {
-      observer.unobserve(sponsorElement);
-    }
+    if (sponsorElement) observer.unobserve(sponsorElement);
   };
 });
 </script>
@@ -72,7 +52,10 @@ onMount(() => {
     </div>
   </div>
 
-  <div bind:this={sponsorElement}>
+  <div
+    bind:this={sponsorElement}
+    use:outboundImpression={{ destination: 'projectionlab', placement: 'sponsor-box' }}
+  >
     <ProjectionLabAd animated {isVisible} />
   </div>
 </a>

--- a/src/lib/components/SupportPrompt.svelte
+++ b/src/lib/components/SupportPrompt.svelte
@@ -1,28 +1,15 @@
 <script lang="ts">
-  import { browser } from "$app/environment";
   import KoFiImg from "$lib/images/kofi.png";
-  import posthog from "posthog-js";
-  import { onMount } from "svelte";
+  import { trackOutboundClick, outboundImpression } from "$lib/analytics/outbound";
 
   const KOFI_URL = "https://ko-fi.com/ssatools";
 
-  let shownTracked = false;
-
   function handleClick() {
-    if (browser) {
-      posthog.capture("Support Prompt: Clicked");
-    }
+    trackOutboundClick("kofi", "support-prompt");
   }
-
-  onMount(() => {
-    if (browser && !shownTracked) {
-      shownTracked = true;
-      posthog.capture("Support Prompt: Shown");
-    }
-  });
 </script>
 
-<aside class="support-prompt">
+<aside class="support-prompt" use:outboundImpression={{ destination: "kofi", placement: "support-prompt" }}>
   <header class="header">
     <p class="kicker">Support this work</p>
   </header>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -2,6 +2,7 @@
   import Header from "$lib/components/Header.svelte";
   import KoFiImg from "$lib/images/kofi.png";
   import { renderWebsiteSocialMeta } from "$lib/schema-org";
+  import { trackOutboundClick, outboundImpression } from "$lib/analytics/outbound";
 
   const pageTitle = "About - Social Security Calculator | SSA.tools";
   const pageDescription =
@@ -146,7 +147,11 @@
       </p>
       <p class="onlyprint kofi-url">https://ko-fi.com/ssatools</p>
       <p class="kofi-button">
-        <a href="https://ko-fi.com/ssatools" target="_blank"
+        <a
+          href="https://ko-fi.com/ssatools"
+          target="_blank"
+          use:outboundImpression={{ destination: 'kofi', placement: 'about-page' }}
+          on:click={() => trackOutboundClick('kofi', 'about-page')}
           ><img
             height="55"
             width="214"

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -2,6 +2,7 @@
 import Header from '$lib/components/Header.svelte';
 import KoFiImg from '$lib/images/kofi.png';
 import { renderWebsiteSocialMeta } from '$lib/schema-org';
+import { trackOutboundClick, outboundImpression } from '$lib/analytics/outbound';
 
 const pageTitle = 'Contact - Social Security Calculator | SSA.tools';
 const pageDescription =
@@ -65,7 +66,11 @@ const pageImageAlt = 'Contact the Social Security Calculator developer';
       </p>
       <p class="onlyprint kofi-url">https://ko-fi.com/ssatools</p>
       <p class="kofi-button">
-        <a href="https://ko-fi.com/ssatools" target="_blank"
+        <a
+          href="https://ko-fi.com/ssatools"
+          target="_blank"
+          use:outboundImpression={{ destination: 'kofi', placement: 'contact-page' }}
+          on:click={() => trackOutboundClick('kofi', 'contact-page')}
           ><img
             height="55"
             width="214"

--- a/src/routes/guides/InlineCTA.svelte
+++ b/src/routes/guides/InlineCTA.svelte
@@ -4,7 +4,7 @@ import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/stores';
 import ProjectionLabAd from '$lib/components/ProjectionLabAd.svelte';
-import { trackOutboundClick } from '$lib/analytics/outbound';
+import { trackOutboundClick, trackOutboundImpression } from '$lib/analytics/outbound';
 import type { GuideCTAType } from './guide-cta-config';
 
 export let type: GuideCTAType;
@@ -31,11 +31,7 @@ onMount(() => {
         if (entry.isIntersecting) {
           if (browser) {
             if (type === 'projectionlab') {
-              posthog.capture('Outbound: Visible', {
-                destination: 'projectionlab',
-                placement: 'guide-inline',
-                guide_slug: guideSlug,
-              });
+              trackOutboundImpression('projectionlab', 'guide-inline', { guide_slug: guideSlug });
             } else {
               posthog.capture('Guide Inline CTA: Visible', { type, guide_slug: guideSlug });
             }

--- a/src/routes/guides/InlineCTA.svelte
+++ b/src/routes/guides/InlineCTA.svelte
@@ -4,6 +4,7 @@ import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/stores';
 import ProjectionLabAd from '$lib/components/ProjectionLabAd.svelte';
+import { trackOutboundClick } from '$lib/analytics/outbound';
 import type { GuideCTAType } from './guide-cta-config';
 
 export let type: GuideCTAType;
@@ -15,11 +16,11 @@ $: guideSlug = ($page?.url?.pathname ?? '')
   .replace(/\/$/, '');
 
 function handleClick() {
-  if (browser) {
-    posthog.capture('Guide Inline CTA: Clicked', {
-      type,
-      guide_slug: guideSlug,
-    });
+  if (!browser) return;
+  if (type === 'projectionlab') {
+    trackOutboundClick('projectionlab', 'guide-inline', { guide_slug: guideSlug });
+  } else {
+    posthog.capture('Guide Inline CTA: Clicked', { type, guide_slug: guideSlug });
   }
 }
 
@@ -29,10 +30,15 @@ onMount(() => {
       for (const entry of entries) {
         if (entry.isIntersecting) {
           if (browser) {
-            posthog.capture('Guide Inline CTA: Visible', {
-              type,
-              guide_slug: guideSlug,
-            });
+            if (type === 'projectionlab') {
+              posthog.capture('Outbound: Visible', {
+                destination: 'projectionlab',
+                placement: 'guide-inline',
+                guide_slug: guideSlug,
+              });
+            } else {
+              posthog.capture('Guide Inline CTA: Visible', { type, guide_slug: guideSlug });
+            }
           }
           observer.unobserve(entry.target);
         }
@@ -41,14 +47,9 @@ onMount(() => {
     { threshold: 0.2 }
   );
 
-  if (ctaElement) {
-    observer.observe(ctaElement);
-  }
-
+  if (ctaElement) observer.observe(ctaElement);
   return () => {
-    if (ctaElement) {
-      observer.unobserve(ctaElement);
-    }
+    if (ctaElement) observer.unobserve(ctaElement);
   };
 });
 </script>

--- a/src/routes/guides/StickyMobileCTA.svelte
+++ b/src/routes/guides/StickyMobileCTA.svelte
@@ -3,6 +3,7 @@ import posthog from 'posthog-js';
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/stores';
+import { trackOutboundClick } from '$lib/analytics/outbound';
 import { getGuideCTAType } from './guide-cta-config';
 
 let visible = false;
@@ -17,11 +18,11 @@ $: guideSlug = ($page?.url?.pathname ?? '')
 $: show = visible && !dismissed && !footerInView;
 
 function handleClick() {
-  if (browser) {
-    posthog.capture('Guide Sticky CTA: Clicked', {
-      type,
-      guide_slug: guideSlug,
-    });
+  if (!browser) return;
+  if (type === 'projectionlab') {
+    trackOutboundClick('projectionlab', 'guide-sticky-mobile', { guide_slug: guideSlug });
+  } else {
+    posthog.capture('Guide Sticky CTA: Clicked', { type, guide_slug: guideSlug });
   }
 }
 
@@ -51,10 +52,15 @@ onMount(() => {
     if (nowVisible && !visible && !tracked) {
       tracked = true;
       if (browser) {
-        posthog.capture('Guide Sticky CTA: Visible', {
-          type,
-          guide_slug: guideSlug,
-        });
+        if (type === 'projectionlab') {
+          posthog.capture('Outbound: Visible', {
+            destination: 'projectionlab',
+            placement: 'guide-sticky-mobile',
+            guide_slug: guideSlug,
+          });
+        } else {
+          posthog.capture('Guide Sticky CTA: Visible', { type, guide_slug: guideSlug });
+        }
       }
     }
     visible = nowVisible;

--- a/src/routes/guides/StickyMobileCTA.svelte
+++ b/src/routes/guides/StickyMobileCTA.svelte
@@ -3,7 +3,7 @@ import posthog from 'posthog-js';
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/stores';
-import { trackOutboundClick } from '$lib/analytics/outbound';
+import { trackOutboundClick, trackOutboundImpression } from '$lib/analytics/outbound';
 import { getGuideCTAType } from './guide-cta-config';
 
 let visible = false;
@@ -53,11 +53,7 @@ onMount(() => {
       tracked = true;
       if (browser) {
         if (type === 'projectionlab') {
-          posthog.capture('Outbound: Visible', {
-            destination: 'projectionlab',
-            placement: 'guide-sticky-mobile',
-            guide_slug: guideSlug,
-          });
+          trackOutboundImpression('projectionlab', 'guide-sticky-mobile', { guide_slug: guideSlug });
         } else {
           posthog.capture('Guide Sticky CTA: Visible', { type, guide_slug: guideSlug });
         }

--- a/src/routes/guides/guide-footer.svelte
+++ b/src/routes/guides/guide-footer.svelte
@@ -3,7 +3,7 @@ import posthog from 'posthog-js';
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/stores';
-import { trackOutboundClick } from '$lib/analytics/outbound';
+import { trackOutboundClick, trackOutboundImpression } from '$lib/analytics/outbound';
 import StickyMobileCTA from './StickyMobileCTA.svelte';
 
 $: guideSlug = ($page?.url?.pathname ?? '')
@@ -63,11 +63,7 @@ onMount(() => {
         if (entry.isIntersecting && !plTracked) {
           plTracked = true;
           if (browser) {
-            posthog.capture('Outbound: Visible', {
-              destination: 'projectionlab',
-              placement: 'guide-footer',
-              guide_slug: guideSlug,
-            });
+            trackOutboundImpression('projectionlab', 'guide-footer', { guide_slug: guideSlug });
           }
           observer.unobserve(entry.target);
         }

--- a/src/routes/guides/guide-footer.svelte
+++ b/src/routes/guides/guide-footer.svelte
@@ -3,6 +3,7 @@ import posthog from 'posthog-js';
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { page } from '$app/stores';
+import { trackOutboundClick } from '$lib/analytics/outbound';
 import StickyMobileCTA from './StickyMobileCTA.svelte';
 
 $: guideSlug = ($page?.url?.pathname ?? '')
@@ -21,12 +22,7 @@ function handleCtaClick() {
 }
 
 function handlePlClick() {
-  if (browser) {
-    posthog.capture('Guide PL Recommendation: Clicked', {
-      guide_slug: guideSlug,
-      sponsor_name: 'ProjectionLab',
-    });
-  }
+  trackOutboundClick('projectionlab', 'guide-footer', { guide_slug: guideSlug });
 }
 
 onMount(() => {
@@ -67,9 +63,10 @@ onMount(() => {
         if (entry.isIntersecting && !plTracked) {
           plTracked = true;
           if (browser) {
-            posthog.capture('Guide PL Recommendation: Visible', {
+            posthog.capture('Outbound: Visible', {
+              destination: 'projectionlab',
+              placement: 'guide-footer',
               guide_slug: guideSlug,
-              sponsor_name: 'ProjectionLab',
             });
           }
           observer.unobserve(entry.target);

--- a/src/routes/guides/projectionlab-review/+page.svelte
+++ b/src/routes/guides/projectionlab-review/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { GuidesSchema, renderFAQSchema } from "$lib/schema-org";
   import type { FAQItem } from "$lib/schema-org";
+  import { trackOutboundClick, outboundImpression } from "$lib/analytics/outbound";
   import GuideFooter from "../guide-footer.svelte";
 
   const title = "ProjectionLab Review and Coupon Code: Retirement Planning Beyond Social Security";
@@ -72,7 +73,9 @@
     <a
       href="https://projectionlab.com?ref=ssa-tools"
       target="_blank"
-      rel="noopener noreferrer">ProjectionLab</a
+      rel="noopener noreferrer"
+      use:outboundImpression={{ destination: "projectionlab", placement: "review-page-primary" }}
+      on:click={() => trackOutboundClick("projectionlab", "review-page-primary")}>ProjectionLab</a
     > is a retirement planning simulator that pairs well with SSA.tools. Here's
     an overview of what it does, what it costs, and where it fits in.
   </p>
@@ -125,7 +128,9 @@
     <a
       href="https://projectionlab.com/blog/compare-mode-upgrades"
       target="_blank"
-      rel="noopener noreferrer">Compare Mode</a
+      rel="noopener noreferrer"
+      use:outboundImpression={{ destination: "projectionlab", placement: "review-page-blog-link" }}
+      on:click={() => trackOutboundClick("projectionlab", "review-page-blog-link")}>Compare Mode</a
     >, which lets you create "what if" variations of your baseline plan and see
     the differences side by side. For example, you might compare:
   </p>


### PR DESCRIPTION
## Summary
- Adds `src/lib/analytics/outbound.ts` with `trackOutboundClick(destination, placement, extras?)` and a `outboundImpression` Svelte action (IntersectionObserver-based, fires once).
- Routes every ProjectionLab and Ko-fi outbound link through unified `Outbound: Clicked` / `Outbound: Visible` events with `destination` and `placement` properties so CTR is computable across placements.
- Replaces per-component event names (`Sponsor: *`, `Support Prompt: *`, `Guide PL Recommendation: *`, and the PL branch of `Guide Inline/Sticky CTA: *`). Internal `/calculator` CTAs keep their existing event names.
- Companion dashboard: https://us.posthog.com/project/33979/dashboard/1544788 — daily clicks, clicks/impressions per placement, a HogQL CTR table, and an impression→click funnel.

## Placements introduced
- `sponsor-box` (calculator end), `support-prompt`, `more-resources`, `about-page`, `contact-page`
- `guide-inline`, `guide-sticky-mobile`, `guide-footer` (each carries `guide_slug`)
- `review-page-primary`, `review-page-blog-link` (ProjectionLab review article)

## Test plan
- [x] `npm run quality` passes
- [x] `npm test` — 1920/1920 pass
- [ ] After merge: load a guide, scroll to the PL CTA, click it; load /about and click the Ko-fi button; verify Outbound: Visible / Outbound: Clicked appear in PostHog Live Events with the right placement.

## Notes
- Historical events (`Sponsor: Clicked`, etc.) remain in PostHog. The old strategy/sponsor dashboards still work; the new dashboard uses only the unified events.