### PR TITLE
fix(strategy): correct zero-PIA dep filing age and use SSA dates for filing display

### DIFF
--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -487,5 +487,20 @@ export function optimalStrategyCoupleFast(
     }
   }
 
+  // Zero-PIA dep can't collect spousal until earner files; multiple
+  // dependent filing ages below earner's produce identical NPV. The loop's
+  // tie-break picks the earliest, which displays a misleading "62y1m". Bump
+  // the reported dep age to match the earner's filing whenever needed.
+  if (depZeroPia) {
+    const bestFE = earnerIndex === 0 ? bestF0 : bestF1;
+    const earnerFileEpoch = eSsaBirth + bestFE;
+    let bestFD = earnerIndex === 0 ? bestF1 : bestF0;
+    const depFileEpoch = dSsaBirth + bestFD;
+    if (depFileEpoch < earnerFileEpoch) {
+      bestFD = earnerFileEpoch - dSsaBirth;
+      if (earnerIndex === 0) bestF1 = bestFD;
+      else bestF0 = bestFD;
+    }
+  }
   return [new MonthDuration(bestF0), new MonthDuration(bestF1), bestNPV];
 }

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -497,7 +497,10 @@ export function optimalStrategyCoupleFast(
     let bestFD = earnerIndex === 0 ? bestF1 : bestF0;
     const depFileEpoch = dSsaBirth + bestFD;
     if (depFileEpoch < earnerFileEpoch) {
-      bestFD = earnerFileEpoch - dSsaBirth;
+      // Cap at SSA age 70 — dep can't file past their max benefit age. This
+      // matters when the earner is younger than the dep and files at 70:
+      // their calendar filing month would map to a dep age above 70.
+      bestFD = Math.min(earnerFileEpoch - dSsaBirth, 840);
       if (earnerIndex === 0) bestF1 = bestFD;
       else bestF0 = bestFD;
     }

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -657,7 +657,10 @@ function clampZeroPiaDepStrategy(
   const depFile = dependent.birthdate.dateAtSsaAge(depAge);
   if (!depFile.lessThan(earnerFile)) return best;
 
-  const newDepAge = dependent.birthdate.ageAtSsaDate(earnerFile);
+  // Cap at SSA age 70 — dep can't file past their max benefit age. Matters
+  // when the earner is younger than the dep and files at 70.
+  const rawAge = dependent.birthdate.ageAtSsaDate(earnerFile).asMonths();
+  const newDepAge = new MonthDuration(Math.min(rawAge, 70 * 12));
   const result: [MonthDuration, MonthDuration, number] = [
     best[0],
     best[1],

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -637,6 +637,37 @@ export function strategySumPeriodsOptimized(
 }
 
 /**
+ * A $0-PIA dependent cannot collect spousal benefits until the earner files.
+ * If the brute-force optimizer recorded a dependent filing age earlier than
+ * the earner's, every such pair produces the same NPV as the (matching-earner)
+ * pair, so the reported dependent age would be misleading. Bump it forward.
+ */
+function clampZeroPiaDepStrategy(
+  recipients: [Recipient, Recipient],
+  best: [MonthDuration, MonthDuration, number]
+): [MonthDuration, MonthDuration, number] {
+  const { earnerIndex, dependentIndex } = classifyEarnerDependent(recipients);
+  const dependent = recipients[dependentIndex];
+  if (dependent.pia().primaryInsuranceAmount().cents() !== 0) return best;
+
+  const earner = recipients[earnerIndex];
+  const earnerAge = best[earnerIndex] as MonthDuration;
+  const depAge = best[dependentIndex] as MonthDuration;
+  const earnerFile = earner.birthdate.dateAtSsaAge(earnerAge);
+  const depFile = dependent.birthdate.dateAtSsaAge(depAge);
+  if (!depFile.lessThan(earnerFile)) return best;
+
+  const newDepAge = dependent.birthdate.ageAtSsaDate(earnerFile);
+  const result: [MonthDuration, MonthDuration, number] = [
+    best[0],
+    best[1],
+    best[2],
+  ];
+  result[dependentIndex] = newDepAge;
+  return result;
+}
+
+/**
  * Calculates the optimal filing ages for a couple so as to maximize lifetime
  * benefits as returned by strategySumCents
  *
@@ -693,7 +724,7 @@ export function optimalStrategyCouple(
     }
   }
 
-  return bestStrategy;
+  return clampZeroPiaDepStrategy(recipients, bestStrategy);
 }
 
 /**
@@ -775,7 +806,7 @@ export function optimalStrategyCoupleOptimized(
     }
   }
 
-  return bestStrategy;
+  return clampZeroPiaDepStrategy(recipients, bestStrategy);
 }
 
 /**

--- a/src/lib/strategy/ui/formatting.ts
+++ b/src/lib/strategy/ui/formatting.ts
@@ -70,7 +70,7 @@ export function getFilingDate(
     years: filingAgeYears,
     months: filingAgeMonths,
   });
-  const filingDate = birthdate.dateAtLayAge(filingAge);
+  const filingDate = birthdate.dateAtSsaAge(filingAge);
 
   // Use different formats based on cell dimensions
   if (cellWidth < 35) {

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -90,7 +90,7 @@
     let monthCount = 0;
 
     for (const duration of ageRange) {
-      const filingDate = recipient.birthdate.dateAtLayAge(duration);
+      const filingDate = recipient.birthdate.dateAtSsaAge(duration);
       const calendarYear = filingDate.year();
 
       if (calendarYear !== currentYear) {
@@ -276,7 +276,7 @@
       return `Age ${years} and ${months} months`;
     }
     const filingDate =
-      recipients[recipientIndex].birthdate.dateAtLayAge(duration);
+      recipients[recipientIndex].birthdate.dateAtSsaAge(duration);
     return `${filingDate.monthName()} ${filingDate.year()}`;
   }
 </script>

--- a/src/routes/strategy/components/OptimalStrategyHeadline.svelte
+++ b/src/routes/strategy/components/OptimalStrategyHeadline.svelte
@@ -26,7 +26,7 @@
     recipient: Recipient,
     age: MonthDuration
   ): string {
-    const date = recipient.birthdate.dateAtLayAge(age);
+    const date = recipient.birthdate.dateAtSsaAge(age);
     return `${date.monthFullName()} ${date.year()}`;
   }
 
@@ -34,7 +34,7 @@
     recipient: Recipient,
     age: MonthDuration
   ): string {
-    const date = recipient.birthdate.dateAtLayAge(age);
+    const date = recipient.birthdate.dateAtSsaAge(age);
     return `${date.monthName()} ${date.year()}`;
   }
 

--- a/src/routes/strategy/components/ScenarioDetail.svelte
+++ b/src/routes/strategy/components/ScenarioDetail.svelte
@@ -32,8 +32,8 @@
     }
   }
 
-  $: filingDate1 = recipients[0].birthdate.dateAtLayAge(result.filingAge1);
-  $: filingDate2 = recipients[1].birthdate.dateAtLayAge(result.filingAge2);
+  $: filingDate1 = recipients[0].birthdate.dateAtSsaAge(result.filingAge1);
+  $: filingDate2 = recipients[1].birthdate.dateAtSsaAge(result.filingAge2);
   $: expectedAge1 = result.bucket1.expectedAge;
   $: expectedAge2 = result.bucket2.expectedAge;
   $: deathDate1 = recipients[0].birthdate.dateAtLayAge(expectedAge1);

--- a/src/routes/strategy/components/ScenarioDetailSingle.svelte
+++ b/src/routes/strategy/components/ScenarioDetailSingle.svelte
@@ -17,7 +17,7 @@
     return `${(prob * 100).toFixed(1)}%`;
   }
 
-  $: filingDate = recipient.birthdate.dateAtLayAge(result.filingAge1);
+  $: filingDate = recipient.birthdate.dateAtSsaAge(result.filingAge1);
   $: expectedAge = result.bucket1.expectedAge;
   $: deathDate = recipient.birthdate.dateAtLayAge(expectedAge);
 

--- a/src/routes/strategy/components/StrategyCell.svelte
+++ b/src/routes/strategy/components/StrategyCell.svelte
@@ -65,8 +65,8 @@ function handleMouseOver(event: MouseEvent) {
       filingAge2,
     } = calculationResult;
 
-    const filingDate1 = recipients[0].birthdate.dateAtLayAge(filingAge1);
-    const filingDate2 = recipients[1].birthdate.dateAtLayAge(filingAge2);
+    const filingDate1 = recipients[0].birthdate.dateAtSsaAge(filingAge1);
+    const filingDate2 = recipients[1].birthdate.dateAtSsaAge(filingAge2);
 
     cellHoverInfo = {
       x: event.clientX,

--- a/src/routes/strategy/components/StrategyMatrix.svelte
+++ b/src/routes/strategy/components/StrategyMatrix.svelte
@@ -67,7 +67,7 @@ function createNormalizedValueExtractor(recipientIndex: number) {
       years: filingAgeYears,
       months: filingAgeMonths,
     });
-    const filingDate = birthdate.dateAtLayAge(filingAge);
+    const filingDate = birthdate.dateAtSsaAge(filingAge);
 
     return `${filingDate.year()}-${(filingDate.monthIndex() + 1).toString().padStart(2, '0')}`;
   };
@@ -302,9 +302,9 @@ function handleCellSelect(position: CellPosition) {
     deathAge1: bucket1.label,
     deathAge2: bucket2.label,
     filingAge1,
-    filingDate1: recipients[0].birthdate.dateAtLayAge(filingAge1),
+    filingDate1: recipients[0].birthdate.dateAtSsaAge(filingAge1),
     filingAge2,
-    filingDate2: recipients[1].birthdate.dateAtLayAge(filingAge2),
+    filingDate2: recipients[1].birthdate.dateAtSsaAge(filingAge2),
     netPresentValue: totalBenefit,
   });
 }

--- a/src/routes/strategy/components/StrategyOverview.svelte
+++ b/src/routes/strategy/components/StrategyOverview.svelte
@@ -18,10 +18,10 @@
 
   // Compute filing dates from filing ages
   $: filingDate1 = result
-    ? recipients[0].birthdate.dateAtLayAge(result.filingAge1)
+    ? recipients[0].birthdate.dateAtSsaAge(result.filingAge1)
     : null;
   $: filingDate2 = result
-    ? recipients[1].birthdate.dateAtLayAge(result.filingAge2)
+    ? recipients[1].birthdate.dateAtSsaAge(result.filingAge2)
     : null;
 
   // Expected death ages (probability-weighted modeled midpoint) are always defined.

--- a/src/test/strategy/edge-zero-pia.test.ts
+++ b/src/test/strategy/edge-zero-pia.test.ts
@@ -689,6 +689,36 @@ describe('Zero-PIA optimizer', () => {
     expect(bestNpv).toBeGreaterThan(0);
   });
 
+  it('reported dependent filing age is bumped to earner filing when earner files later', () => {
+    // Same setup as "for long-lived dependent, optimizer delays earner filing"
+    // — earner optimally files at 70. The zero-PIA dependent cannot start
+    // collecting spousal until the earner files, so the reported dependent
+    // filing age should be 70y0m, not 62y1m.
+    const earner = makeRecipient(2000, 1965, 5, 15);
+    const dependent = makeRecipient(0, 1965, 5, 15);
+    const earnerDeath = finalDateAtAge(earner, 75);
+    const depDeath = finalDateAtAge(dependent, 95);
+
+    const [bestStrat0, bestStrat1] = optimalStrategyCouple(
+      [earner, dependent],
+      [earnerDeath, depDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+    const [bestStrat0Opt, bestStrat1Opt] = optimalStrategyCoupleOptimized(
+      [earner, dependent],
+      [earnerDeath, depDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+
+    // Earner (r0) files at 70, dependent (r1) should also be reported at 70.
+    expect(bestStrat0.asMonths()).toBe(70 * 12);
+    expect(bestStrat1.asMonths()).toBe(70 * 12);
+    expect(bestStrat0Opt.asMonths()).toBe(70 * 12);
+    expect(bestStrat1Opt.asMonths()).toBe(70 * 12);
+  });
+
   it('optimized matches non-optimized for zero-PIA couple', () => {
     const earner = makeRecipient(2000, 1965, 5, 15);
     const dependent = makeRecipient(0, 1965, 5, 15);

--- a/src/test/strategy/edge-zero-pia.test.ts
+++ b/src/test/strategy/edge-zero-pia.test.ts
@@ -16,6 +16,7 @@ import {
   strategySumPeriodsCouple,
   sumBenefitPeriods,
 } from '$lib/strategy/calculations';
+import { optimalStrategyCoupleFast } from '$lib/strategy/calculations/optimal-strategy-fast';
 import {
   optimalStrategyCouple,
   optimalStrategyCoupleOptimized,
@@ -712,11 +713,98 @@ describe('Zero-PIA optimizer', () => {
       NO_DISCOUNT
     );
 
+    const [bestStrat0Fast, bestStrat1Fast] = optimalStrategyCoupleFast(
+      [earner, dependent],
+      [earnerDeath, depDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+
     // Earner (r0) files at 70, dependent (r1) should also be reported at 70.
     expect(bestStrat0.asMonths()).toBe(70 * 12);
     expect(bestStrat1.asMonths()).toBe(70 * 12);
     expect(bestStrat0Opt.asMonths()).toBe(70 * 12);
     expect(bestStrat1Opt.asMonths()).toBe(70 * 12);
+    expect(bestStrat0Fast.asMonths()).toBe(70 * 12);
+    expect(bestStrat1Fast.asMonths()).toBe(70 * 12);
+  });
+
+  it('bump still works when zero-PIA dep is at index 0 (swapped order)', () => {
+    // Same scenario, but recipients are passed with dep first. The bump must
+    // update recipients[0] (the dep), not recipients[1].
+    const earner = makeRecipient(2000, 1965, 5, 15);
+    const dependent = makeRecipient(0, 1965, 5, 15);
+    const earnerDeath = finalDateAtAge(earner, 75);
+    const depDeath = finalDateAtAge(dependent, 95);
+
+    const [bestStrat0, bestStrat1] = optimalStrategyCouple(
+      [dependent, earner],
+      [depDeath, earnerDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+    const [bestStrat0Fast, bestStrat1Fast] = optimalStrategyCoupleFast(
+      [dependent, earner],
+      [depDeath, earnerDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+
+    // Dep (r0) bumped to 70; earner (r1) files at 70.
+    expect(bestStrat0.asMonths()).toBe(70 * 12);
+    expect(bestStrat1.asMonths()).toBe(70 * 12);
+    expect(bestStrat0Fast.asMonths()).toBe(70 * 12);
+    expect(bestStrat1Fast.asMonths()).toBe(70 * 12);
+  });
+
+  it('no bump when dep optimally files later than earner anyway', () => {
+    // Short-lived earner: optimal earner age is early (62y1m). Even so, the
+    // dep is zero-PIA and gains nothing from filing before earner; the bump
+    // should report the dep at the canonical match (62y1m), not later.
+    const earner = makeRecipient(2000, 1965, 5, 15);
+    const dependent = makeRecipient(0, 1965, 5, 15);
+    const earnerDeath = finalDateAtAge(earner, 64);
+    const depDeath = finalDateAtAge(dependent, 70);
+
+    const [bestStrat0, bestStrat1] = optimalStrategyCouple(
+      [earner, dependent],
+      [earnerDeath, depDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+    // Dep's reported age should equal earner's chosen age (no later bumping
+    // beyond what the constraint requires).
+    expect(bestStrat1.asMonths()).toBe(bestStrat0.asMonths());
+  });
+
+  it('bump is capped at SSA age 70 when earner is younger than dep', () => {
+    // Earner is 5 years younger than dep. If earner optimally files at 70,
+    // their filing month maps to a dep age of 75 — which exceeds 70 and is
+    // not a valid filing age. The clamp must cap the reported dep age at 70.
+    const dependent = makeRecipient(0, 1960, 5, 15);
+    const earner = makeRecipient(2000, 1965, 5, 15);
+    const earnerDeath = finalDateAtAge(earner, 75);
+    const depDeath = finalDateAtAge(dependent, 100);
+
+    const [bestStrat0, bestStrat1] = optimalStrategyCouple(
+      [earner, dependent],
+      [earnerDeath, depDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+    const [bestStrat0Fast, bestStrat1Fast] = optimalStrategyCoupleFast(
+      [earner, dependent],
+      [earnerDeath, depDeath],
+      FAR_PAST,
+      NO_DISCOUNT
+    );
+
+    // Whatever the earner does, the dep's reported age must not exceed 70.
+    expect(bestStrat1.asMonths()).toBeLessThanOrEqual(70 * 12);
+    expect(bestStrat1Fast.asMonths()).toBeLessThanOrEqual(70 * 12);
+    // And we expect the bump to have actually fired (earner files at 70).
+    expect(bestStrat0.asMonths()).toBe(70 * 12);
+    expect(bestStrat0Fast.asMonths()).toBe(70 * 12);
   });
 
   it('optimized matches non-optimized for zero-PIA couple', () => {

--- a/src/test/strategy/ui/formatting.test.ts
+++ b/src/test/strategy/ui/formatting.test.ts
@@ -105,10 +105,11 @@ describe('formatting', () => {
     });
 
     it('calculates correct date from filing age for first recipient', () => {
-      // First recipient born March 1, 1962
-      // Filing at age 67y 0m = March 2029
+      // First recipient born March 1, 1962. SSA's "attains age the day before
+      // birthday" rule shifts the SSA birth month to February, so filing at
+      // age 67y 0m yields Feb 2029 (the first month benefits accrue).
       const result = getFilingDate(recipients, 0, 67, 0, 100);
-      expect(result).toBe('Mar 2029');
+      expect(result).toBe('Feb 2029');
     });
 
     it('calculates correct date for second recipient', () => {
@@ -119,10 +120,10 @@ describe('formatting', () => {
     });
 
     it('handles fractional months', () => {
-      // First recipient born March 1962
-      // Filing at 67y 6m = September 2029
+      // First recipient born March 1, 1962 (born-on-1st rule shifts SSA
+      // birth month to Feb). Filing at 67y 6m = Aug 2029.
       const result = getFilingDate(recipients, 0, 67, 6, 100);
-      expect(result).toBe('Sep 2029');
+      expect(result).toBe('Aug 2029');
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix couple optimizer reporting a zero-PIA spouse at 62y1m even when the earner files much later. The NPV math already clamped the dep's effective filing to the earner's, but the recorded `bestF0/bestF1` retained the loop's tie-break winner (the lowest fd). Post-process the result to bump the dep's reported age so the displayed filing month is never earlier than the earner's. Applied in all three couple optimizer entry points (`optimalStrategyCouple`, `optimalStrategyCoupleOptimized`, `optimalStrategyCoupleFast`).
- Switch filing-date displays across the strategy UI from `dateAtLayAge` → `dateAtSsaAge` so the shown month is the actual first month benefits accrue. For most birthdates this is identical; for someone born on the 1st of a month (where SSA's "attains age the day before birthday" rule shifts the SSA birth month back by one), this removes a misleading one-month gap between the earner's and dep's displayed filing dates. Death and expected-age displays remain `dateAtLayAge` — those represent calendar age, not benefit accrual.
- Adds regression test in `edge-zero-pia.test.ts` covering all three optimizer entry points; updates two formatting tests whose expected values assumed the old lay-date convention (first recipient is born March 1 — exactly the born-on-1st case being fixed).

## Test plan

- [x] `npm test` — 1936/1936 passing
- [x] `npm run quality` — biome + svelte-check clean
- [ ] Manual check: enter two recipients with the reported scenario (1982-10-01 with positive PIA, 1982-10-21 with \$0 PIA) and verify the displayed optimal strategy is no longer misleading.