### PR TITLE
feat(chart): show nominal historical benefit amounts on filing-date chart (#559)

### DIFF
--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -112,7 +112,9 @@ export function benefitOnDateOptimized(
  * the same current-dollar value as `benefitOnDate`.
  */
 function colaYearForDisplayDate(atDate: MonthDate): number {
-  // monthIndex() === 11 is December (the January precedent is === 0 below).
+  // monthIndex() is 0 for January and 11 for December. A December benefit is the
+  // first month to reflect that year's COLA; January through November reflect
+  // only through the prior year's.
   const raw = atDate.monthIndex() === 11 ? atDate.year() : atDate.year() - 1;
   return Math.min(raw, constants.CURRENT_YEAR - 1);
 }
@@ -123,12 +125,17 @@ function colaYearForDisplayDate(atDate: MonthDate): number {
  *
  * benefitOnDate always applies every COLA through `CURRENT_YEAR - 1`, so a past
  * month is shown inflated by COLAs that had not yet taken effect then. This
- * variant instead caps COLAs at the vintage in effect for `atDate`, matching
- * SSA letters/deposits for historical months. For any `atDate` at or after the
- * most recent applied COLA, it is identical to benefitOnDate.
+ * variant instead caps COLAs at the vintage in effect for `atDate`, so a past
+ * month reflects the nominal amount payable then (matching SSA letters/deposits
+ * to within whole-dollar rounding). For any `atDate` at or after the most recent
+ * applied COLA, it is identical to benefitOnDate.
  *
  * Used by the filing-date chart display only; the strategy optimizer continues
  * to use benefitOnDate/benefitOnDateOptimized (constant today's dollars).
+ *
+ * PIA-only recipients have no earnings history to unwind COLAs from, so their
+ * override PIA (already in current dollars) is returned unchanged; for them this
+ * matches benefitOnDate for every date.
  *
  * @param recipient - The recipient
  * @param filingDate - The date the recipient files for benefits

--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -1,3 +1,4 @@
+import * as constants from '$lib/constants';
 import { Money } from '$lib/money';
 import { MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
@@ -31,11 +32,19 @@ function benefitMultiplierAtAge(
 
 /**
  * Returns personal benefit amount if starting benefits at a given age.
+ *
+ * @param throughColaYear - Optional last COLA year to apply to the PIA. Defaults
+ *   to the current-dollar value. Pass an earlier year (see benefitOnDateNominal)
+ *   to compute the nominal benefit payable before later COLAs took effect.
  */
-export function benefitAtAge(recipient: Recipient, age: MonthDuration): Money {
+export function benefitAtAge(
+  recipient: Recipient,
+  age: MonthDuration,
+  throughColaYear?: number
+): Money {
   return recipient
     .pia()
-    .primaryInsuranceAmount()
+    .primaryInsuranceAmount(throughColaYear)
     .floorToDollar()
     .times(
       1 +
@@ -93,32 +102,101 @@ export function benefitOnDateOptimized(
 }
 
 /**
+ * Returns the last COLA year in effect for a benefit shown for the month
+ * `atDate`, for display of historical (nominal) amounts.
+ *
+ * A given year's COLA is effective in December of that year (payable the
+ * following January), so a benefit "for" a month only reflects COLA[Y] once
+ * that December has arrived. We also never assume COLAs beyond those already
+ * applied today (`CURRENT_YEAR - 1`), so any current or future `atDate` yields
+ * the same current-dollar value as `benefitOnDate`.
+ */
+function colaYearForDisplayDate(atDate: MonthDate): number {
+  // monthIndex() === 11 is December (the January precedent is === 0 below).
+  const raw = atDate.monthIndex() === 11 ? atDate.year() : atDate.year() - 1;
+  return Math.min(raw, constants.CURRENT_YEAR - 1);
+}
+
+/**
+ * Like benefitOnDate, but expresses the result in the dollars actually payable
+ * in the month `atDate` rather than in today's dollars.
+ *
+ * benefitOnDate always applies every COLA through `CURRENT_YEAR - 1`, so a past
+ * month is shown inflated by COLAs that had not yet taken effect then. This
+ * variant instead caps COLAs at the vintage in effect for `atDate`, matching
+ * SSA letters/deposits for historical months. For any `atDate` at or after the
+ * most recent applied COLA, it is identical to benefitOnDate.
+ *
+ * Used by the filing-date chart display only; the strategy optimizer continues
+ * to use benefitOnDate/benefitOnDateOptimized (constant today's dollars).
+ *
+ * @param recipient - The recipient
+ * @param filingDate - The date the recipient files for benefits
+ * @param atDate - The month to express the benefit in (and to calculate for)
+ * @throws Error if filing age is less than 62
+ */
+export function benefitOnDateNominal(
+  recipient: Recipient,
+  filingDate: MonthDate,
+  atDate: MonthDate
+): Money {
+  const filingAge = recipient.birthdate.ageAtSsaDate(filingDate);
+  const minFilingAge = MonthDuration.initFromYearsMonths({
+    years: 62,
+    months: 0,
+  });
+  if (filingAge.lessThan(minFilingAge)) {
+    throw new Error(
+      `Filing age must be at least 62, got ${filingAge.years()}y ${filingAge.modMonths()}m`
+    );
+  }
+
+  // If the recipient hasn't filed yet, return $0:
+  if (filingDate.greaterThan(atDate)) return Money.from(0);
+
+  return benefitOnDateCore(
+    recipient,
+    filingDate,
+    atDate,
+    filingAge,
+    colaYearForDisplayDate(atDate)
+  );
+}
+
+/**
  * Core benefit calculation logic shared between benefitOnDate variants.
  * Calculates delayed retirement credits based on filing date.
+ *
+ * @param throughColaYear - Optional last COLA year to apply to the PIA. When
+ *   omitted, the current-dollar PIA is used (today's dollars). benefitOnDateNominal
+ *   passes the vintage in effect for `atDate` to show historical amounts.
  */
 function benefitOnDateCore(
   recipient: Recipient,
   filingDate: MonthDate,
   atDate: MonthDate,
-  filingAge: MonthDuration
+  filingAge: MonthDuration,
+  throughColaYear?: number
 ): Money {
   // If this is the year after filing, delayed credits are fully applied.
   if (filingDate.year() < atDate.year())
-    return benefitAtAge(recipient, filingAge);
+    return benefitAtAge(recipient, filingAge, throughColaYear);
 
   const normalRetirementDate: MonthDate = recipient.normalRetirementDate();
 
   // If you are filing before normal retirement, no delayed credits apply.
   if (filingDate.lessThanOrEqual(normalRetirementDate))
-    return benefitAtAge(recipient, filingAge);
+    return benefitAtAge(recipient, filingAge, throughColaYear);
 
   // 70 is an explicit exception because the SSA likes to make my life harder.
   // Normally, you'd need to wait until the next year to get delayed credits,
   // but not if you file at exactly 70.
-  if (filingAge.years() >= 70) return benefitAtAge(recipient, filingAge);
+  if (filingAge.years() >= 70)
+    return benefitAtAge(recipient, filingAge, throughColaYear);
 
   // If you file in January, delayed credits are fully applied.
-  if (filingDate.monthIndex() === 0) return benefitAtAge(recipient, filingAge);
+  if (filingDate.monthIndex() === 0)
+    return benefitAtAge(recipient, filingAge, throughColaYear);
 
   // Otherwise, you only get credits up to January of this year,
   // or NRA, whichever is later.
@@ -133,7 +211,8 @@ function benefitOnDateCore(
 
   return benefitAtAge(
     recipient,
-    recipient.birthdate.ageAtSsaDate(benefitComputationDate)
+    recipient.birthdate.ageAtSsaDate(benefitComputationDate),
+    throughColaYear
   );
 }
 

--- a/src/lib/components/FilingDateChart.svelte
+++ b/src/lib/components/FilingDateChart.svelte
@@ -2,7 +2,7 @@
 import { onMount } from 'svelte';
 
 import type { Birthdate } from '$lib/birthday';
-import { benefitOnDate } from '$lib/benefit-calculator';
+import { benefitOnDateNominal } from '$lib/benefit-calculator';
 import {
   type ChartLayout,
   type TickItem,
@@ -344,7 +344,7 @@ $: filingDateString_ = updateFilingDateString(
       > benefit will be:
 
       <b>
-        {benefitOnDate($recipient, userSelectedDate(), dateX(lastMouseX_, recipient.birthdate, layout()))
+        {benefitOnDateNominal($recipient, userSelectedDate(), dateX(lastMouseX_, recipient.birthdate, layout()))
           .wholeDollars()}</b
       >
     {:else}

--- a/src/lib/components/filing-date-chart-renderer.ts
+++ b/src/lib/components/filing-date-chart-renderer.ts
@@ -1,4 +1,4 @@
-import { benefitOnDate } from '$lib/benefit-calculator';
+import { benefitOnDateNominal } from '$lib/benefit-calculator';
 import {
   type ChartLayout,
   dollarLineIncrement,
@@ -127,7 +127,7 @@ export function benefitBoxes(
   const birthdate = recipient.birthdate;
 
   const boxes: Array<[number, number, Money]> = [];
-  let benefit = benefitOnDate(recipient, selectedDate, selectedDate);
+  let benefit = benefitOnDateNominal(recipient, selectedDate, selectedDate);
   boxes.push([
     canvasX(selectedDate, birthdate, layout),
     canvasY(benefit, maxY, layout),
@@ -140,8 +140,11 @@ export function benefitBoxes(
     i.lessThanOrEqual(endDate);
     i = i.addDuration(new MonthDuration(1))
   ) {
-    if (benefitOnDate(recipient, selectedDate, i).value() !== benefit.value()) {
-      benefit = benefitOnDate(recipient, selectedDate, i);
+    if (
+      benefitOnDateNominal(recipient, selectedDate, i).value() !==
+      benefit.value()
+    ) {
+      benefit = benefitOnDateNominal(recipient, selectedDate, i);
       boxes.push([
         canvasX(i, birthdate, layout),
         canvasY(benefit, maxY, layout),
@@ -303,7 +306,7 @@ export function renderTrendline(
     i = i.addDuration(new MonthDuration(1))
   ) {
     const thisX = canvasX(i, birthdate, layout);
-    const yDollars = benefitOnDate(recipient, i, i);
+    const yDollars = benefitOnDateNominal(recipient, i, i);
     const thisY = canvasY(yDollars, maxY, layout);
     if (i.monthsSinceEpoch() === startDate.monthsSinceEpoch()) {
       ctx.moveTo(thisX, thisY);

--- a/src/lib/pia.ts
+++ b/src/lib/pia.ts
@@ -154,9 +154,14 @@ export class PrimaryInsuranceAmount {
    * This is the final PIA value that would be used to determine actual benefit
    * payments. COLAs are applied starting from the year the individual turns 62.
    *
+   * @param throughColaYear - Optional last COLA year to apply. Defaults to
+   *   `lastAppliedColaYear()` (the current-dollar value). Pass an earlier year
+   *   to obtain the nominal PIA payable at a past date, used by display code
+   *   that shows historical amounts (see benefitOnDateNominal). PIA-only
+   *   recipients ignore this and always return their (current-dollar) override.
    * @returns {Money} The final PIA amount after all applicable COLA adjustments
    */
-  primaryInsuranceAmount(): Money {
+  primaryInsuranceAmount(throughColaYear?: number): Money {
     if (this.input_.isPiaOnly) {
       if (this.input_.overridePia === null) {
         throw new Error('overridePia must not be null when isPiaOnly is true');
@@ -165,7 +170,7 @@ export class PrimaryInsuranceAmount {
     }
 
     const pia = this.primaryInsuranceAmountUnadjusted();
-    return this.applyColaAdjustments(pia);
+    return this.applyColaAdjustments(pia, throughColaYear);
   }
 
   /**
@@ -217,17 +222,23 @@ export class PrimaryInsuranceAmount {
 
   /**
    * Applies COLA adjustments to a PIA value from the year the individual turns 62
-   * through the last applied COLA year. Each year's adjustment is rounded down
-   * to the nearest dime per SSA rules.
+   * through the given (or last applied) COLA year. Each year's adjustment is
+   * rounded down to the nearest dime per SSA rules.
    *
    * @param pia - The unadjusted PIA to apply COLA to
+   * @param throughYear - The last COLA year to apply, inclusive. Defaults to
+   *   `lastAppliedColaYear()`. An earlier value yields the nominal PIA payable
+   *   before later COLAs took effect.
    * @returns The COLA-adjusted PIA
    */
-  private applyColaAdjustments(pia: Money): Money {
+  private applyColaAdjustments(
+    pia: Money,
+    throughYear: number = this.lastAppliedColaYear()
+  ): Money {
     let adjusted = pia;
     for (
       let year = this.input_.birthdate.yearTurningSsaAge(62);
-      year <= this.lastAppliedColaYear();
+      year <= throughYear;
       ++year
     ) {
       if (constants.COLA[year] !== undefined) {

--- a/src/test/benefit-calculator.test.ts
+++ b/src/test/benefit-calculator.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { benefitOnDate, benefitOnDateNominal } from '$lib/benefit-calculator';
+import { Birthdate } from '$lib/birthday';
+import { MonthDate } from '$lib/month-time';
+import demo0 from '$lib/pastes/averagepaste.txt?raw';
+import { Recipient } from '$lib/recipient';
+import { parsePaste } from '$lib/ssa-parse';
+
+import * as constants from '../lib/constants';
+
+/**
+ * benefitOnDateNominal expresses a benefit in the dollars actually payable in
+ * the month `atDate` (historical COLA vintage), whereas benefitOnDate always
+ * uses today's dollars. These tests mirror the real report behind issue #559:
+ * a 1956-born earner who filed mid-2024.
+ */
+describe('benefitOnDateNominal', () => {
+  // Born Sep 29, 1956: NRA is 66y4m, turns 62 in 2018 (COLAs 2018.. apply).
+  const BIRTHDATE = Birthdate.FromYMD(1956, 8, 29);
+  // Filed July 2024, at age 67y10m (past NRA, so delayed credits accrue).
+  const FILING = MonthDate.initFromYearsMonths({ years: 2024, months: 6 });
+
+  function recipient(): Recipient {
+    const r = new Recipient();
+    r.birthdate = BIRTHDATE;
+    r.earningsRecords = parsePaste(demo0);
+    return r;
+  }
+
+  const ym = (years: number, months: number) =>
+    MonthDate.initFromYearsMonths({ years, months });
+
+  it('equals benefitOnDate for a current/future month (no future COLA assumed)', () => {
+    const r = recipient();
+    // January of the current year is at/after the most recently applied COLA,
+    // so the nominal vintage matches today's dollars exactly.
+    const at = ym(constants.CURRENT_YEAR, 0);
+    expect(benefitOnDateNominal(r, FILING, at).value()).toEqual(
+      benefitOnDate(r, FILING, at).value()
+    );
+  });
+
+  it('shows a smaller (nominal) amount for a past mid-year month', () => {
+    const r = recipient();
+    // June 2025: today's-dollars value includes the Dec-2025 COLA that had not
+    // yet taken effect, so the nominal value must be strictly smaller.
+    const at = ym(2025, 5);
+    expect(benefitOnDateNominal(r, FILING, at).value()).toBeLessThan(
+      benefitOnDate(r, FILING, at).value()
+    );
+  });
+
+  it('never exceeds the today’s-dollars value', () => {
+    const r = recipient();
+    for (let year = 2024; year <= constants.CURRENT_YEAR; year++) {
+      for (let month = 0; month < 12; month++) {
+        const at = ym(year, month);
+        if (at.lessThan(FILING)) continue;
+        expect(benefitOnDateNominal(r, FILING, at).value()).toBeLessThanOrEqual(
+          benefitOnDate(r, FILING, at).value()
+        );
+      }
+    }
+  });
+
+  it('steps up at the December COLA effective date, not January', () => {
+    const r = recipient();
+    const nov2025 = benefitOnDateNominal(r, FILING, ym(2025, 10)).value();
+    const dec2025 = benefitOnDateNominal(r, FILING, ym(2025, 11)).value();
+    // The 2.8% COLA is effective December 2025 (paid the following January).
+    expect(dec2025).toBeGreaterThan(nov2025);
+    // And December's nominal value reaches today's dollars (most recent COLA).
+    expect(dec2025).toEqual(benefitOnDate(r, FILING, ym(2025, 11)).value());
+  });
+
+  it('applies delayed retirement credits the January after filing, independent of COLA', () => {
+    const r = recipient();
+    // Dec 2024 and Jan 2025 share the same COLA vintage (2024's COLA, effective
+    // Dec 2024), so any increase between them is purely the delayed-credit jump.
+    const dec2024 = benefitOnDateNominal(r, FILING, ym(2024, 11)).value();
+    const jan2025 = benefitOnDateNominal(r, FILING, ym(2025, 0)).value();
+    expect(jan2025).toBeGreaterThan(dec2024);
+  });
+
+  it('returns zero before the filing date', () => {
+    const r = recipient();
+    expect(benefitOnDateNominal(r, FILING, ym(2024, 5)).value()).toEqual(0);
+  });
+});

--- a/src/test/benefit-calculator.test.ts
+++ b/src/test/benefit-calculator.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { benefitOnDate, benefitOnDateNominal } from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
 import { MonthDate } from '$lib/month-time';
 import demo0 from '$lib/pastes/averagepaste.txt?raw';
 import { Recipient } from '$lib/recipient';
 import { parsePaste } from '$lib/ssa-parse';
 
 import * as constants from '../lib/constants';
+
+const ym = (years: number, months: number) =>
+  MonthDate.initFromYearsMonths({ years, months });
 
 /**
  * benefitOnDateNominal expresses a benefit in the dollars actually payable in
@@ -18,7 +22,7 @@ describe('benefitOnDateNominal', () => {
   // Born Sep 29, 1956: NRA is 66y4m, turns 62 in 2018 (COLAs 2018.. apply).
   const BIRTHDATE = Birthdate.FromYMD(1956, 8, 29);
   // Filed July 2024, at age 67y10m (past NRA, so delayed credits accrue).
-  const FILING = MonthDate.initFromYearsMonths({ years: 2024, months: 6 });
+  const FILING = ym(2024, 6);
 
   function recipient(): Recipient {
     const r = new Recipient();
@@ -27,14 +31,22 @@ describe('benefitOnDateNominal', () => {
     return r;
   }
 
-  const ym = (years: number, months: number) =>
-    MonthDate.initFromYearsMonths({ years, months });
-
   it('equals benefitOnDate for a current/future month (no future COLA assumed)', () => {
     const r = recipient();
     // January of the current year is at/after the most recently applied COLA,
     // so the nominal vintage matches today's dollars exactly.
     const at = ym(constants.CURRENT_YEAR, 0);
+    expect(benefitOnDateNominal(r, FILING, at).value()).toEqual(
+      benefitOnDate(r, FILING, at).value()
+    );
+  });
+
+  it('clamps to today: a future December does not assume a future COLA', () => {
+    const r = recipient();
+    // raw vintage would be next year (a December), which exceeds CURRENT_YEAR-1
+    // and must be clamped so no not-yet-existent COLA is applied. This exercises
+    // the Math.min clamp (not merely its equality case).
+    const at = ym(constants.CURRENT_YEAR + 1, 11);
     expect(benefitOnDateNominal(r, FILING, at).value()).toEqual(
       benefitOnDate(r, FILING, at).value()
     );
@@ -50,7 +62,7 @@ describe('benefitOnDateNominal', () => {
     );
   });
 
-  it('never exceeds the today’s-dollars value', () => {
+  it('never exceeds the present-day value', () => {
     const r = recipient();
     for (let year = 2024; year <= constants.CURRENT_YEAR; year++) {
       for (let month = 0; month < 12; month++) {
@@ -69,8 +81,17 @@ describe('benefitOnDateNominal', () => {
     const dec2025 = benefitOnDateNominal(r, FILING, ym(2025, 11)).value();
     // The 2.8% COLA is effective December 2025 (paid the following January).
     expect(dec2025).toBeGreaterThan(nov2025);
-    // And December's nominal value reaches today's dollars (most recent COLA).
-    expect(dec2025).toEqual(benefitOnDate(r, FILING, ym(2025, 11)).value());
+  });
+
+  it('reaches present-day dollars at the December of the last applied COLA year', () => {
+    const r = recipient();
+    // December of CURRENT_YEAR-1 has the most recently applied COLA as its
+    // vintage, which equals benefitOnDate's fixed cutoff. Anchored to the
+    // constant rather than a literal year so it stays correct as time advances.
+    const at = ym(constants.CURRENT_YEAR - 1, 11);
+    expect(benefitOnDateNominal(r, FILING, at).value()).toEqual(
+      benefitOnDate(r, FILING, at).value()
+    );
   });
 
   it('applies delayed retirement credits the January after filing, independent of COLA', () => {
@@ -82,8 +103,45 @@ describe('benefitOnDateNominal', () => {
     expect(jan2025).toBeGreaterThan(dec2024);
   });
 
-  it('returns zero before the filing date', () => {
+  it('returns zero before the filing date and is non-zero at it', () => {
     const r = recipient();
     expect(benefitOnDateNominal(r, FILING, ym(2024, 5)).value()).toEqual(0);
+    expect(benefitOnDateNominal(r, FILING, FILING).value()).toBeGreaterThan(0);
+  });
+
+  it('caps COLA vintage on the January-filing branch', () => {
+    const r = recipient();
+    // Filing in January past NRA grants full delayed credits immediately
+    // (the monthIndex === 0 branch). A past December in that year should still
+    // be capped below today's dollars.
+    const janFiling = ym(2024, 0);
+    const at = ym(2024, 11);
+    expect(benefitOnDateNominal(r, janFiling, at).value()).toBeLessThan(
+      benefitOnDate(r, janFiling, at).value()
+    );
+  });
+
+  it('caps COLA vintage on the exactly-age-70 branch', () => {
+    // Born June 1950 -> turns 70 in June 2020. Filing at exactly 70 grants full
+    // credits even mid-year (the >= 70 branch); the nominal value for that same
+    // year must still reflect only the COLAs in effect then.
+    const r = new Recipient();
+    r.birthdate = Birthdate.FromYMD(1950, 5, 15);
+    r.earningsRecords = parsePaste(demo0);
+    const filing = ym(2020, 5);
+    const at = ym(2020, 7); // August 2020, same year as filing.
+    expect(benefitOnDateNominal(r, filing, at).value()).toBeLessThan(
+      benefitOnDate(r, filing, at).value()
+    );
+  });
+
+  it('is a no-op for PIA-only recipients (no earnings history to unwind)', () => {
+    const r = new Recipient();
+    r.birthdate = BIRTHDATE;
+    r.setPia(Money.from(2000));
+    const at = ym(2025, 5); // A past month where an earnings recipient would differ.
+    expect(benefitOnDateNominal(r, FILING, at).value()).toEqual(
+      benefitOnDate(r, FILING, at).value()
+    );
   });
 });

--- a/src/test/pia.test.ts
+++ b/src/test/pia.test.ts
@@ -178,4 +178,13 @@ describe('primaryInsuranceAmount COLA cutoff (throughColaYear)', () => {
       pia.primaryInsuranceAmount(2023).value()
     );
   });
+
+  it('ignores the cutoff for PIA-only recipients (returns the override)', () => {
+    const r = new Recipient();
+    r.birthdate = BIRTHDATE;
+    r.setPia(Money.from(2000));
+    const pia = r.pia();
+    expect(pia.primaryInsuranceAmount(2019).value()).toEqual(2000);
+    expect(pia.primaryInsuranceAmount().value()).toEqual(2000);
+  });
 });

--- a/src/test/pia.test.ts
+++ b/src/test/pia.test.ts
@@ -111,3 +111,71 @@ describe('Recipient', () => {
     ).toEqual(r.pia().primaryInsuranceAmount().value());
   });
 });
+
+describe('primaryInsuranceAmount COLA cutoff (throughColaYear)', () => {
+  // Born Sep 29, 1956 -> turns 62 in 2018, so COLAs 2018..present apply.
+  const BIRTHDATE = Birthdate.FromYMD(1956, 8, 29);
+
+  function earningsPia(): PrimaryInsuranceAmount {
+    const r = new Recipient();
+    r.birthdate = BIRTHDATE;
+    r.earningsRecords = parsePaste(demo0);
+    return r.pia();
+  }
+
+  it('default argument applies all COLAs through CURRENT_YEAR - 1', () => {
+    const pia = earningsPia();
+    expect(
+      pia.primaryInsuranceAmount(constants.CURRENT_YEAR - 1).value()
+    ).toEqual(pia.primaryInsuranceAmount().value());
+  });
+
+  it('a cutoff before age 62 applies no COLAs (equals unadjusted)', () => {
+    const pia = earningsPia();
+    const age62Year = BIRTHDATE.yearTurningSsaAge(62);
+    expect(pia.primaryInsuranceAmount(age62Year - 1).value()).toEqual(
+      pia.primaryInsuranceAmountUnadjusted().value()
+    );
+  });
+
+  it('is monotonic non-decreasing as the cutoff year advances', () => {
+    const pia = earningsPia();
+    let prev = pia
+      .primaryInsuranceAmount(BIRTHDATE.yearTurningSsaAge(62) - 1)
+      .value();
+    for (
+      let year = BIRTHDATE.yearTurningSsaAge(62);
+      year <= constants.CURRENT_YEAR - 1;
+      year++
+    ) {
+      const current = pia.primaryInsuranceAmount(year).value();
+      expect(current).toBeGreaterThanOrEqual(prev);
+      prev = current;
+    }
+  });
+
+  it('matches manual COLA application up to the cutoff year', () => {
+    const pia = earningsPia();
+    const cutoff = 2020;
+    let expected = pia.primaryInsuranceAmountUnadjusted();
+    for (let year = BIRTHDATE.yearTurningSsaAge(62); year <= cutoff; year++) {
+      if (constants.COLA[year] !== undefined) {
+        expected = expected
+          .times(1 + constants.COLA[year] / 100.0)
+          .floorToDime();
+      }
+    }
+    expect(pia.primaryInsuranceAmount(cutoff).value()).toEqual(
+      expected.value()
+    );
+  });
+
+  it('excludes a COLA whose cutoff year has not been reached', () => {
+    const pia = earningsPia();
+    // 2024's COLA (effective for benefits starting Dec 2024) should be present
+    // at cutoff 2024 but absent at cutoff 2023.
+    expect(pia.primaryInsuranceAmount(2024).value()).toBeGreaterThan(
+      pia.primaryInsuranceAmount(2023).value()
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the core of #559. The "Explore Filing Dates" chart expressed every month's benefit in **today's dollars** — `PrimaryInsuranceAmount.applyColaAdjustments()` always baked in all COLAs through `CURRENT_YEAR - 1`. A benefit shown for a *past* month therefore included COLAs that hadn't taken effect yet, so the trendline was flat across each year and the hover note ("In Jan 2025, your benefit will be $3,517") disagreed with SSA letters.

This makes **COLA vintage track the display month** the same way DRC vintage already does (`benefitOnDateCore`), via an **opt-in** `benefitOnDateNominal()` used only by the chart display. The strategy/NPV optimizer is untouched and keeps comparing in constant (real) dollars.

## Approach

- `pia.ts`: `primaryInsuranceAmount(throughColaYear?)` and `applyColaAdjustments(pia, throughYear?)` gain an optional COLA cutoff. Default preserves current behavior, so all existing callers are unaffected.
- `benefit-calculator.ts`: thread the cutoff through `benefitAtAge`/`benefitOnDateCore`; add `colaYearForDisplayDate()` (steps at each **December** effective date — COLA[Y] is effective Dec of year Y — clamped so present/future never assume future COLAs) and export `benefitOnDateNominal()`.
- Wire the 5 display call sites (filing-date chart renderer + hover label) to `benefitOnDateNominal`.

## Behavior

For a 1956-born earner who filed mid-2024, the chart now steps across past years instead of showing a flat current-dollar amount:

| Month | Chart (nominal, this PR) | Previously (today's dollars) |
|---|---|---|
| Jul 2024 | $3,219 | $3,392 |
| Jan 2025 | $3,421 (delayed credits complete) | $3,517 |
| Dec 2025 | $3,517 (2.8% COLA) | $3,517 |

Past months now match the nominal amount actually payable then (to within whole-dollar rounding), and the December COLA step is visible rather than absorbed into a flat year.

## Tests

- `pia.test.ts`: COLA cutoff behavior (default == `CURRENT_YEAR-1`, pre-age-62 cutoff == unadjusted, monotonic, exact manual-COLA match, PIA-only no-op).
- New `benefit-calculator.test.ts`: December step (not January), the `Math.min` clamp firing on a future December, DRC-vs-COLA independence, January-filing and exactly-age-70 branches, PIA-only no-op, and present/future equivalence with `benefitOnDate`.
- Full suite: 1978 passing; `npm run quality` clean.

## Follow-ups (tracked on #559, not in this PR)

- Apply the same nominal-for-past treatment to spousal/survivor displays and integration report panels.
- PIA-only recipients can't reconstruct historical COLA vintage (return the current-dollar override); noted in code.

A separate issue (#561) tracks the unrelated PDF/print "drop line" coordinate bug (stale `lastMouseX_` re-mapped under print-mode canvas resize in `dateX()`).
