### PR TITLE
feat(chart): show nominal historical amounts on spousal (combined) chart (#559)

### DIFF
--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -263,6 +263,10 @@ export function eligibleForSpousalBenefit(
  * @param spouseFilingDate - The date when the higher-earning spouse files
  * @param filingDate - The date when this recipient (lower earner) files
  * @param atDate - The specific date for which to calculate the benefit amount
+ * @param throughColaYear - Optional last COLA year to apply to the underlying
+ *   PIAs and personal benefit. Defaults to the current-dollar value; pass an
+ *   earlier year (see allBenefitsOnDateNominal) to express the spousal benefit
+ *   in the dollars payable at a past month.
  * @returns The calculated spousal benefit amount
  */
 export function spousalBenefitOnDate(
@@ -270,7 +274,8 @@ export function spousalBenefitOnDate(
   spouse: Recipient,
   spouseFilingDate: MonthDate,
   filingDate: MonthDate,
-  atDate: MonthDate
+  atDate: MonthDate,
+  throughColaYear?: number
 ): Money {
   // Calculate the starting date as the latest of the two filing dates:
   const startDate = spouseFilingDate.greaterThan(filingDate)
@@ -285,11 +290,11 @@ export function spousalBenefitOnDate(
 
   const piaAmountCents: number = recipient
     .pia()
-    .primaryInsuranceAmount()
+    .primaryInsuranceAmount(throughColaYear)
     .cents();
   const spousePiaAmountCents: number = spouse
     .pia()
-    .primaryInsuranceAmount()
+    .primaryInsuranceAmount(throughColaYear)
     .cents();
 
   // Calculate the base spousal benefit amount:
@@ -313,7 +318,18 @@ export function spousalBenefitOnDate(
     // The way this is computed is to reduce the spousal benefit if the sum
     // of the spousal and personal benefits exceeds 50% of the higher
     // earner's PIA.
-    const personalBenefit = benefitOnDate(recipient, filingDate, atDate);
+    // Use benefitOnDateCore (not benefitOnDate) so the optional COLA cutoff is
+    // applied to the personal benefit too. In this branch filingDate is past
+    // NRA and startDate <= atDate, so benefitOnDate's age>=62 and
+    // filingDate>atDate guards are never relevant here; the result matches
+    // benefitOnDate when throughColaYear is undefined.
+    const personalBenefit = benefitOnDateCore(
+      recipient,
+      filingDate,
+      atDate,
+      recipient.birthdate.ageAtSsaDate(filingDate),
+      throughColaYear
+    );
     const spouseBenefitCents =
       spousePiaAmountCents / 2 - personalBenefit.cents();
     if (spouseBenefitCents <= 0) {
@@ -361,6 +377,38 @@ export function allBenefitsOnDate(
       spouseFilingDate,
       filingDate,
       atDate
+    )
+  );
+}
+
+/**
+ * Like allBenefitsOnDate, but expresses the combined personal + spousal benefit
+ * in the dollars actually payable in the month `atDate` rather than in today's
+ * dollars. Used by the combined (spousal) chart display only; the strategy
+ * optimizer continues to use allBenefitsOnDate (constant today's dollars).
+ *
+ * For any `atDate` at or after the most recent applied COLA this is identical
+ * to allBenefitsOnDate. See benefitOnDateNominal for the COLA-vintage rule.
+ *
+ * Note: this covers the personal and spousal components only; survivor benefits
+ * are not adjusted here (tracked separately on issue #559).
+ */
+export function allBenefitsOnDateNominal(
+  recipient: Recipient,
+  spouse: Recipient,
+  spouseFilingDate: MonthDate,
+  filingDate: MonthDate,
+  atDate: MonthDate
+): Money {
+  const throughColaYear = colaYearForDisplayDate(atDate);
+  return benefitOnDateNominal(recipient, filingDate, atDate).plus(
+    spousalBenefitOnDate(
+      recipient,
+      spouse,
+      spouseFilingDate,
+      filingDate,
+      atDate,
+      throughColaYear
     )
   );
 }

--- a/src/lib/components/CombinedChart.svelte
+++ b/src/lib/components/CombinedChart.svelte
@@ -14,7 +14,7 @@
     userSelectedDate,
   } from "./combined-chart-context";
   import {
-    allBenefitsOnDate,
+    allBenefitsOnDateNominal,
     canvasX,
     dateX,
     youngerOlder,
@@ -412,7 +412,7 @@
                 <RecipientName r={recipientCtx_.r} apos shortenTo={50} /> Benefit:
               </td>
               <td class="value">
-                {allBenefitsOnDate(recipientCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout())).wholeDollars()}
+                {allBenefitsOnDateNominal(recipientCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout())).wholeDollars()}
               </td>
             </tr>
             <tr>
@@ -421,7 +421,7 @@
                 <RecipientName r={spouseCtx_.r} apos shortenTo={50} /> Benefit:
               </td>
               <td class="value">
-                {allBenefitsOnDate(spouseCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout())).wholeDollars()}
+                {allBenefitsOnDateNominal(spouseCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout())).wholeDollars()}
               </td>
             </tr>
             <tr>
@@ -430,10 +430,10 @@
                 <b>Total</b> Benefit:
               </td>
               <td class="value sum"
-                >{allBenefitsOnDate(recipientCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout()))
+                >{allBenefitsOnDateNominal(recipientCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout()))
                   .roundToDollar()
                   .plus(
-                    allBenefitsOnDate(spouseCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout())).roundToDollar()
+                    allBenefitsOnDateNominal(spouseCtx_, recipientCtx_, spouseCtx_, dateX(lastMouseX_, recipient, spouse, layout())).roundToDollar()
                   )
                   .wholeDollars()}</td
               >

--- a/src/lib/components/combined-chart-math.ts
+++ b/src/lib/components/combined-chart-math.ts
@@ -279,6 +279,32 @@ export function minRenderedYDollars(
  * `firstCtx` or `secondCtx`). The function uses `personCtx.r.first` to
  * determine which context is self vs spouse for the filing date lookup.
  */
+/**
+ * Resolves the self vs spouse recipient and filing dates for the combined
+ * chart from the per-person contexts. `personCtx.r.first` determines which
+ * context is self vs spouse; a zero `selfFilingDate` means "use the slider".
+ */
+function resolveCouple(
+  personCtx: RecipientContext,
+  firstCtx: RecipientContext,
+  secondCtx: RecipientContext,
+  selfFilingDate: MonthDate
+): {
+  spouse: Recipient;
+  spouseFilingDate: MonthDate;
+  selfFilingDate: MonthDate;
+} {
+  const selfCtx = personCtx.r.first ? firstCtx : secondCtx;
+  const spouseCtx = personCtx.r.first ? secondCtx : firstCtx;
+  if (selfFilingDate.monthsSinceEpoch() === 0)
+    selfFilingDate = userSelectedDate(selfCtx);
+  return {
+    spouse: spouseCtx.r,
+    spouseFilingDate: userSelectedDate(spouseCtx),
+    selfFilingDate,
+  };
+}
+
 export function allBenefitsOnDate(
   personCtx: RecipientContext,
   firstCtx: RecipientContext,
@@ -286,25 +312,12 @@ export function allBenefitsOnDate(
   atDate: MonthDate,
   selfFilingDate: MonthDate = new MonthDate(0)
 ): Money {
-  let spouseFilingDate: MonthDate;
-  let spouse: Recipient;
-  if (personCtx.r.first) {
-    if (selfFilingDate.monthsSinceEpoch() === 0)
-      selfFilingDate = userSelectedDate(firstCtx);
-    spouseFilingDate = userSelectedDate(secondCtx);
-    spouse = secondCtx.r;
-  } else {
-    if (selfFilingDate.monthsSinceEpoch() === 0)
-      selfFilingDate = userSelectedDate(secondCtx);
-    spouseFilingDate = userSelectedDate(firstCtx);
-    spouse = firstCtx.r;
-  }
-
+  const couple = resolveCouple(personCtx, firstCtx, secondCtx, selfFilingDate);
   return allBenefitsOnDate_(
     personCtx.r,
-    spouse,
-    spouseFilingDate,
-    selfFilingDate,
+    couple.spouse,
+    couple.spouseFilingDate,
+    couple.selfFilingDate,
     atDate
   );
 }
@@ -322,25 +335,12 @@ export function allBenefitsOnDateNominal(
   atDate: MonthDate,
   selfFilingDate: MonthDate = new MonthDate(0)
 ): Money {
-  let spouseFilingDate: MonthDate;
-  let spouse: Recipient;
-  if (personCtx.r.first) {
-    if (selfFilingDate.monthsSinceEpoch() === 0)
-      selfFilingDate = userSelectedDate(firstCtx);
-    spouseFilingDate = userSelectedDate(secondCtx);
-    spouse = secondCtx.r;
-  } else {
-    if (selfFilingDate.monthsSinceEpoch() === 0)
-      selfFilingDate = userSelectedDate(secondCtx);
-    spouseFilingDate = userSelectedDate(firstCtx);
-    spouse = firstCtx.r;
-  }
-
+  const couple = resolveCouple(personCtx, firstCtx, secondCtx, selfFilingDate);
   return allBenefitsOnDateNominal_(
     personCtx.r,
-    spouse,
-    spouseFilingDate,
-    selfFilingDate,
+    couple.spouse,
+    couple.spouseFilingDate,
+    couple.selfFilingDate,
     atDate
   );
 }

--- a/src/lib/components/combined-chart-math.ts
+++ b/src/lib/components/combined-chart-math.ts
@@ -1,4 +1,7 @@
-import { allBenefitsOnDate as allBenefitsOnDate_ } from '$lib/benefit-calculator';
+import {
+  allBenefitsOnDate as allBenefitsOnDate_,
+  allBenefitsOnDateNominal as allBenefitsOnDateNominal_,
+} from '$lib/benefit-calculator';
 import type { ChartLayout } from '$lib/components/chart-utils';
 import type { Money } from '$lib/money';
 import { MonthDate, MonthDuration } from '$lib/month-time';
@@ -298,6 +301,42 @@ export function allBenefitsOnDate(
   }
 
   return allBenefitsOnDate_(
+    personCtx.r,
+    spouse,
+    spouseFilingDate,
+    selfFilingDate,
+    atDate
+  );
+}
+
+/**
+ * Like allBenefitsOnDate, but expresses the combined personal + spousal benefit
+ * in the dollars payable in the month `atDate` (historical COLA vintage) rather
+ * than today's dollars. Used by the combined chart display so past months match
+ * the amounts actually received then.
+ */
+export function allBenefitsOnDateNominal(
+  personCtx: RecipientContext,
+  firstCtx: RecipientContext,
+  secondCtx: RecipientContext,
+  atDate: MonthDate,
+  selfFilingDate: MonthDate = new MonthDate(0)
+): Money {
+  let spouseFilingDate: MonthDate;
+  let spouse: Recipient;
+  if (personCtx.r.first) {
+    if (selfFilingDate.monthsSinceEpoch() === 0)
+      selfFilingDate = userSelectedDate(firstCtx);
+    spouseFilingDate = userSelectedDate(secondCtx);
+    spouse = secondCtx.r;
+  } else {
+    if (selfFilingDate.monthsSinceEpoch() === 0)
+      selfFilingDate = userSelectedDate(secondCtx);
+    spouseFilingDate = userSelectedDate(firstCtx);
+    spouse = firstCtx.r;
+  }
+
+  return allBenefitsOnDateNominal_(
     personCtx.r,
     spouse,
     spouseFilingDate,

--- a/src/lib/components/combined-chart-renderer.ts
+++ b/src/lib/components/combined-chart-renderer.ts
@@ -10,7 +10,7 @@ import type { Recipient } from '$lib/recipient';
 import type { RecipientContext } from './combined-chart-context';
 import { userSelectedDate } from './combined-chart-context';
 import {
-  allBenefitsOnDate,
+  allBenefitsOnDateNominal,
   canvasX,
   canvasY,
   dateRange,
@@ -223,7 +223,12 @@ export function benefitBoxes(
   const selectedDate = userSelectedDate(personCtx);
 
   const boxes: Array<[number, number, Money]> = [];
-  let benefit = allBenefitsOnDate(personCtx, firstCtx, secondCtx, selectedDate);
+  let benefit = allBenefitsOnDateNominal(
+    personCtx,
+    firstCtx,
+    secondCtx,
+    selectedDate
+  );
   boxes.push([
     canvasX(selectedDate, recipient, spouse, layout),
     canvasY(personCtx, benefit, maxY, minY, layout),
@@ -236,7 +241,7 @@ export function benefitBoxes(
     i.lessThanOrEqual(endDate);
     i = i.addDuration(new MonthDuration(1))
   ) {
-    const all = allBenefitsOnDate(
+    const all = allBenefitsOnDateNominal(
       personCtx,
       firstCtx,
       secondCtx,
@@ -513,7 +518,13 @@ export function renderTrendline(
     i = i.addDuration(new MonthDuration(1))
   ) {
     const thisX = canvasX(i, recipient, spouse, layout);
-    const yDollars = allBenefitsOnDate(personCtx, firstCtx, secondCtx, i, i);
+    const yDollars = allBenefitsOnDateNominal(
+      personCtx,
+      firstCtx,
+      secondCtx,
+      i,
+      i
+    );
     const thisY = canvasY(personCtx, yDollars, maxY, minY, layout);
     if (i.monthsSinceEpoch() === startDate.monthsSinceEpoch()) {
       ctx.moveTo(thisX, thisY);

--- a/src/test/benefit-calculator.test.ts
+++ b/src/test/benefit-calculator.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { benefitOnDate, benefitOnDateNominal } from '$lib/benefit-calculator';
+import {
+  allBenefitsOnDate,
+  allBenefitsOnDateNominal,
+  benefitOnDate,
+  benefitOnDateNominal,
+  spousalBenefitOnDate,
+} from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
 import { Money } from '$lib/money';
 import { MonthDate } from '$lib/month-time';
@@ -143,5 +149,99 @@ describe('benefitOnDateNominal', () => {
     expect(benefitOnDateNominal(r, FILING, at).value()).toEqual(
       benefitOnDate(r, FILING, at).value()
     );
+  });
+});
+
+/**
+ * allBenefitsOnDateNominal applies the same historical-COLA-vintage rule to the
+ * combined personal + spousal benefit shown on the spousal (combined) chart.
+ */
+describe('allBenefitsOnDateNominal (spousal)', () => {
+  const BIRTHDATE = Birthdate.FromYMD(1956, 8, 29);
+  // Both file at NRA (Jan 2023 for someone born in 1956), so the lower earner
+  // receives an unreduced spousal top-up.
+  const FILING = ym(2023, 0);
+
+  function paste(annual: number): string {
+    const lines: string[] = [];
+    for (let year = 2024; year >= 1985; year--) {
+      lines.push(`${year} $${annual} $${annual}`);
+    }
+    return lines.join('\n');
+  }
+
+  function earner(annual: number): Recipient {
+    const r = new Recipient();
+    r.birthdate = BIRTHDATE;
+    r.earningsRecords = parsePaste(paste(annual));
+    return r;
+  }
+
+  // Low earner gets a spousal top-up from the high earner.
+  const lowEarner = () => earner(18000);
+  const highEarner = () => earner(160000);
+
+  it('has a positive spousal component for this fixture', () => {
+    const low = lowEarner();
+    const high = highEarner();
+    const at = ym(constants.CURRENT_YEAR, 0);
+    const combined = allBenefitsOnDate(low, high, FILING, FILING, at).value();
+    const personalOnly = benefitOnDate(low, FILING, at).value();
+    expect(combined).toBeGreaterThan(personalOnly);
+  });
+
+  it('equals allBenefitsOnDate for a current/future month', () => {
+    const low = lowEarner();
+    const high = highEarner();
+    const at = ym(constants.CURRENT_YEAR, 0);
+    expect(
+      allBenefitsOnDateNominal(low, high, FILING, FILING, at).value()
+    ).toEqual(allBenefitsOnDate(low, high, FILING, FILING, at).value());
+  });
+
+  it('shows a smaller (nominal) combined benefit for a past mid-year month', () => {
+    const low = lowEarner();
+    const high = highEarner();
+    const at = ym(2025, 5); // June 2025: excludes the Dec-2025 COLA.
+    expect(
+      allBenefitsOnDateNominal(low, high, FILING, FILING, at).value()
+    ).toBeLessThan(allBenefitsOnDate(low, high, FILING, FILING, at).value());
+  });
+
+  it('steps up the combined benefit at the December COLA effective date', () => {
+    const low = lowEarner();
+    const high = highEarner();
+    const nov = allBenefitsOnDateNominal(
+      low,
+      high,
+      FILING,
+      FILING,
+      ym(2025, 10)
+    ).value();
+    const dec = allBenefitsOnDateNominal(
+      low,
+      high,
+      FILING,
+      FILING,
+      ym(2025, 11)
+    ).value();
+    expect(dec).toBeGreaterThan(nov);
+  });
+
+  it('caps the spousal component COLA vintage via throughColaYear', () => {
+    const low = lowEarner();
+    const high = highEarner();
+    const at = ym(2025, 5);
+    const today = spousalBenefitOnDate(low, high, FILING, FILING, at).value();
+    const nominal = spousalBenefitOnDate(
+      low,
+      high,
+      FILING,
+      FILING,
+      at,
+      2024
+    ).value();
+    expect(today).toBeGreaterThan(0);
+    expect(nominal).toBeLessThan(today);
   });
 });

--- a/src/test/benefit-calculator.test.ts
+++ b/src/test/benefit-calculator.test.ts
@@ -244,4 +244,32 @@ describe('allBenefitsOnDateNominal (spousal)', () => {
     expect(today).toBeGreaterThan(0);
     expect(nominal).toBeLessThan(today);
   });
+
+  it('caps COLA vintage in the combined-max branch (lower earner files after NRA)', () => {
+    const low = lowEarner();
+    const high = highEarner();
+    // Lower earner files July 2024 (after their NRA of Jan 2023), entering the
+    // combined-max branch where the personal benefit is subtracted from half
+    // the higher earner's PIA. That personal benefit must also honor the COLA
+    // cutoff (computed via benefitOnDateCore, not benefitOnDate).
+    const lateFiling = ym(2024, 6);
+    const at = ym(2025, 5);
+    const today = spousalBenefitOnDate(
+      low,
+      high,
+      FILING,
+      lateFiling,
+      at
+    ).value();
+    const nominal = spousalBenefitOnDate(
+      low,
+      high,
+      FILING,
+      lateFiling,
+      at,
+      2024
+    ).value();
+    expect(today).toBeGreaterThan(0);
+    expect(nominal).toBeLessThan(today);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #559 (filing-date chart). The combined (spousal) chart had the same gap: it showed each month's combined personal + spousal benefit in **today's dollars** via `allBenefitsOnDate`, so past months were inflated by COLAs that hadn't taken effect then.

This applies the same opt-in nominal-COLA approach to the spousal chart, leaving the strategy/NPV optimizer in constant dollars.

## Approach

- `benefit-calculator.ts`: thread an optional `throughColaYear` through `spousalBenefitOnDate` — applied to both PIA halves and, in the combined-max rule, to the personal benefit (via `benefitOnDateCore`). Add exported `allBenefitsOnDateNominal` that derives the COLA vintage from `atDate` (`colaYearForDisplayDate`) and sums `benefitOnDateNominal` + the cutoff-aware spousal benefit. Core `allBenefitsOnDate` / `spousalBenefitOnDate` default behavior is unchanged.
- `combined-chart-math.ts`: add an `allBenefitsOnDateNominal` context-layer wrapper mirroring the existing one.
- Wire the combined-chart renderer (trendline + step boxes) and the `CombinedChart.svelte` hover label to the nominal wrapper.

## Scope

- **In:** personal + spousal components on the combined chart (calculator).
- **Out (tracked on #559):** survivor benefits remain in today's dollars; integration/embed panels unchanged.
- **Unchanged:** strategy optimizer (`benefitOnDateOptimized`, `allBenefitsOnDate`) — constant (real) dollars, correct for lifetime comparison.

## Tests

- New `allBenefitsOnDateNominal (spousal)` block in `benefit-calculator.test.ts`: positive-spousal fixture (low + high earner), present/future equivalence with `allBenefitsOnDate`, past mid-year month strictly smaller, December COLA step, and `throughColaYear` capping the spousal PIAs.
- Full suite: 1983 passing; `npm run quality` clean.
