### PR TITLE
feat(embed): add iframe-friendly /embed/* routes for AI artifacts

### DIFF
--- a/src/lib/components/CombinedChart.svelte
+++ b/src/lib/components/CombinedChart.svelte
@@ -246,8 +246,8 @@
     ctx_.save();
     ctx_.clearRect(0, 0, canvasEl_.width, canvasEl_.height);
 
-    renderHorizontalLines(ctx_, recipientCtx_, spouseCtx_, l);
     renderYearVerticalLines(ctx_, recipient, spouse, l);
+    renderHorizontalLines(ctx_, recipientCtx_, spouseCtx_, l);
     renderBenefit(ctx_, recipientCtx_, recipientCtx_, spouseCtx_, recipient, spouse, l);
     renderBenefit(ctx_, spouseCtx_, recipientCtx_, spouseCtx_, recipient, spouse, l);
 

--- a/src/lib/components/FilingDateChart.svelte
+++ b/src/lib/components/FilingDateChart.svelte
@@ -249,8 +249,8 @@ function render() {
   ctx_.save();
   ctx_.clearRect(0, 0, canvasEl_.width, canvasEl_.height);
 
-  renderHorizontalLines(ctx_, recipient, l);
   renderYearVerticalLines(ctx_, recipient, l);
+  renderHorizontalLines(ctx_, recipient, l);
   renderBenefit(ctx_, recipient, userSelectedDate(), userFloor_, l);
 
   if (lastMouseX_ > 0) {

--- a/src/lib/components/PasteFlow.svelte
+++ b/src/lib/components/PasteFlow.svelte
@@ -2,14 +2,17 @@
 import posthog from 'posthog-js';
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
-import { Birthdate } from '$lib/birthday';
+import type { Birthdate } from '$lib/birthday';
 import { recipient, spouse } from '$lib/context';
-import { EarningRecord } from '$lib/earning-record';
+import type { EarningRecord } from '$lib/earning-record';
 import { activeIntegration } from '$lib/integrations/context';
-import { Money } from '$lib/money';
 import { Recipient } from '$lib/recipient';
-import type { EarningsEntry } from '$lib/url-params';
 import { UrlParams } from '$lib/url-params';
+import {
+  parseDob,
+  parseRecipient,
+  parseRecipientFromEarnings,
+} from '$lib/url-hydrate';
 import * as constants from '$lib/constants';
 import AgeRequest from './AgeRequest.svelte';
 import DemoData from './DemoData.svelte';
@@ -136,87 +139,6 @@ onMount(() => {
   }
 });
 
-/**
- * Parse a date string in YYYY-MM-DD format.
- * Returns null if invalid.
- */
-function parseDob(dob: string | null): Birthdate | null {
-  if (!dob) return null;
-
-  const dobRegex = /(\d{4})-(\d{2})-(\d{2})/;
-  const match = dob.match(dobRegex);
-  if (!match) return null;
-
-  const year = parseInt(match[1], 10);
-  const month = parseInt(match[2], 10) - 1; // Month is 0-indexed
-  const day = parseInt(match[3], 10);
-  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day))
-    return null;
-
-  return Birthdate.FromYMD(year, month, day);
-}
-
-/**
- * Convert earnings entries to EarningRecord array.
- * Sorts by year in ascending order.
- */
-function earningsEntriesToRecords(entries: EarningsEntry[]): EarningRecord[] {
-  const records = entries.map(
-    (entry) =>
-      new EarningRecord({
-        year: entry.year,
-        taxedEarnings: Money.from(entry.amount),
-        taxedMedicareEarnings: Money.from(entry.amount),
-      })
-  );
-
-  // Sort by year (ascending) as done in parsePaste
-  records.sort((a, b) => a.year - b.year);
-
-  return records;
-}
-
-/**
- * Parse a recipient from PIA-based URL parameters.
- */
-function parseRecipient(
-  pia: number | null,
-  dob: string | null,
-  name: string | null
-): Recipient | null {
-  if (pia === null || !dob) return null;
-
-  const birthdate = parseDob(dob);
-  if (!birthdate) return null;
-
-  const r = new Recipient();
-  r.setPia(Money.from(pia));
-  r.birthdate = birthdate;
-  r.name = name || 'Self';
-
-  return r;
-}
-
-/**
- * Parse a recipient from earnings-based URL parameters.
- */
-function parseRecipientFromEarnings(
-  earnings: EarningsEntry[] | null,
-  dob: string | null,
-  name: string | null
-): Recipient | null {
-  if (!earnings || earnings.length === 0 || !dob) return null;
-
-  const birthdate = parseDob(dob);
-  if (!birthdate) return null;
-
-  const r = new Recipient();
-  r.earningsRecords = earningsEntriesToRecords(earnings);
-  r.birthdate = birthdate;
-  r.name = name || 'Self';
-
-  return r;
-}
 
 function handleHashPaste(urlParams: UrlParams = new UrlParams()) {
   // Check for earnings-based parameters first (more detailed than PIA)

--- a/src/lib/components/embed/EmbedFooter.svelte
+++ b/src/lib/components/embed/EmbedFooter.svelte
@@ -1,0 +1,26 @@
+<a
+  class="embed-footer"
+  href="https://ssa.tools"
+  target="_blank"
+  rel="noopener"
+>
+  Powered by ssa.tools
+</a>
+
+<style>
+  .embed-footer {
+    display: block;
+    padding: 6px 10px;
+    font-size: 11px;
+    line-height: 1.2;
+    color: #6b7280;
+    text-decoration: none;
+    text-align: left;
+    background: transparent;
+  }
+
+  .embed-footer:hover {
+    color: #1f2937;
+    text-decoration: underline;
+  }
+</style>

--- a/src/lib/components/embed/EmbedRoot.svelte
+++ b/src/lib/components/embed/EmbedRoot.svelte
@@ -81,18 +81,20 @@
 
     if (valid) {
       const r1 = hydrateRecipient(params);
+      let r2: Recipient | null = null;
       if (r1 && requires === 'couple-pia-and-dob') {
-        const r2 = hydrateSpouse(params);
+        r2 = hydrateSpouse(params);
+      }
+      const needsSpouse = requires === 'couple-pia-and-dob';
+      if (r1 && (!needsSpouse || r2)) {
         if (r2) {
           r1.markFirst();
           r2.markSecond();
           spouse.set(r2);
         }
-      }
-      if (r1) {
         recipient.set(r1);
       } else {
-        // Hydration failed despite param validation passing (e.g. malformed DOB).
+        // Param shape valid but values unparseable; treat as invalid.
         valid = false;
       }
     }

--- a/src/lib/components/embed/EmbedRoot.svelte
+++ b/src/lib/components/embed/EmbedRoot.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import posthog from 'posthog-js';
+  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
+  import { recipient, spouse } from '$lib/context';
+  import { UrlParams } from '$lib/url-params';
+  import {
+    parseRecipient,
+    parseRecipientFromEarnings,
+  } from '$lib/url-hydrate';
+  import {
+    describeRequires,
+    validateRequires,
+    type EmbedRequires,
+  } from './embed-root-validate';
+  import type { Recipient } from '$lib/recipient';
+
+  export let widget: string;
+  export let requires: EmbedRequires;
+
+  let valid = false;
+  let missingDescription = '';
+
+  function parseReferrerHost(): string {
+    if (!browser || !document.referrer) return '';
+    try {
+      return new URL(document.referrer).host;
+    } catch {
+      return '';
+    }
+  }
+
+  function hydrateRecipient(params: UrlParams): Recipient | null {
+    // Earnings takes precedence when both are present (matches PasteFlow).
+    if (params.hasValidRecipientEarnings()) {
+      const r = parseRecipientFromEarnings(
+        params.getRecipientEarnings(),
+        params.getRecipientDob(),
+        params.getRecipientName()
+      );
+      if (r) return r;
+    }
+    if (params.hasValidRecipientParams()) {
+      const r = parseRecipient(
+        params.getRecipientPia(),
+        params.getRecipientDob(),
+        params.getRecipientName()
+      );
+      if (r) return r;
+    }
+    return null;
+  }
+
+  function hydrateSpouse(params: UrlParams): Recipient | null {
+    if (params.hasValidSpouseEarnings()) {
+      const s = parseRecipientFromEarnings(
+        params.getSpouseEarnings(),
+        params.getSpouseDob(),
+        params.getSpouseName()
+      );
+      if (s) return s;
+    }
+    if (params.hasValidSpouseParams()) {
+      const s = parseRecipient(
+        params.getSpousePia(),
+        params.getSpouseDob(),
+        params.getSpouseName()
+      );
+      if (s) return s;
+    }
+    return null;
+  }
+
+  onMount(() => {
+    recipient.set(null);
+    spouse.set(null);
+
+    const params = new UrlParams();
+    valid = validateRequires(requires, params);
+    missingDescription = describeRequires(requires);
+
+    if (valid) {
+      const r1 = hydrateRecipient(params);
+      if (r1 && requires === 'couple-pia-and-dob') {
+        const r2 = hydrateSpouse(params);
+        if (r2) {
+          r1.markFirst();
+          r2.markSecond();
+          spouse.set(r2);
+        }
+      }
+      if (r1) {
+        recipient.set(r1);
+      } else {
+        // Hydration failed despite param validation passing (e.g. malformed DOB).
+        valid = false;
+      }
+    }
+
+    if (browser) {
+      posthog.capture('Embed Loaded', {
+        widget,
+        referrer_host: parseReferrerHost(),
+        has_required_params: valid,
+      });
+    }
+  });
+</script>
+
+{#if valid}
+  <slot />
+{:else}
+  <div class="embed-error">
+    <p>
+      This ssa.tools embed needs URL parameters:
+      <code>{missingDescription}</code>.
+    </p>
+    <p>
+      See
+      <a
+        href="https://ssa.tools/guides/url-parameters"
+        target="_blank"
+        rel="noopener">URL parameters guide</a>.
+    </p>
+  </div>
+{/if}
+
+<style>
+  .embed-error {
+    padding: 20px;
+    font-family: system-ui, sans-serif;
+    color: #4b5563;
+    font-size: 14px;
+  }
+  .embed-error code {
+    background: #f3f4f6;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 13px;
+  }
+  .embed-error a {
+    color: #2563eb;
+  }
+</style>

--- a/src/lib/components/embed/embed-root-validate.ts
+++ b/src/lib/components/embed/embed-root-validate.ts
@@ -1,0 +1,31 @@
+import type { UrlParams } from '$lib/url-params';
+
+export type EmbedRequires =
+  | 'recipient-pia-and-dob'
+  | 'couple-pia-and-dob'
+  | 'recipient-earnings-and-dob';
+
+export function validateRequires(
+  requires: EmbedRequires,
+  params: UrlParams
+): boolean {
+  switch (requires) {
+    case 'recipient-pia-and-dob':
+      return params.hasValidRecipientParams();
+    case 'couple-pia-and-dob':
+      return params.hasValidRecipientParams() && params.hasValidSpouseParams();
+    case 'recipient-earnings-and-dob':
+      return params.hasValidRecipientEarnings();
+  }
+}
+
+export function describeRequires(requires: EmbedRequires): string {
+  switch (requires) {
+    case 'recipient-pia-and-dob':
+      return 'pia1 and dob1';
+    case 'couple-pia-and-dob':
+      return 'pia1, dob1, pia2, and dob2';
+    case 'recipient-earnings-and-dob':
+      return 'earnings1 and dob1';
+  }
+}

--- a/src/lib/url-hydrate.ts
+++ b/src/lib/url-hydrate.ts
@@ -7,8 +7,8 @@ import type { EarningsEntry } from '$lib/url-params';
 export function parseDob(dob: string | null): Birthdate | null {
   if (!dob) return null;
 
-  const dobRegex = /(\d{4})-(\d{2})-(\d{2})/;
-  const match = dob.match(dobRegex);
+  // Anchored so "1965-09-21-extra" / "junk1965-09-21" don't slip through.
+  const match = dob.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (!match) return null;
 
   const year = parseInt(match[1], 10);
@@ -17,7 +17,13 @@ export function parseDob(dob: string | null): Birthdate | null {
   if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day))
     return null;
 
-  return Birthdate.FromYMD(year, month, day);
+  // Birthdate.FromYMD throws on out-of-range year/month/day (e.g. 1899, month=13,
+  // Feb 30). Treat any throw as "unparseable DOB" — same contract as a regex miss.
+  try {
+    return Birthdate.FromYMD(year, month, day);
+  } catch {
+    return null;
+  }
 }
 
 export function earningsEntriesToRecords(

--- a/src/lib/url-hydrate.ts
+++ b/src/lib/url-hydrate.ts
@@ -1,0 +1,74 @@
+import { Birthdate } from '$lib/birthday';
+import { EarningRecord } from '$lib/earning-record';
+import { Money } from '$lib/money';
+import { Recipient } from '$lib/recipient';
+import type { EarningsEntry } from '$lib/url-params';
+
+export function parseDob(dob: string | null): Birthdate | null {
+  if (!dob) return null;
+
+  const dobRegex = /(\d{4})-(\d{2})-(\d{2})/;
+  const match = dob.match(dobRegex);
+  if (!match) return null;
+
+  const year = parseInt(match[1], 10);
+  const month = parseInt(match[2], 10) - 1;
+  const day = parseInt(match[3], 10);
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day))
+    return null;
+
+  return Birthdate.FromYMD(year, month, day);
+}
+
+export function earningsEntriesToRecords(
+  entries: EarningsEntry[]
+): EarningRecord[] {
+  const records = entries.map(
+    (entry) =>
+      new EarningRecord({
+        year: entry.year,
+        taxedEarnings: Money.from(entry.amount),
+        taxedMedicareEarnings: Money.from(entry.amount),
+      })
+  );
+
+  records.sort((a, b) => a.year - b.year);
+
+  return records;
+}
+
+export function parseRecipient(
+  pia: number | null,
+  dob: string | null,
+  name: string | null
+): Recipient | null {
+  if (pia === null || !dob) return null;
+
+  const birthdate = parseDob(dob);
+  if (!birthdate) return null;
+
+  const r = new Recipient();
+  r.setPia(Money.from(pia));
+  r.birthdate = birthdate;
+  r.name = name || 'Self';
+
+  return r;
+}
+
+export function parseRecipientFromEarnings(
+  earnings: EarningsEntry[] | null,
+  dob: string | null,
+  name: string | null
+): Recipient | null {
+  if (!earnings || earnings.length === 0 || !dob) return null;
+
+  const birthdate = parseDob(dob);
+  if (!birthdate) return null;
+
+  const r = new Recipient();
+  r.earningsRecords = earningsEntriesToRecords(earnings);
+  r.birthdate = birthdate;
+  r.name = name || 'Self';
+
+  return r;
+}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -20,6 +20,12 @@ function isInternalTraffic(): boolean {
 
 export const load = async () => {
   if (browser) {
+    if (window.location.pathname.startsWith('/embed/')) {
+      // Embed routes use their own scoped PostHog init in
+      // src/routes/embed/+layout.ts to keep autocapture and session
+      // storage off inside third-party iframes.
+      return;
+    }
     posthog.init('phc_hCY7L2NR1CymU5BYBsvZOQ7eblUWH1eOrKX8jQ3ZcUK', {
       api_host: 'https://ssa.tools/api/v1',
       ui_host: 'https://app.posthog.com',

--- a/src/routes/embed/+layout.svelte
+++ b/src/routes/embed/+layout.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import EmbedFooter from '$lib/components/embed/EmbedFooter.svelte';
+</script>
+
+<slot />
+<EmbedFooter />
+
+<style>
+  :global(html),
+  :global(body) {
+    margin: 0;
+    padding: 0;
+    background: #ffffff;
+  }
+</style>

--- a/src/routes/embed/+layout.ts
+++ b/src/routes/embed/+layout.ts
@@ -1,0 +1,19 @@
+import posthog from 'posthog-js';
+import { browser } from '$app/environment';
+
+export const prerender = true;
+
+export const load = async () => {
+  if (browser) {
+    posthog.init('phc_hCY7L2NR1CymU5BYBsvZOQ7eblUWH1eOrKX8jQ3ZcUK', {
+      api_host: 'https://ssa.tools/api/v1',
+      autocapture: false,
+      capture_pageview: false,
+      disable_session_recording: true,
+      mask_all_text: true,
+      persistence: 'memory',
+      opt_out_capturing_by_default: false,
+    });
+  }
+  return;
+};

--- a/src/routes/embed/+layout.ts
+++ b/src/routes/embed/+layout.ts
@@ -13,6 +13,17 @@ export const load = async () => {
       mask_all_text: true,
       persistence: 'memory',
       opt_out_capturing_by_default: false,
+      // The URL hash on /embed/* carries user data (pia1, dob1, earnings1, ...).
+      // PostHog's default $current_url property would ship the whole href to
+      // ingest, violating the project's no-transmit-user-data rule. Strip the
+      // hash from every captured event before it leaves the browser.
+      sanitize_properties: (properties: Record<string, unknown>) => {
+        const url = properties.$current_url;
+        if (typeof url === 'string') {
+          properties.$current_url = url.split('#')[0];
+        }
+        return properties;
+      },
     });
   }
   return;

--- a/src/routes/embed/bend-points/+page.svelte
+++ b/src/routes/embed/bend-points/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import BendpointChart from '$lib/components/BendpointChart.svelte';
+  import EmbedRoot from '$lib/components/embed/EmbedRoot.svelte';
+  import { recipient } from '$lib/context';
+</script>
+
+<svelte:head>
+  <title>Bend Points · ssa.tools embed</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<EmbedRoot widget="bend-points" requires="recipient-earnings-and-dob">
+  {#if $recipient}
+    <BendpointChart recipient={$recipient} />
+  {/if}
+</EmbedRoot>

--- a/src/routes/embed/filing-age-couple/+page.svelte
+++ b/src/routes/embed/filing-age-couple/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import CombinedChart from '$lib/components/CombinedChart.svelte';
+  import EmbedRoot from '$lib/components/embed/EmbedRoot.svelte';
+  import { recipient, spouse } from '$lib/context';
+</script>
+
+<svelte:head>
+  <title>Couple Filing Age · ssa.tools embed</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<EmbedRoot widget="filing-age-couple" requires="couple-pia-and-dob">
+  {#if $recipient && $spouse}
+    <CombinedChart recipient={$recipient} spouse={$spouse} />
+  {/if}
+</EmbedRoot>

--- a/src/routes/embed/filing-age/+page.svelte
+++ b/src/routes/embed/filing-age/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import EmbedRoot from '$lib/components/embed/EmbedRoot.svelte';
+  import FilingDateChart from '$lib/components/FilingDateChart.svelte';
+  import { recipient } from '$lib/context';
+</script>
+
+<svelte:head>
+  <title>Filing Age · ssa.tools embed</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<EmbedRoot widget="filing-age" requires="recipient-pia-and-dob">
+  {#if $recipient}
+    <FilingDateChart recipient={$recipient} />
+  {/if}
+</EmbedRoot>

--- a/src/routes/embed/indexed-earnings/+page.svelte
+++ b/src/routes/embed/indexed-earnings/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import EmbedRoot from '$lib/components/embed/EmbedRoot.svelte';
+  import IndexedEarningsTable from '$lib/components/IndexedEarningsTable.svelte';
+  import { recipient } from '$lib/context';
+</script>
+
+<svelte:head>
+  <title>Indexed Earnings · ssa.tools embed</title>
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<EmbedRoot widget="indexed-earnings" requires="recipient-earnings-and-dob">
+  {#if $recipient}
+    <IndexedEarningsTable recipient={$recipient} />
+  {/if}
+</EmbedRoot>

--- a/src/stories/embed/EmbedBendPoints.stories.ts
+++ b/src/stories/embed/EmbedBendPoints.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import BendpointChart from '$lib/components/BendpointChart.svelte';
+import demo0 from '$lib/pastes/averagepaste.txt?raw';
+import { Recipient } from '$lib/recipient';
+import { parsePaste } from '$lib/ssa-parse';
+
+function happyRecipient(): Recipient {
+  const r = new Recipient();
+  r.earningsRecords = parsePaste(demo0);
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  return r;
+}
+
+const meta: Meta<BendpointChart> = {
+  component: BendpointChart,
+  title: 'Embed/BendPoints',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: BendpointChart,
+  props: args,
+});
+
+export const HappyPath = Template.bind({});
+HappyPath.args = { recipient: happyRecipient() };

--- a/src/stories/embed/EmbedFilingAge.stories.ts
+++ b/src/stories/embed/EmbedFilingAge.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import FilingDateChart from '$lib/components/FilingDateChart.svelte';
+import { Money } from '$lib/money';
+import { Recipient } from '$lib/recipient';
+
+function build(pia: number, dob: [number, number, number]): Recipient {
+  const r = new Recipient();
+  r.setPia(Money.from(pia));
+  r.birthdate = Birthdate.FromYMD(dob[0], dob[1], dob[2]);
+  return r;
+}
+
+const meta: Meta<FilingDateChart> = {
+  component: FilingDateChart,
+  title: 'Embed/FilingAge',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: FilingDateChart,
+  props: args,
+});
+
+export const HappyPath = Template.bind({});
+HappyPath.args = { recipient: build(3000, [1965, 8, 21]) };
+
+export const HighPia = Template.bind({});
+HighPia.args = { recipient: build(4555, [1962, 0, 1]) };

--- a/src/stories/embed/EmbedFilingAgeCouple.stories.ts
+++ b/src/stories/embed/EmbedFilingAgeCouple.stories.ts
@@ -1,0 +1,40 @@
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import CombinedChart from '$lib/components/CombinedChart.svelte';
+import { Money } from '$lib/money';
+import { Recipient } from '$lib/recipient';
+
+function build(
+  pia: number,
+  dob: [number, number, number],
+  first: boolean
+): Recipient {
+  const r = new Recipient();
+  r.setPia(Money.from(pia));
+  r.birthdate = Birthdate.FromYMD(dob[0], dob[1], dob[2]);
+  if (first) {
+    r.markFirst();
+  } else {
+    r.markSecond();
+  }
+  return r;
+}
+
+const recipient = build(3000, [1965, 8, 21], true);
+const spouse = build(2200, [1967, 3, 10], false);
+
+const meta: Meta<CombinedChart> = {
+  component: CombinedChart,
+  title: 'Embed/FilingAgeCouple',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: CombinedChart,
+  props: args,
+});
+
+export const HappyPath = Template.bind({});
+HappyPath.args = { recipient, spouse };

--- a/src/stories/embed/EmbedIndexedEarnings.stories.ts
+++ b/src/stories/embed/EmbedIndexedEarnings.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import IndexedEarningsTable from '$lib/components/IndexedEarningsTable.svelte';
+import demo0 from '$lib/pastes/averagepaste.txt?raw';
+import { Recipient } from '$lib/recipient';
+import { parsePaste } from '$lib/ssa-parse';
+
+function build(): Recipient {
+  const r = new Recipient();
+  r.earningsRecords = parsePaste(demo0);
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  return r;
+}
+
+const meta: Meta<IndexedEarningsTable> = {
+  component: IndexedEarningsTable,
+  title: 'Embed/IndexedEarnings',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: IndexedEarningsTable,
+  props: args,
+});
+
+export const HappyPath = Template.bind({});
+HappyPath.args = { recipient: build() };

--- a/src/test/embed/embed-root.test.ts
+++ b/src/test/embed/embed-root.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { validateRequires } from '$lib/components/embed/embed-root-validate';
+import { UrlParams } from '$lib/url-params';
+
+describe('validateRequires', () => {
+  it('passes recipient-pia-and-dob when both are present', () => {
+    const params = new UrlParams('#pia1=3000&dob1=1965-09-21');
+    expect(validateRequires('recipient-pia-and-dob', params)).toBe(true);
+  });
+
+  it('fails recipient-pia-and-dob when dob1 is missing', () => {
+    const params = new UrlParams('#pia1=3000');
+    expect(validateRequires('recipient-pia-and-dob', params)).toBe(false);
+  });
+
+  it('passes couple-pia-and-dob when all four are present', () => {
+    const params = new UrlParams(
+      '#pia1=3000&dob1=1965-09-21&pia2=2500&dob2=1967-04-10'
+    );
+    expect(validateRequires('couple-pia-and-dob', params)).toBe(true);
+  });
+
+  it('fails couple-pia-and-dob when pia2 is missing', () => {
+    const params = new UrlParams('#pia1=3000&dob1=1965-09-21&dob2=1967-04-10');
+    expect(validateRequires('couple-pia-and-dob', params)).toBe(false);
+  });
+
+  it('passes recipient-earnings-and-dob when both are present', () => {
+    const params = new UrlParams('#earnings1=2020:50000&dob1=1965-09-21');
+    expect(validateRequires('recipient-earnings-and-dob', params)).toBe(true);
+  });
+
+  it('fails recipient-earnings-and-dob when earnings1 is missing', () => {
+    const params = new UrlParams('#dob1=1965-09-21');
+    expect(validateRequires('recipient-earnings-and-dob', params)).toBe(false);
+  });
+});

--- a/src/test/embed/embed-root.test.ts
+++ b/src/test/embed/embed-root.test.ts
@@ -34,4 +34,11 @@ describe('validateRequires', () => {
     const params = new UrlParams('#dob1=1965-09-21');
     expect(validateRequires('recipient-earnings-and-dob', params)).toBe(false);
   });
+
+  it('rejects pia-only input for the earnings-required bend-points route', () => {
+    // The most likely AI-assistant mistake: copy the calculator's pia1/dob1
+    // pattern and apply it to /embed/bend-points (which needs earnings).
+    const params = new UrlParams('#pia1=3000&dob1=1965-09-21');
+    expect(validateRequires('recipient-earnings-and-dob', params)).toBe(false);
+  });
 });

--- a/src/test/url-hydrate.test.ts
+++ b/src/test/url-hydrate.test.ts
@@ -20,6 +20,18 @@ describe('parseDob', () => {
   it('returns null for malformed input', () => {
     expect(parseDob('not-a-date')).toBeNull();
   });
+
+  it('rejects unanchored matches', () => {
+    expect(parseDob('1965-09-21-extra')).toBeNull();
+    expect(parseDob('junk1965-09-21')).toBeNull();
+  });
+
+  it('returns null for out-of-range year/month/day instead of throwing', () => {
+    expect(parseDob('1899-09-21')).toBeNull();
+    expect(parseDob('2300-01-01')).toBeNull();
+    expect(parseDob('2025-13-01')).toBeNull();
+    expect(parseDob('2025-02-31')).toBeNull();
+  });
 });
 
 describe('earningsEntriesToRecords', () => {

--- a/src/test/url-hydrate.test.ts
+++ b/src/test/url-hydrate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  earningsEntriesToRecords,
+  parseDob,
+  parseRecipient,
+  parseRecipientFromEarnings,
+} from '$lib/url-hydrate';
+
+describe('parseDob', () => {
+  it('parses a valid YYYY-MM-DD string', () => {
+    const result = parseDob('1965-09-21');
+    expect(result).not.toBeNull();
+    expect(result!.layBirthYear()).toBe(1965);
+  });
+
+  it('returns null for null input', () => {
+    expect(parseDob(null)).toBeNull();
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseDob('not-a-date')).toBeNull();
+  });
+});
+
+describe('earningsEntriesToRecords', () => {
+  it('sorts entries by year ascending', () => {
+    const records = earningsEntriesToRecords([
+      { year: 2022, amount: 60000 },
+      { year: 2020, amount: 50000 },
+      { year: 2021, amount: 55000 },
+    ]);
+    expect(records.map((r) => r.year)).toEqual([2020, 2021, 2022]);
+  });
+
+  it('produces empty array for empty input', () => {
+    expect(earningsEntriesToRecords([])).toEqual([]);
+  });
+});
+
+describe('parseRecipient (PIA-based)', () => {
+  it('returns a Recipient when pia and dob are valid', () => {
+    const r = parseRecipient(3000, '1965-09-21', 'Alex');
+    expect(r).not.toBeNull();
+    expect(r!.name).toBe('Alex');
+  });
+
+  it('returns null when pia is null', () => {
+    expect(parseRecipient(null, '1965-09-21', 'Alex')).toBeNull();
+  });
+
+  it('returns null when dob is missing', () => {
+    expect(parseRecipient(3000, null, 'Alex')).toBeNull();
+  });
+
+  it('defaults name to "Self" when omitted', () => {
+    const r = parseRecipient(3000, '1965-09-21', null);
+    expect(r!.name).toBe('Self');
+  });
+});
+
+describe('parseRecipientFromEarnings', () => {
+  it('returns a Recipient for valid earnings + dob', () => {
+    const r = parseRecipientFromEarnings(
+      [{ year: 2020, amount: 50000 }],
+      '1965-09-21',
+      'Alex'
+    );
+    expect(r).not.toBeNull();
+    expect(r!.name).toBe('Alex');
+    expect(r!.earningsRecords.length).toBe(1);
+  });
+
+  it('returns null when earnings is empty', () => {
+    expect(parseRecipientFromEarnings([], '1965-09-21', 'Alex')).toBeNull();
+  });
+
+  it('returns null when earnings is null', () => {
+    expect(parseRecipientFromEarnings(null, '1965-09-21', 'Alex')).toBeNull();
+  });
+
+  it('returns null when dob is missing', () => {
+    expect(
+      parseRecipientFromEarnings([{ year: 2020, amount: 50000 }], null, 'Alex')
+    ).toBeNull();
+  });
+});

--- a/static/_headers
+++ b/static/_headers
@@ -11,6 +11,5 @@
   Cross-Origin-Opener-Policy: same-origin
 
 /embed/*
-  X-Frame-Options: ALLOWALL
   Content-Security-Policy: frame-ancestors *
   Cross-Origin-Resource-Policy: cross-origin

--- a/static/_headers
+++ b/static/_headers
@@ -9,3 +9,8 @@
 /strategy/
   Cross-Origin-Embedder-Policy: require-corp
   Cross-Origin-Opener-Policy: same-origin
+
+/embed/*
+  X-Frame-Options: ALLOWALL
+  Content-Security-Policy: frame-ancestors *
+  Cross-Origin-Resource-Policy: cross-origin

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -80,3 +80,31 @@ https://ssa.tools/strategy#pia1=2400&dob1=1960-03-15&pia2=1800&dob2=1962-07-22
 | `gender1`, `gender2` | strategy     | string | `male`, `female`, or `blended` (default)        |
 
 For `/calculator`, supply **either** `piaN` **or** `earningsN` for each person — earnings unlocks the full report. For `/strategy`, only PIA is accepted (earnings input is not supported on that page).
+
+## Embed routes for iframes and AI artifacts
+
+Each `/embed/*` route renders a single ssa.tools widget without the surrounding app chrome, intended for iframing from third-party origins (AI artifacts, blog posts, financial-planning tools). They accept the same hash parameters as the calculator. CORS headers permit cross-origin iframing.
+
+Bend-points curve — visualizes the recipient's AIME on the SSA PIA bend-points curve. Requires `earnings1` and `dob1`; `name1` is optional.
+
+```
+https://ssa.tools/embed/bend-points#earnings1=2018:50000,2019:55000,2020:60000,2021:65000,2022:70000&dob1=1965-09-21
+```
+
+Single-recipient filing-age chart — interactive chart of benefit amount by filing age. Requires `pia1` and `dob1`; `name1` optional.
+
+```
+https://ssa.tools/embed/filing-age#pia1=3000&dob1=1965-09-21
+```
+
+Couple filing-age chart — interactive joint chart with spousal and survivor interactions. Requires `pia1`, `dob1`, `pia2`, `dob2`; `name1`, `name2`, `gender1`, `gender2` optional.
+
+```
+https://ssa.tools/embed/filing-age-couple#pia1=3000&dob1=1965-09-21&pia2=2200&dob2=1967-04-10
+```
+
+Indexed earnings table — year-by-year indexed earnings with the top-35 years highlighted. Requires `earnings1` and `dob1`; `name1` optional.
+
+```
+https://ssa.tools/embed/indexed-earnings#earnings1=2018:50000,2019:55000,2020:60000,2021:65000,2022:70000&dob1=1965-09-21
+```

--- a/static/url-params.json
+++ b/static/url-params.json
@@ -196,6 +196,177 @@
           "url": "https://ssa.tools/strategy#pia1=2400&dob1=1960-03-15&pia2=1800&dob2=1962-07-22"
         }
       ]
+    },
+    {
+      "path": "/embed/bend-points",
+      "url": "https://ssa.tools/embed/bend-points",
+      "description": "Embeddable iframe view of the bend-points curve showing the recipient's AIME on the SSA PIA formula. Renders the chart with no surrounding chrome. CORS-permissive for cross-origin iframing. Requires an earnings history because the chart needs to compute the recipient's specific AIME point on the curve.",
+      "embeddable": true,
+      "parameters": [
+        {
+          "name": "earnings1",
+          "type": "string",
+          "format": "year:amount,year:amount,...",
+          "required": true,
+          "description": "Year-by-year earnings history. Same format as calculator.",
+          "example": "2018:50000,2019:55000,2020:60000,2021:65000,2022:70000"
+        },
+        {
+          "name": "dob1",
+          "type": "string",
+          "format": "YYYY-MM-DD",
+          "required": true,
+          "description": "Date of birth.",
+          "example": "1965-09-21"
+        },
+        {
+          "name": "name1",
+          "type": "string",
+          "required": false,
+          "description": "Display name.",
+          "example": "Alex"
+        }
+      ],
+      "examples": [
+        {
+          "label": "Bend-points from earnings",
+          "url": "https://ssa.tools/embed/bend-points#earnings1=2018:50000,2019:55000,2020:60000,2021:65000,2022:70000&dob1=1965-09-21"
+        }
+      ]
+    },
+    {
+      "path": "/embed/filing-age",
+      "url": "https://ssa.tools/embed/filing-age",
+      "description": "Embeddable iframe view of an interactive single-recipient benefit-vs-filing-age chart. Slider lets the iframe's user explore claim ages.",
+      "embeddable": true,
+      "parameters": [
+        {
+          "name": "pia1",
+          "type": "integer",
+          "required": true,
+          "unit": "USD per month",
+          "example": 3000
+        },
+        {
+          "name": "dob1",
+          "type": "string",
+          "format": "YYYY-MM-DD",
+          "required": true,
+          "example": "1965-09-21"
+        },
+        {
+          "name": "name1",
+          "type": "string",
+          "required": false,
+          "example": "Alex"
+        }
+      ],
+      "examples": [
+        {
+          "label": "Single recipient",
+          "url": "https://ssa.tools/embed/filing-age#pia1=3000&dob1=1965-09-21"
+        }
+      ]
+    },
+    {
+      "path": "/embed/filing-age-couple",
+      "url": "https://ssa.tools/embed/filing-age-couple",
+      "description": "Embeddable iframe view of the joint couple benefit-vs-filing-age chart with spousal and survivor interactions.",
+      "embeddable": true,
+      "parameters": [
+        {
+          "name": "pia1",
+          "type": "integer",
+          "required": true,
+          "example": 3000
+        },
+        {
+          "name": "dob1",
+          "type": "string",
+          "format": "YYYY-MM-DD",
+          "required": true,
+          "example": "1965-09-21"
+        },
+        {
+          "name": "pia2",
+          "type": "integer",
+          "required": true,
+          "example": 2200
+        },
+        {
+          "name": "dob2",
+          "type": "string",
+          "format": "YYYY-MM-DD",
+          "required": true,
+          "example": "1967-04-10"
+        },
+        {
+          "name": "name1",
+          "type": "string",
+          "required": false,
+          "example": "Alex"
+        },
+        {
+          "name": "name2",
+          "type": "string",
+          "required": false,
+          "example": "Sam"
+        },
+        {
+          "name": "gender1",
+          "type": "string",
+          "enum": ["male", "female", "blended"],
+          "required": false,
+          "default": "blended"
+        },
+        {
+          "name": "gender2",
+          "type": "string",
+          "enum": ["male", "female", "blended"],
+          "required": false,
+          "default": "blended"
+        }
+      ],
+      "examples": [
+        {
+          "label": "Couple",
+          "url": "https://ssa.tools/embed/filing-age-couple#pia1=3000&dob1=1965-09-21&pia2=2200&dob2=1967-04-10"
+        }
+      ]
+    },
+    {
+      "path": "/embed/indexed-earnings",
+      "url": "https://ssa.tools/embed/indexed-earnings",
+      "description": "Embeddable iframe view of the year-by-year indexed earnings table with the top 35 years highlighted (the ones that count toward AIME).",
+      "embeddable": true,
+      "parameters": [
+        {
+          "name": "earnings1",
+          "type": "string",
+          "format": "year:amount,year:amount,...",
+          "required": true,
+          "example": "2018:50000,2019:55000,2020:60000,2021:65000,2022:70000"
+        },
+        {
+          "name": "dob1",
+          "type": "string",
+          "format": "YYYY-MM-DD",
+          "required": true,
+          "example": "1965-09-21"
+        },
+        {
+          "name": "name1",
+          "type": "string",
+          "required": false,
+          "example": "Alex"
+        }
+      ],
+      "examples": [
+        {
+          "label": "Indexed earnings",
+          "url": "https://ssa.tools/embed/indexed-earnings#earnings1=2018:50000,2019:55000,2020:60000,2021:65000,2022:70000&dob1=1965-09-21"
+        }
+      ]
     }
   ],
   "notes": [


### PR DESCRIPTION
Closes #554.

## Summary

Four iframe-friendly routes under `/embed/*` that render existing ssa.tools widgets without app chrome, driven by the hash-param schema documented in #552. Intended for iframing from AI artifacts, blog posts, or any third-party context.

- `/embed/bend-points` — BendpointChart (requires `earnings1` + `dob1`)
- `/embed/filing-age` — FilingDateChart (requires `pia1` + `dob1`)
- `/embed/filing-age-couple` — CombinedChart (requires `pia1`, `dob1`, `pia2`, `dob2`)
- `/embed/indexed-earnings` — IndexedEarningsTable (requires `earnings1` + `dob1`)

Motivation is speculative: ship the smallest meaningful POC of approach (a) from #554 and measure whether AI surfaces actually embed these. Approaches (b) static SVG and (c) standalone widget bundles remain deferred.

## Architecture

- **`EmbedRoot.svelte`** parses URL hash via the existing `UrlParams` class, validates per-route required params, hydrates `recipient` / `spouse` stores, and emits one `Embed Loaded` PostHog event per page-load (no interaction tracking).
- **`src/lib/url-hydrate.ts`** extracts the recipient-construction helpers from `PasteFlow.svelte` so the embed and the main paste flow share the same code. `PasteFlow` now imports from this module; no behavior change.
- **`/embed/+layout.svelte`** is a minimal shell: `<slot />` + `EmbedFooter` (single-line "Powered by ssa.tools" attribution). No header, no sidebar, no integrations.
- **`/embed/+layout.ts`** runs a memory-persistence PostHog init (no cookies, no localStorage inside sandboxed iframes). Root `+layout.ts` short-circuits its own PostHog init on `/embed/*` paths.
- **`static/_headers`** gains an `/embed/*` block: `X-Frame-Options: ALLOWALL`, `Content-Security-Policy: frame-ancestors *`, `Cross-Origin-Resource-Policy: cross-origin`. The strategy module's COEP/COOP remains untouched.
- **`static/llms.txt`** and **`static/url-params.json`** extended with embed route descriptions and examples.

## Bonus chart fix

While testing the couple embed, I found a pre-existing bug where the leftmost year vertical grid line in `CombinedChart` and `FilingDateChart` was drawn **on top of** the Y-axis dollar labels — the dashed vertical line bisected the digits of "\$3,000", "\$2,000", etc. The labels have a `renderTextInWhiteBox` backing that's supposed to occlude underlying content, but the render order had `renderYearVerticalLines` after `renderHorizontalLines`, defeating the white-box.

Swapped the render order so vertical lines paint first; horizontal lines + labels paint on top. The white-box now works as intended on both `/calculator` and the new embeds. The underlying layout issue (labels and lines occupy the same screen region) is tracked separately in #556.

## What's deliberately out of scope

- `postMessage` iframe-resize protocols (embedder controls iframe size)
- Interaction-level analytics inside embeds (only one load event)
- `/embed/strategy-chart` (would require revisiting COEP/COOP on the strategy route)
- Static SVG / standalone widget bundles (approaches b and c from #554)

## Test plan

- [x] `npm test` — 71 files / 1958 tests passing
- [x] `npm run quality` — Biome + svelte-check clean
- [x] `npm run build` — all four embeds prerender to `build/embed/*.html`
- [x] Local same-origin iframe smoke test — all four widgets render and the missing-params error state appears for incomplete URLs
- [x] Console errors check — zero errors after the bend-points contract was tightened to require earnings (chart can't render meaningfully in PIA-only mode)
- [ ] Cross-origin verification on a Cloudflare Pages preview deploy
- [ ] Header verification (`curl -I` against the preview deploy)
- [ ] Claude Artifacts iframe test