### PR TITLE
fix(calculator): keep filing-date drop-line on the same month in print

### DIFF
--- a/src/lib/components/FilingDateChart.svelte
+++ b/src/lib/components/FilingDateChart.svelte
@@ -145,15 +145,25 @@ function removeMediaQueryListener() {
 }
 
 let mouseToggle_: boolean = true;
-let lastMouseX_: number = -1;
-let lastMouseDate_: MonthDate = new MonthDate(0);
+// The "Explore Filing Dates" selection is persisted as a date (or null when
+// nothing is hovered), NOT as a pixel. The pixel is recomputed from this date
+// at render time for whatever canvas width is in effect, so the drop-line and
+// its label stay on the same month across screen and print, even though the
+// @media print block resizes the canvas. See issue #561.
+let selectedDate_: MonthDate | null = null;
+
+function eventDate(event: MouseEvent): MonthDate {
+  const mouseX = event.clientX - canvasEl_.getBoundingClientRect().left;
+  return dateX(mouseX, recipient.birthdate, layout());
+}
+
 function onClick(event: MouseEvent) {
   if (!canvasEl_) return;
   if (mouseToggle_) {
     mouseToggle_ = false;
   } else {
     mouseToggle_ = true;
-    lastMouseX_ = event.clientX - canvasEl_.getBoundingClientRect().left;
+    selectedDate_ = eventDate(event);
   }
   render();
 }
@@ -161,25 +171,27 @@ function onClick(event: MouseEvent) {
 function onMove(event: MouseEvent) {
   if (!mouseToggle_) return;
   if (!canvasEl_) return;
-  lastMouseX_ = event.clientX - canvasEl_.getBoundingClientRect().left;
+  const mouseDate = eventDate(event);
   // Avoid redrawing if the mouse hasn't moved to a new month.
-  const mouseDate = dateX(lastMouseX_, recipient.birthdate, layout());
-  if (mouseDate.monthsSinceEpoch() === lastMouseDate_.monthsSinceEpoch())
+  if (
+    selectedDate_ !== null &&
+    mouseDate.monthsSinceEpoch() === selectedDate_.monthsSinceEpoch()
+  )
     return;
-  lastMouseDate_ = mouseDate;
+  selectedDate_ = mouseDate;
 
   render();
 }
 
 function onOut(_event: MouseEvent) {
   if (!mouseToggle_) return;
-  lastMouseX_ = -1;
+  selectedDate_ = null;
   render();
 }
 
 function onBlur(_event: FocusEvent) {
   if (!mouseToggle_) return;
-  lastMouseX_ = -1;
+  selectedDate_ = null;
   render();
 }
 
@@ -253,8 +265,8 @@ function render() {
   renderHorizontalLines(ctx_, recipient, l);
   renderBenefit(ctx_, recipient, userSelectedDate(), userFloor_, l);
 
-  if (lastMouseX_ > 0) {
-    renderSelectedDateVerticalLine(ctx_, lastMouseX_, recipient, l);
+  if (selectedDate_ !== null) {
+    renderSelectedDateVerticalLine(ctx_, selectedDate_, recipient, l);
   }
 
   ctx_.restore();
@@ -328,23 +340,23 @@ $: filingDateString_ = updateFilingDateString(
     style:--selected-date-border-color={blueish_}
     style:--selected-date-text-color={blueish_}
     style:--filing-date-text-color={recipient.colors().dark}
-    class:hidden={lastMouseX_ <= 0}
+    class:hidden={selectedDate_ === null}
   >
-    {#if lastMouseX_ > 0}
+    {#if selectedDate_ !== null}
       If filing for benefits in <span class="filingDate"
         >{filingDateString_}</span
       >,
       <br />
       In
       <span class="selectedDate"
-        >{dateX(lastMouseX_, recipient.birthdate, layout()).monthName()}
-        {dateX(lastMouseX_, recipient.birthdate, layout()).year()}</span
+        >{selectedDate_.monthName()}
+        {selectedDate_.year()}</span
       >, <RecipientName r={recipient} apos noColor={true} shortenTo={30}
         >your</RecipientName
       > benefit will be:
 
       <b>
-        {benefitOnDateNominal($recipient, userSelectedDate(), dateX(lastMouseX_, recipient.birthdate, layout()))
+        {benefitOnDateNominal($recipient, userSelectedDate(), selectedDate_)
           .wholeDollars()}</b
       >
     {:else}

--- a/src/lib/components/filing-date-chart-renderer.ts
+++ b/src/lib/components/filing-date-chart-renderer.ts
@@ -335,19 +335,24 @@ export function renderBenefit(
 }
 
 /**
- * Renders a vertical dashed line at a mouse position with a date label.
+ * Renders a vertical dashed line at the selected date with a month/year label.
+ *
+ * The selected date is passed as a MonthDate (not a pixel) so the line and its
+ * label land on the same month regardless of the current canvas width. The
+ * pixel position is recomputed here via canvasX for whatever width is in
+ * effect, which keeps screen and print output consistent. See issue #561.
  */
 export function renderSelectedDateVerticalLine(
   ctx: CanvasRenderingContext2D,
-  mouseX: number,
+  date: MonthDate,
   recipient: Recipient,
   layout: ChartLayout
 ): void {
-  if (mouseX <= 0 || mouseX >= layout.canvasWidth) return;
+  const x = canvasX(date, recipient.birthdate, layout);
+  if (x < layout.reservedLeft || x >= layout.canvasWidth) return;
 
   ctx.save();
 
-  const date = dateX(mouseX, recipient.birthdate, layout);
   const text = `${date.monthName()} ${date.year()}`;
   const textWidth = ctx.measureText(text).width;
   // This seems to position the year to line up with the vertical year lines.
@@ -362,11 +367,11 @@ export function renderSelectedDateVerticalLine(
 
   // Draw vertical line.
   ctx.beginPath();
-  ctx.moveTo(mouseX, 0);
-  ctx.lineTo(mouseX, layout.canvasHeight);
+  ctx.moveTo(x, 0);
+  ctx.lineTo(x, layout.canvasHeight);
   ctx.stroke();
   ctx.save();
-  ctx.translate(mouseX + 5, xpos);
+  ctx.translate(x + 5, xpos);
   ctx.rotate((-90 * Math.PI) / 180);
   ctx.fillStyle = '#337ab7';
   renderTextInWhiteBox(ctx, text, 0, 0);

--- a/src/test/components/filing-date-chart-math.test.ts
+++ b/src/test/components/filing-date-chart-math.test.ts
@@ -11,7 +11,8 @@ import { Recipient } from '$lib/recipient';
  *
  * The "Explore Filing Dates" selection must be stored as a date and converted
  * to a pixel at render time, so the selected month is stable no matter what
- * canvas width is in effect (screen min(55vw,740px) vs print 80vw).
+ * canvas width is in effect (the canvas is a different width in print than on a
+ * wide screen).
  *
  * These tests guard the canvasX/dateX pair the fix relies on:
  *  - a stored DATE round-trips to the same month at any width (the property
@@ -35,7 +36,8 @@ function recipientBornJan1960(): Recipient {
   return recipient;
 }
 
-// Screen (capped), a mid mobile width, and a representative print width.
+// Three differing canvas widths. The exact values don't matter; the invariant
+// is that the round-trip holds regardless of width.
 const WIDTHS = [320, 740, 1184];
 
 describe('filing-date chart coordinate math', () => {
@@ -44,21 +46,33 @@ describe('filing-date chart coordinate math', () => {
   const startDate = birthdate.dateAtSsaAge(
     MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
   );
-  const endDate = birthdate.dateAtSsaAge(
-    MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
-  );
 
   it('round-trips every month (date -> x -> date) at every canvas width', () => {
-    for (const width of WIDTHS) {
-      const layout = layoutOfWidth(width);
-      for (
-        let date = startDate;
-        date.lessThanOrEqual(endDate);
-        date = date.addDuration(new MonthDuration(1))
-      ) {
-        const x = canvasX(date, birthdate, layout);
-        const back = dateX(x, birthdate, layout);
-        expect(back.monthsSinceEpoch()).toBe(date.monthsSinceEpoch());
+    // Cover a clean year-aligned start (born on the 1st -> age-62 floor is
+    // 62y0m) and a mid-month birth (floor is 62y1m, so startDate is not aligned
+    // to a year boundary), which exercises the dateAtSsaAge floor inside the map.
+    const birthdates = [
+      Birthdate.FromYMD(1960, 0, 1),
+      Birthdate.FromYMD(1960, 5, 15),
+    ];
+    for (const bd of birthdates) {
+      const start = bd.dateAtSsaAge(
+        MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
+      );
+      const end = bd.dateAtSsaAge(
+        MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
+      );
+      for (const width of WIDTHS) {
+        const layout = layoutOfWidth(width);
+        for (
+          let date = start;
+          date.lessThanOrEqual(end);
+          date = date.addDuration(new MonthDuration(1))
+        ) {
+          const x = canvasX(date, bd, layout);
+          const back = dateX(x, bd, layout);
+          expect(back.monthsSinceEpoch()).toBe(date.monthsSinceEpoch());
+        }
       }
     }
   });

--- a/src/test/components/filing-date-chart-math.test.ts
+++ b/src/test/components/filing-date-chart-math.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { Birthdate } from '$lib/birthday';
+import type { ChartLayout } from '$lib/components/chart-utils';
+import { canvasX, dateX } from '$lib/components/filing-date-chart-math';
+import { MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+
+/**
+ * Invariants behind the fix for issue #561.
+ *
+ * The "Explore Filing Dates" selection must be stored as a date and converted
+ * to a pixel at render time, so the selected month is stable no matter what
+ * canvas width is in effect (screen min(55vw,740px) vs print 80vw).
+ *
+ * These tests guard the canvasX/dateX pair the fix relies on:
+ *  - a stored DATE round-trips to the same month at any width (the property
+ *    the fix guarantees), and
+ *  - a stored PIXEL does NOT (the bug fingerprint we moved away from).
+ */
+
+function layoutOfWidth(canvasWidth: number): ChartLayout {
+  return {
+    canvasWidth,
+    canvasHeight: 420,
+    reservedLeft: 70,
+    reservedTop: 120,
+    reservedBottom: 8,
+  };
+}
+
+function recipientBornJan1960(): Recipient {
+  const recipient = new Recipient();
+  recipient.birthdate = Birthdate.FromYMD(1960, 0, 1);
+  return recipient;
+}
+
+// Screen (capped), a mid mobile width, and a representative print width.
+const WIDTHS = [320, 740, 1184];
+
+describe('filing-date chart coordinate math', () => {
+  const recipient = recipientBornJan1960();
+  const birthdate = recipient.birthdate;
+  const startDate = birthdate.dateAtSsaAge(
+    MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
+  );
+  const endDate = birthdate.dateAtSsaAge(
+    MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
+  );
+
+  it('round-trips every month (date -> x -> date) at every canvas width', () => {
+    for (const width of WIDTHS) {
+      const layout = layoutOfWidth(width);
+      for (
+        let date = startDate;
+        date.lessThanOrEqual(endDate);
+        date = date.addDuration(new MonthDuration(1))
+      ) {
+        const x = canvasX(date, birthdate, layout);
+        const back = dateX(x, birthdate, layout);
+        expect(back.monthsSinceEpoch()).toBe(date.monthsSinceEpoch());
+      }
+    }
+  });
+
+  it('maps a stored DATE to the same month across screen and print widths', () => {
+    // An arbitrary date a user might explore: 36 months into the range.
+    const exploredDate = startDate.addDuration(new MonthDuration(36));
+
+    const monthsAcrossWidths = WIDTHS.map((width) => {
+      const layout = layoutOfWidth(width);
+      // Persist the date, recompute the pixel at this width, re-derive the date.
+      const x = canvasX(exploredDate, birthdate, layout);
+      return dateX(x, birthdate, layout).monthsSinceEpoch();
+    });
+
+    // Every width resolves back to the same month.
+    for (const m of monthsAcrossWidths) {
+      expect(m).toBe(exploredDate.monthsSinceEpoch());
+    }
+  });
+
+  it('documents the bug: a stored PIXEL maps to different months across widths', () => {
+    // The old code stored the raw mouse pixel. The same pixel divides by a
+    // different (canvasWidth - reservedLeft) at print width, so it lands on a
+    // different month. This is exactly what the fix avoids by storing a date.
+    const pixel = 400;
+    const screenMonth = dateX(
+      pixel,
+      birthdate,
+      layoutOfWidth(740)
+    ).monthsSinceEpoch();
+    const printMonth = dateX(
+      pixel,
+      birthdate,
+      layoutOfWidth(1184)
+    ).monthsSinceEpoch();
+
+    expect(screenMonth).not.toBe(printMonth);
+  });
+});

--- a/src/test/components/filing-date-chart-renderer.test.ts
+++ b/src/test/components/filing-date-chart-renderer.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { Birthdate } from '$lib/birthday';
+import type { ChartLayout } from '$lib/components/chart-utils';
+import { canvasX } from '$lib/components/filing-date-chart-math';
+import { renderSelectedDateVerticalLine } from '$lib/components/filing-date-chart-renderer';
+import { MonthDate } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+
+/**
+ * Regression tests for issue #561: the "Explore Filing Dates" drop-line and its
+ * label must point at the same month regardless of the canvas width in effect.
+ *
+ * Print mode resizes the canvas (80vw) relative to the screen (min(55vw, 740px)),
+ * so a date-driven renderer must derive both the line position and the label
+ * from a MonthDate, not from a stored pixel.
+ */
+
+/**
+ * A minimal recording stand-in for CanvasRenderingContext2D that captures the
+ * text drawn (fillText) and the path moves (moveTo/lineTo) so tests can assert
+ * what the renderer produced without a real canvas.
+ */
+function recordingContext() {
+  const fillTexts: string[] = [];
+  const moveTos: Array<[number, number]> = [];
+  const lineTos: Array<[number, number]> = [];
+  const ctx = {
+    fillTexts,
+    moveTos,
+    lineTos,
+    // Settable style properties the renderer assigns to.
+    strokeStyle: '',
+    fillStyle: '',
+    lineCap: '',
+    lineWidth: 0,
+    font: '',
+    save() {},
+    restore() {},
+    beginPath() {},
+    stroke() {},
+    translate() {},
+    rotate() {},
+    setLineDash() {},
+    fillRect() {},
+    measureText(text: string) {
+      // Width proportional to length is enough for layout math under test.
+      return { width: text.length * 7 } as TextMetrics;
+    },
+    moveTo(x: number, y: number) {
+      moveTos.push([x, y]);
+    },
+    lineTo(x: number, y: number) {
+      lineTos.push([x, y]);
+    },
+    fillText(text: string) {
+      fillTexts.push(text);
+    },
+  };
+  return ctx;
+}
+
+function layoutOfWidth(canvasWidth: number): ChartLayout {
+  return {
+    canvasWidth,
+    canvasHeight: 420,
+    reservedLeft: 70,
+    reservedTop: 120,
+    reservedBottom: 8,
+  };
+}
+
+function recipientBornJan1960(): Recipient {
+  const recipient = new Recipient();
+  recipient.birthdate = Birthdate.FromYMD(1960, 0, 1);
+  return recipient;
+}
+
+describe('renderSelectedDateVerticalLine', () => {
+  // January 2025 is comfortably within the age 62..71 window for a 1960 birth.
+  const selectedDate = MonthDate.initFromYearsMonths({
+    years: 2025,
+    months: 0,
+  });
+
+  it('labels the drop-line with the selected month, independent of canvas width', () => {
+    const recipient = recipientBornJan1960();
+
+    const screen = recordingContext();
+    renderSelectedDateVerticalLine(
+      screen as unknown as CanvasRenderingContext2D,
+      selectedDate,
+      recipient,
+      layoutOfWidth(740)
+    );
+
+    const print = recordingContext();
+    renderSelectedDateVerticalLine(
+      print as unknown as CanvasRenderingContext2D,
+      selectedDate,
+      recipient,
+      layoutOfWidth(1184)
+    );
+
+    // The label is the selected month (3-char month name, as the canvas has
+    // always rendered it), and it is the same at both widths.
+    expect(screen.fillTexts).toContain('Jan 2025');
+    expect(print.fillTexts).toContain('Jan 2025');
+    expect(screen.fillTexts).toEqual(print.fillTexts);
+  });
+
+  it('positions the vertical line at canvasX(date) for the active width', () => {
+    const recipient = recipientBornJan1960();
+
+    for (const width of [740, 1184]) {
+      const ctx = recordingContext();
+      renderSelectedDateVerticalLine(
+        ctx as unknown as CanvasRenderingContext2D,
+        selectedDate,
+        recipient,
+        layoutOfWidth(width)
+      );
+
+      const expectedX = canvasX(
+        selectedDate,
+        recipient.birthdate,
+        layoutOfWidth(width)
+      );
+      // The vertical line starts at the top (y=0) at the date's x position.
+      expect(ctx.moveTos).toContainEqual([expectedX, 0]);
+    }
+  });
+});

--- a/src/test/components/filing-date-chart-renderer.test.ts
+++ b/src/test/components/filing-date-chart-renderer.test.ts
@@ -4,16 +4,16 @@ import { Birthdate } from '$lib/birthday';
 import type { ChartLayout } from '$lib/components/chart-utils';
 import { canvasX } from '$lib/components/filing-date-chart-math';
 import { renderSelectedDateVerticalLine } from '$lib/components/filing-date-chart-renderer';
-import { MonthDate } from '$lib/month-time';
+import { MonthDate, MonthDuration } from '$lib/month-time';
 import { Recipient } from '$lib/recipient';
 
 /**
  * Regression tests for issue #561: the "Explore Filing Dates" drop-line and its
  * label must point at the same month regardless of the canvas width in effect.
  *
- * Print mode resizes the canvas (80vw) relative to the screen (min(55vw, 740px)),
- * so a date-driven renderer must derive both the line position and the label
- * from a MonthDate, not from a stored pixel.
+ * The canvas is rendered at different widths on screen vs in print (the
+ * @media print block widens it), so a date-driven renderer must derive both the
+ * line position and the label from a MonthDate, not from a stored pixel.
  */
 
 /**
@@ -129,5 +129,57 @@ describe('renderSelectedDateVerticalLine', () => {
       // The vertical line starts at the top (y=0) at the date's x position.
       expect(ctx.moveTos).toContainEqual([expectedX, 0]);
     }
+  });
+
+  // The renderer's guard is the half-open interval [reservedLeft, canvasWidth):
+  //   if (x < reservedLeft || x >= canvasWidth) return;
+  // These two tests pin both ends so a future tweak to the comparison operators
+  // is caught.
+
+  it('draws the line at the age-62 start date (x === reservedLeft, inclusive)', () => {
+    const recipient = recipientBornJan1960();
+    const startDate = recipient.birthdate.dateAtSsaAge(
+      MonthDuration.initFromYearsMonths({ years: 62, months: 0 })
+    );
+    const layout = layoutOfWidth(740);
+    // The earliest selectable date sits exactly on the left edge of the plot.
+    expect(canvasX(startDate, recipient.birthdate, layout)).toBe(
+      layout.reservedLeft
+    );
+
+    const ctx = recordingContext();
+    renderSelectedDateVerticalLine(
+      ctx as unknown as CanvasRenderingContext2D,
+      startDate,
+      recipient,
+      layout
+    );
+
+    expect(ctx.moveTos).toContainEqual([layout.reservedLeft, 0]);
+    expect(ctx.fillTexts.length).toBeGreaterThan(0);
+  });
+
+  it('skips the line at the age-71 end date (x === canvasWidth, exclusive)', () => {
+    const recipient = recipientBornJan1960();
+    const endDate = recipient.birthdate.dateAtSsaAge(
+      MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
+    );
+    const layout = layoutOfWidth(740);
+    // Age 71 is the right edge of the rendered range; it maps to canvasWidth and
+    // is intentionally not drawn (the selectable slider stops at age 70).
+    expect(canvasX(endDate, recipient.birthdate, layout)).toBe(
+      layout.canvasWidth
+    );
+
+    const ctx = recordingContext();
+    renderSelectedDateVerticalLine(
+      ctx as unknown as CanvasRenderingContext2D,
+      endDate,
+      recipient,
+      layout
+    );
+
+    expect(ctx.moveTos).toEqual([]);
+    expect(ctx.fillTexts).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #561

## Problem

On `/calculator`, the "Explore Filing Dates" hover annotation (the vertical drop-line plus the "In {month} {year}, your benefit will be \$X" note) landed on a **different month** when the page was saved to PDF / printed than what was shown on screen.

## Root cause

The selection was stored as a raw **pixel** (`lastMouseX_`) and converted to a date lazily, at render time, using the *current* canvas width:

```
percent = (clampedX - reservedLeft) / (canvasWidth - reservedLeft)   // dateX()
```

`FilingDateChart` is the only chart that both (a) widens its canvas via an `@media print` block (`80vw` vs `min(55vw, 740px)` on a wide screen) and (b) registers a `matchMedia('print')` listener that re-syncs the canvas bitmap width. So on print, the same `lastMouseX_` pixel divided by a different denominator and mapped to a different month — in both the canvas drop-line label and the HTML detail box.

## Fix

Persist the selection as a **`MonthDate`** (`selectedDate_`), and recompute the pixel from that date via the existing `canvasX()` at render time, for whatever canvas width is in effect. The inverse function `canvasX` already existed as the mirror of `dateX`, so this is a small, surgical change:

- `FilingDateChart.svelte`: replace `lastMouseX_` / `lastMouseDate_` with `selectedDate_: MonthDate | null`; convert the event pixel to a date on hover/click; clear to `null` on out/blur. The detail box reads `selectedDate_` directly (removing three redundant `dateX(..., layout())` recomputations).
- `filing-date-chart-renderer.ts`: `renderSelectedDateVerticalLine` now takes a `MonthDate` and computes the line position internally, so the line and its label can never disagree.

One intentional, beneficial side effect: the drop-line now snaps exactly to the labeled month's boundary (≈±3px), where before it sat at the raw mouse pixel while the label showed the rounded month.

## Verification & regression prevention

- **`src/test/components/filing-date-chart-math.test.ts`** — guards the `canvasX`/`dateX` pair: a stored *date* round-trips to the same month at widths `[320, 740, 1184]`; a stored *pixel* does **not** (the bug's fingerprint).
- **`src/test/components/filing-date-chart-renderer.test.ts`** — with a recording fake canvas context, asserts the drop-line label is identical at screen vs print width for a fixed date, and the line `x` equals `canvasX(date, layout)`.
- Full suite: 1989 tests pass; `npm run quality` (Biome + svelte-check) clean.

### Manual print check (for reviewer)

1. `/calculator` -> hover a known month (e.g. Jan 2025) on the Explore Filing Dates chart.
2. Cmd/Ctrl-P. Confirm the drop-line + detail box still read the same month in the print preview.

## Scope note

`CombinedChart` / `BendpointChart` share the same latent pixel-storage pattern but are **not** affected: neither resizes its canvas on print (no `@media print` canvas rule, no print media listener). Unifying them is a possible follow-up, intentionally left out of scope here.