### PR TITLE
feat(calculator): past-tense NRA box text when NRA is in the past

### DIFF
--- a/src/lib/components/NormalRetirementAgeReport.svelte
+++ b/src/lib/components/NormalRetirementAgeReport.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { benefitOnDateNominal } from '$lib/benefit-calculator';
 import * as constants from '$lib/constants';
 import { Money } from '$lib/money';
 import { MonthDate } from '$lib/month-time';
@@ -11,21 +12,27 @@ const r: Recipient = recipient;
 const exampleAge = recipient.birthdate.exampleSsaAge(constants.CURRENT_YEAR);
 
 /**
- * The benefit amount at normal retirement age.
- */
-let benefit: Money = Money.from(0);
-$: benefit = $recipient.pia().primaryInsuranceAmount().floorToDollar();
-
-/**
- * Whether normal retirement age is already in the past. When it is, the PIA
- * shown is no longer an amount the user can newly elect at NRA; it is the NRA
- * benefit restated in today's dollars (COLAs since NRA already applied), so the
- * explanatory text switches to past tense.
+ * Whether normal retirement age is already in the past. When it is, the benefit
+ * is shown in the nominal dollars actually payable at NRA (matching the
+ * filing-date chart); otherwise it is shown in today's dollars.
  */
 let isPastNra = false;
 $: isPastNra = $recipient
   .normalRetirementDate()
   .lessThan(MonthDate.initFromNow());
+
+/**
+ * The benefit amount at normal retirement age. Filing exactly at NRA means no
+ * reduction or delayed credits, so this is the PIA. benefitOnDateNominal caps
+ * the COLA vintage at the NRA month, so a past NRA yields the nominal amount
+ * payable then and a future NRA yields today's dollars.
+ */
+let benefit: Money = Money.from(0);
+$: benefit = benefitOnDateNominal(
+  $recipient,
+  $recipient.normalRetirementDate(),
+  $recipient.normalRetirementDate()
+).floorToDollar();
 </script>
 
 <div>
@@ -33,12 +40,14 @@ $: isPastNra = $recipient
   <div class="text pageBreakAvoid">
     {#if isPastNra}
       <p>
-        The primary insurance amount rounded down (<b>{benefit.wholeDollars()}</b
-        >
-        / month) is the benefit you would have earned by collecting at your
-        <u>normal retirement age</u> (NRA), which has already passed. It is shown
-        in <u>today's dollars</u>: the amount has already been adjusted upward
-        for the cost-of-living adjustments (COLAs) applied since then.
+        The benefit you would have earned by collecting at your
+        <u>normal retirement age</u> (NRA) in
+        {recipient.normalRetirementDate().monthFullName()}
+        {recipient.normalRetirementDate().year()} was
+        <b>{benefit.wholeDollars()} / month</b>. This is the nominal amount
+        payable then; it has since grown with annual
+        <u>cost-of-living adjustments</u> (COLAs), so the equivalent in today's
+        dollars is higher.
       </p>
     {:else}
       <p>

--- a/src/lib/components/NormalRetirementAgeReport.svelte
+++ b/src/lib/components/NormalRetirementAgeReport.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import * as constants from '$lib/constants';
 import { Money } from '$lib/money';
+import { MonthDate } from '$lib/month-time';
 import { Recipient } from '$lib/recipient';
 import RName from './RecipientName.svelte';
 
@@ -14,16 +15,39 @@ const exampleAge = recipient.birthdate.exampleSsaAge(constants.CURRENT_YEAR);
  */
 let benefit: Money = Money.from(0);
 $: benefit = $recipient.pia().primaryInsuranceAmount().floorToDollar();
+
+/**
+ * Whether normal retirement age is already in the past. When it is, the PIA
+ * shown is no longer an amount the user can newly elect at NRA; it is the NRA
+ * benefit restated in today's dollars (COLAs since NRA already applied), so the
+ * explanatory text switches to past tense.
+ */
+let isPastNra = false;
+$: isPastNra = $recipient
+  .normalRetirementDate()
+  .lessThan(MonthDate.initFromNow());
 </script>
 
 <div>
   <h2>Normal Retirement Age</h2>
   <div class="text pageBreakAvoid">
-    <p>
-      The primary insurance amount rounded down (<b>{benefit.wholeDollars()}</b>
-      / month) is the benefit you will earn if you begin collecting your benefit
-      at your <u>normal retirement age</u> (NRA).
-    </p>
+    {#if isPastNra}
+      <p>
+        The primary insurance amount rounded down (<b>{benefit.wholeDollars()}</b
+        >
+        / month) is the benefit you would have earned by collecting at your
+        <u>normal retirement age</u> (NRA), which has already passed. It is shown
+        in <u>today's dollars</u>: the amount has already been adjusted upward
+        for the cost-of-living adjustments (COLAs) applied since then.
+      </p>
+    {:else}
+      <p>
+        The primary insurance amount rounded down (<b>{benefit.wholeDollars()}</b
+        >
+        / month) is the benefit you will earn if you begin collecting your
+        benefit at your <u>normal retirement age</u> (NRA).
+      </p>
+    {/if}
     <p>
       You may also see this referred to as the <u>full retirement age</u> (FRA).
     </p>


### PR DESCRIPTION
## Summary

Follow-up to the nominal-COLA chart work (#560/#562). The "Normal Retirement Age" box always showed the PIA in **today's dollars** and said "the benefit you **will** earn at NRA". For anyone whose NRA is already in the past that's wrong tense, and the figure didn't match the filing-date chart at the (past) NRA month, which now shows nominal amounts (#560).

This makes the NRA box consistent with the charts: **past dollar amounts are shown in nominal terms; future amounts stay in today's dollars.**

## Change

`NormalRetirementAgeReport.svelte`:
- `isPastNra = normalRetirementDate() < MonthDate.initFromNow()`.
- The benefit value is now `benefitOnDateNominal(r, nraDate, nraDate)`. Filing exactly at NRA means no reduction/credits, so this is the PIA — capped to the NRA-month COLA vintage. A past NRA yields the nominal amount payable then; a future NRA auto-clamps to today's dollars (unchanged behavior).
- Past-NRA copy switches to past tense and explains the figure is the nominal amount payable then, which has since grown with COLAs (so today's equivalent is higher).

Verified on localhost:

- **Past NRA (born 1956, NRA Jan 2023):**
  > The benefit you would have earned by collecting at your normal retirement age (NRA) in January 2023 was **$1,544 / month**. This is the nominal amount payable then; it has since grown with annual cost-of-living adjustments (COLAs), so the equivalent in today's dollars is higher.

  ($1,544 nominal × the 2023–2025 COLAs ≈ the $1,679 today's-dollars PIA shown in the PIA box, and matches the filing-date chart at the NRA month.)
- **Future NRA (born 1975):** unchanged —
  > The primary insurance amount rounded down ($2,326 / month) is the benefit you will earn if you begin collecting your benefit at your normal retirement age (NRA).

## Tests

Presentational/conditional change. `npm run quality` clean (svelte-check 0/0); full suite 1984 passing. Both branches verified in-browser.
