### PR TITLE
fix(parse): handle Firefox single-line earnings table paste

### DIFF
--- a/src/lib/ssa-parse.ts
+++ b/src/lib/ssa-parse.ts
@@ -243,6 +243,48 @@ function isYearString(maybeYearStr: string): boolean {
   return true;
 }
 
+/**
+ * Some browsers (notably Firefox) copy the SSA earnings table without row
+ * breaks, producing a single long line like:
+ *   "Work YearTaxed ... Earnings2025 $176,100 $200,259 2024 $125,370 ..."
+ * If the input line contains three or more year tokens, split it into one
+ * line per year. Tokens before the first year are dropped (header garbage).
+ * Lines that don't match this pattern are returned unchanged.
+ */
+function splitRunOnYearLine(line: string): string[] {
+  // Unglue a header word from a year, e.g. "Earnings2025" -> ["Earnings",
+  // "2025"]. The anchored shape keeps this from firing on normal tokens.
+  const gluedYear = /^([A-Za-z]+)(\d{4})$/;
+  const tokens: string[] = [];
+  for (const raw of line.split(' ')) {
+    const match = gluedYear.exec(raw);
+    if (match && isYearString(match[2])) {
+      tokens.push(match[1], match[2]);
+    } else {
+      tokens.push(raw);
+    }
+  }
+
+  let yearCount = 0;
+  for (const t of tokens) {
+    if (isYearString(t)) yearCount++;
+  }
+  if (yearCount < 3) return [line];
+
+  const rows: string[] = [];
+  let current: string[] = [];
+  for (const t of tokens) {
+    if (isYearString(t)) {
+      if (current.length > 0) rows.push(current.join(' '));
+      current = [t];
+    } else if (current.length > 0) {
+      current.push(t);
+    }
+  }
+  if (current.length > 0) rows.push(current.join(' '));
+  return rows;
+}
+
 export function parsePaste(paste: string): Array<EarningRecord> {
   // We first collapse whitespace on each line as
   // different browsers insert different whitespace for column
@@ -263,8 +305,12 @@ export function parsePaste(paste: string): Array<EarningRecord> {
     'MedicareBeganIn1966'
   );
 
-  // Split based on newlines.
-  const lines: string[] = replacedStr.split('\n');
+  // Split based on newlines. Firefox sometimes copies the entire SSA earnings
+  // table onto a single line; splitRunOnYearLine() detects this and expands
+  // such a line into one row per year. For all other formats it is a no-op.
+  const lines: string[] = replacedStr
+    .split('\n')
+    .flatMap((line) => splitRunOnYearLine(line));
 
   if (isPdfPaste(lines)) {
     const out = parseSsaPdfTable(lines);

--- a/src/test/ssa-parse.test.ts
+++ b/src/test/ssa-parse.test.ts
@@ -358,6 +358,36 @@ describe('parsePaste', () => {
     parsePasteExpect(parsePaste(pasteData));
   });
 
+  it('Leaves a 2-year run-on line below the split threshold', () => {
+    // Boundary test: splitRunOnYearLine only activates at 3+ year tokens.
+    // A two-year line must pass through unchanged. Here the data is on
+    // separate lines (the normal case); the extra "2015 $70,000" tail on
+    // line one would be ignored as trailing garbage if not split.
+    const pasteData =
+      '2018 $100,000 2015 $70,000\n' + '2017 $90,000\n' + '2016 $80,000\n';
+    const parsed = parsePaste(pasteData);
+    // Should parse 3 records (2016, 2017, 2018) — the trailing "2015 $70,000"
+    // on the first line is dropped by parseFormattedTable (only first 2 cols
+    // are used), and the 2-year threshold prevents run-on splitting.
+    parsePasteExpect(parsed);
+  });
+
+  it('Parses Firefox run-on line with NotYetRecorded current year', () => {
+    const pasteData =
+      'Work YearTaxed Social Security EarningsTaxed Medicare Earnings' +
+      '2018 Not Yet Recorded Not Yet Recorded ' +
+      '2017 $90,000 $90,000 2016 $80,000 $80,000\n';
+    const parsed = parsePaste(pasteData);
+    expect(parsed.length).toBe(3);
+    expect(parsed[0].year).toBe(2016);
+    expect(parsed[0].taxedEarnings.value()).toBe(80000);
+    expect(parsed[1].year).toBe(2017);
+    expect(parsed[1].taxedEarnings.value()).toBe(90000);
+    expect(parsed[2].year).toBe(2018);
+    expect(parsed[2].taxedEarnings.value()).toBe(0);
+    expect(parsed[2].incomplete).toBe(true);
+  });
+
   it('Parses ssa.gov format before medicare', () => {
     const pasteData =
       '1966\t$2,966\t$2,966\n' +

--- a/src/test/ssa-parse.test.ts
+++ b/src/test/ssa-parse.test.ts
@@ -348,6 +348,16 @@ describe('parsePaste', () => {
     expect(parsed[2].incomplete).toBe(true);
   });
 
+  it('Parses ssa.gov format (Firefox 2026, single-line run-on)', () => {
+    // Some Firefox versions copy the entire earnings table onto a single
+    // line, with the header word glued to the first year ("Earnings2018").
+    const pasteData =
+      'Work YearTaxed Social Security EarningsTaxed Medicare Earnings' +
+      '2018 $100,000 $100,000 2017 $90,000 $90,000 2016 $80,000 $80,000\n' +
+      'Not sure if you need to request a correction? Take a closer look\n';
+    parsePasteExpect(parsePaste(pasteData));
+  });
+
   it('Parses ssa.gov format before medicare', () => {
     const pasteData =
       '1966\t$2,966\t$2,966\n' +


### PR DESCRIPTION
## Summary
- User-reported regression: pasting the SSA earnings table from Firefox produces zero records. Firefox copies the entire table onto a single line with the header word glued to the first year (e.g. `...Taxed Medicare Earnings2025 $176,100 $200,259 2024 ...`), so the line-based parser saw `Work` as the first token and discarded the input.
- Adds `splitRunOnYearLine()` in `src/lib/ssa-parse.ts`: a token-walking helper that activates only when a line contains 3+ year tokens, ungues a header-glued first year (anchored regex `^([A-Za-z]+)(\d{4})$`), and expands the line into one row per year. For every other paste format it is a no-op.
- Adds a regression test mirroring the Firefox shape using the existing 3-year fixture values.

## Test plan
- [x] `npm test` — 1933 tests pass (including new Firefox run-on case)
- [x] `npm run quality` — biome + svelte-check clean
- [x] Manual: copy/paste from ssa.gov in Firefox and verify records load