### PR TITLE
feat(ai-export): full benefit-derivation export for AI assistants (#553)

### DIFF
--- a/src/lib/ai-export.ts
+++ b/src/lib/ai-export.ts
@@ -1,0 +1,233 @@
+import { benefitAtAge } from '$lib/benefit-calculator';
+import type { Birthdate } from '$lib/birthday';
+import { MAX_COLA_YEAR, MAX_WAGE_INDEX_YEAR } from '$lib/constants';
+import { MonthDuration } from '$lib/month-time';
+import type { Recipient } from '$lib/recipient';
+import { buildStrategyHash } from '$lib/url-params';
+
+/**
+ * Options for {@link buildCalculatorAiExport}.
+ */
+export interface CalculatorAiExportOptions {
+  /**
+   * Include the year-by-year taxed-earnings table. Defaults to true. Ignored
+   * for PIA-only recipients (which have no earnings history).
+   */
+  includeEarnings?: boolean;
+  /**
+   * Base URL for the deep link back to the calculator. Defaults to the
+   * production URL. Override for tests or alternate deployments.
+   */
+  baseUrl?: string;
+  /**
+   * A "generated on" date string (e.g. "2026-06-19") stamped into the header.
+   * Injected by the caller so the builder stays pure and deterministic rather
+   * than reading the system clock. Omitted means no generated-on line.
+   */
+  generatedDate?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://ssa.tools/calculator';
+
+/**
+ * Formats a birthdate as an ISO `YYYY-MM-DD` string for the `dob1` URL
+ * parameter (the format {@link buildStrategyHash} and the calculator's URL
+ * hydration expect).
+ */
+function isoBirthdate(birthdate: Birthdate): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  // layBirthMonth() is 0-indexed (January = 0); the dob parameter is 1-indexed.
+  const month = pad(birthdate.layBirthMonth() + 1);
+  const day = pad(birthdate.layBirthDayOfMonth());
+  return `${birthdate.layBirthYear()}-${month}-${day}`;
+}
+
+/**
+ * Builds the deep link back to the calculator that reloads this recipient's
+ * inputs. The link is PIA-based (the same approach as the strategy share link):
+ * it carries the current-dollar PIA, so reopening it reconstructs the headline
+ * numbers even though the raw earnings history is not encoded in the URL.
+ */
+function deepLink(recipient: Recipient, baseUrl: string): string {
+  const pia = Math.round(recipient.pia().primaryInsuranceAmount().value());
+  const hash = buildStrategyHash({
+    isSingle: true,
+    pia1: pia,
+    dob1: isoBirthdate(recipient.birthdate),
+    name1:
+      recipient.name && recipient.name !== 'Self' ? recipient.name : undefined,
+    gender1: recipient.gender,
+  });
+  return `${baseUrl}${hash}`;
+}
+
+function ageOf(years: number): MonthDuration {
+  return MonthDuration.initFromYearsMonths({ years, months: 0 });
+}
+
+/**
+ * Describes the recipient's eligibility (40 work credits) so an AI assistant
+ * understands a $0 PIA as "not yet eligible" rather than a calculation error.
+ * Returns null for PIA-only recipients, who have no earnings/credit history.
+ */
+function eligibilityLine(recipient: Recipient): string | null {
+  if (recipient.isPiaOnly) return null;
+  const earned = recipient.earnedCredits();
+  if (earned >= 40) {
+    return '- Eligibility: 40 of 40 credits earned (eligible for retirement benefits).';
+  }
+  if (recipient.totalCredits() >= 40) {
+    return `- Eligibility: ${earned} of 40 credits earned so far; projected to reach 40 and become eligible with future earnings.`;
+  }
+  return `- Eligibility: ${earned} of 40 credits earned — not yet eligible for retirement benefits, so the PIA and benefit estimates below remain $0 until 40 credits are earned.`;
+}
+
+/**
+ * Builds a self-contained markdown snippet summarizing a calculator recipient's
+ * Social Security situation, intended to be pasted into an AI assistant such as
+ * Claude or ChatGPT. See issue #553.
+ *
+ * The function is pure and deterministic: every value is derived from the
+ * recipient and the fixed SSA constants, and any "as of today" value comes from
+ * {@link CalculatorAiExportOptions.generatedDate} rather than the system clock.
+ * Nothing is transmitted anywhere; the caller copies the returned string to the
+ * clipboard only when the user asks.
+ */
+export function buildCalculatorAiExport(
+  recipient: Recipient,
+  options: CalculatorAiExportOptions = {}
+): string {
+  const includeEarnings = options.includeEarnings ?? true;
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+
+  const pia = recipient.pia();
+  const fra = recipient.normalRetirementAge();
+  const fraDate = recipient.normalRetirementDate();
+
+  const sections: string[] = [];
+
+  // --- Header ---
+  const generated = options.generatedDate
+    ? `_Generated ${options.generatedDate}. All amounts in today's dollars._`
+    : "_All amounts in today's dollars._";
+  sections.push(
+    ['# Social Security benefit summary (from ssa.tools)', '', generated].join(
+      '\n'
+    )
+  );
+
+  // --- Inputs ---
+  const inputs: string[] = [
+    '## Inputs',
+    '',
+    `- Birthdate: ${recipient.birthdate.layBirthdateString()}`,
+  ];
+  if (recipient.isPiaOnly) {
+    inputs.push(
+      `- Primary Insurance Amount (PIA) entered directly: ${pia
+        .primaryInsuranceAmount()
+        .wholeDollars()} (no earnings history provided)`
+    );
+  } else if (includeEarnings && recipient.earningsRecords.length > 0) {
+    inputs.push(
+      '',
+      '### Taxed earnings history',
+      '',
+      '| Year | Taxed earnings |',
+      '| --- | --- |'
+    );
+    for (const record of recipient.earningsRecords) {
+      inputs.push(
+        `| ${record.year} | ${record.taxedEarnings.wholeDollars()} |`
+      );
+    }
+  } else {
+    inputs.push('- Earnings history omitted.');
+  }
+  sections.push(inputs.join('\n'));
+
+  // --- Computed results ---
+  const results: string[] = ['## Computed results', ''];
+  const eligibility = eligibilityLine(recipient);
+  if (eligibility) results.push(eligibility);
+  results.push(
+    `- Primary Insurance Amount (PIA): ${pia.primaryInsuranceAmount().wholeDollars()} / month`,
+    `- Full Retirement Age (FRA): ${fra.toFullAgeString()} (reached ${fraDate.monthName()} ${fraDate.year()})`
+  );
+  if (!recipient.isPiaOnly) {
+    results.push(
+      `- Average Indexed Monthly Earnings (AIME): ${recipient
+        .monthlyIndexedEarnings()
+        .wholeDollars()} / month`
+    );
+  }
+  results.push(
+    '',
+    'Estimated monthly benefit by filing age:',
+    '',
+    '| Filing age | Monthly benefit |',
+    '| --- | --- |'
+  );
+  const benefitRows: Array<[string, MonthDuration]> = [
+    ['62', ageOf(62)],
+    [`FRA (${fra.toFullAgeString()})`, fra],
+    ['70', ageOf(70)],
+  ];
+  for (const [label, filingAge] of benefitRows) {
+    results.push(
+      `| ${label} | ${benefitAtAge(recipient, filingAge).wholeDollars()} |`
+    );
+  }
+  sections.push(results.join('\n'));
+
+  // --- Methodology footnotes (the most important section for an AI: it pins
+  //     which SSA constants produced these numbers, preventing the assistant
+  //     from inventing different ones). ---
+  const methodology: string[] = [
+    '## Methodology',
+    '',
+    `- PIA uses the SSA bend-point formula wage-indexed to the eligibility year (${recipient.indexingYear()}): first bend point ${pia
+      .firstBendPoint()
+      .wholeDollars()}, second bend point ${pia.secondBendPoint().wholeDollars()}.`,
+    `- Cost-of-living adjustments (COLA) are applied through ${MAX_COLA_YEAR} (the latest published COLA).`,
+    `- Average-wage indexing uses national wage data through ${MAX_WAGE_INDEX_YEAR}.`,
+    "- Figures are estimates in today's dollars and exclude spousal and survivor benefits, taxation, and Medicare premiums.",
+  ];
+  sections.push(methodology.join('\n'));
+
+  // --- Deep link ---
+  sections.push(
+    [
+      '## Recompute or adjust on ssa.tools',
+      '',
+      'Open this link to reload these inputs and explore filing ages, spousal, and survivor scenarios:',
+      '',
+      deepLink(recipient, baseUrl),
+    ].join('\n')
+  );
+
+  // --- Caveats ---
+  sections.push(
+    [
+      '## Caveats',
+      '',
+      '- ssa.tools runs entirely in your browser; none of your data is sent to a server. This summary exists only because you chose to copy it.',
+      '- This is an educational estimate, not financial or legal advice.',
+      '- An AI assistant can misinterpret Social Security rules; treat its answers as a starting point and verify against ssa.gov.',
+    ].join('\n')
+  );
+
+  // --- Suggested follow-ups ---
+  sections.push(
+    [
+      '## Suggested follow-up questions',
+      '',
+      '- How do spousal benefits change the best filing age?',
+      '- What survivor benefit would my spouse receive?',
+      '- How are these benefits taxed at the federal and state level?',
+      '- How does Medicare enrollment timing interact with my filing date?',
+    ].join('\n')
+  );
+
+  return `${sections.join('\n\n')}\n`;
+}

--- a/src/lib/ai-export.ts
+++ b/src/lib/ai-export.ts
@@ -185,16 +185,26 @@ export function buildCalculatorAiExport(
   // --- Methodology footnotes (the most important section for an AI: it pins
   //     which SSA constants produced these numbers, preventing the assistant
   //     from inventing different ones). ---
-  const methodology: string[] = [
-    '## Methodology',
-    '',
-    `- PIA uses the SSA bend-point formula wage-indexed to the eligibility year (${recipient.indexingYear()}): first bend point ${pia
-      .firstBendPoint()
-      .wholeDollars()}, second bend point ${pia.secondBendPoint().wholeDollars()}.`,
-    `- Cost-of-living adjustments (COLA) are applied through ${MAX_COLA_YEAR} (the latest published COLA).`,
-    `- Average-wage indexing uses national wage data through ${MAX_WAGE_INDEX_YEAR}.`,
-    "- Figures are estimates in today's dollars and exclude spousal and survivor benefits, taxation, and Medicare premiums.",
-  ];
+  const methodology: string[] = ['## Methodology', ''];
+  if (recipient.isPiaOnly) {
+    // The PIA was typed in directly, so the bend-point/COLA/wage-indexing
+    // derivation does not apply; only the filing-age adjustments do.
+    methodology.push(
+      "- The Primary Insurance Amount was entered directly (in today's dollars), not derived from an earnings record, so bend points, wage indexing, and COLA assumptions do not apply."
+    );
+  } else {
+    methodology.push(
+      `- PIA uses the SSA bend-point formula wage-indexed to the eligibility year (${recipient.indexingYear()}): first bend point ${pia
+        .firstBendPoint()
+        .wholeDollars()}, second bend point ${pia.secondBendPoint().wholeDollars()}.`,
+      `- Cost-of-living adjustments (COLA) are applied through ${MAX_COLA_YEAR} (the latest published COLA).`,
+      `- Average-wage indexing uses national wage data through ${MAX_WAGE_INDEX_YEAR}.`
+    );
+  }
+  methodology.push(
+    '- Monthly benefit by filing age applies the standard early-filing reduction and delayed retirement credits to the PIA.',
+    "- Figures are estimates in today's dollars and exclude spousal and survivor benefits, taxation, and Medicare premiums."
+  );
   sections.push(methodology.join('\n'));
 
   // --- Deep link ---

--- a/src/lib/ai-export.ts
+++ b/src/lib/ai-export.ts
@@ -1,39 +1,96 @@
-import { benefitAtAge } from '$lib/benefit-calculator';
+import {
+  benefitAtAge,
+  eligibleForSpousalBenefit,
+  spousalBenefitOnDate,
+  survivorBenefit,
+} from '$lib/benefit-calculator';
 import type { Birthdate } from '$lib/birthday';
-import { MAX_COLA_YEAR, MAX_WAGE_INDEX_YEAR } from '$lib/constants';
+import {
+  AFTER_BENDPOINT2_MULTIPLIER,
+  BEFORE_BENDPOINT1_MULTIPLIER,
+  BEFORE_BENDPOINT2_MULTIPLIER,
+  MAX_COLA_YEAR,
+  MAX_WAGE_INDEX_YEAR,
+} from '$lib/constants';
 import { MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
-import { buildStrategyHash } from '$lib/url-params';
+import { buildStrategyHash, type Gender } from '$lib/url-params';
 
 /**
- * Options for {@link buildCalculatorAiExport}.
+ * Options for the AI-export builders.
  */
 export interface CalculatorAiExportOptions {
-  /**
-   * Include the year-by-year taxed-earnings table. Defaults to true. Ignored
-   * for PIA-only recipients (which have no earnings history).
-   */
-  includeEarnings?: boolean;
   /**
    * Base URL for the deep link back to the calculator. Defaults to the
    * production URL. Override for tests or alternate deployments.
    */
   baseUrl?: string;
   /**
-   * A "generated on" date string (e.g. "2026-06-19") stamped into the header.
-   * Injected by the caller so the builder stays pure and deterministic rather
-   * than reading the system clock. Omitted means no generated-on line.
+   * A "generated on" date string (e.g. "2026-06-18") stamped into the header.
+   * Injected by the caller so the builder stays deterministic rather than
+   * reading the system clock. Omitted means no generated-on line.
+   *
+   * The caller is responsible for formatting a local-time date — do not derive
+   * this from `new Date().toISOString()`, whose UTC value can be a day off.
    */
   generatedDate?: string;
 }
 
 const DEFAULT_BASE_URL = 'https://ssa.tools/calculator';
 
+// ---------------------------------------------------------------------------
+// Text helpers
+// ---------------------------------------------------------------------------
+
+type Align = 'left' | 'right' | 'center';
+
 /**
- * Formats a birthdate as an ISO `YYYY-MM-DD` string for the `dob1` URL
- * parameter (the format {@link buildStrategyHash} and the calculator's URL
- * hydration expect).
+ * Renders an aligned GitHub-flavored markdown table. Cells are padded to a
+ * fixed column width so the table also lines up when read as plain monospace
+ * text (e.g. before an AI renders the markdown).
  */
+function renderTable(
+  headers: string[],
+  rows: string[][],
+  aligns: Align[]
+): string {
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => row[i].length))
+  );
+
+  const padCell = (text: string, width: number, align: Align): string => {
+    if (align === 'right') return text.padStart(width);
+    if (align === 'center') {
+      const total = width - text.length;
+      const left = Math.floor(total / 2);
+      return ' '.repeat(left) + text + ' '.repeat(total - left);
+    }
+    return text.padEnd(width);
+  };
+
+  const sepCell = (width: number, align: Align): string => {
+    if (align === 'right') return `${'-'.repeat(width - 1)}:`;
+    if (align === 'center') return `:${'-'.repeat(width - 2)}:`;
+    return '-'.repeat(width);
+  };
+
+  const line = (cells: string[]): string => `| ${cells.join(' | ')} |`;
+
+  return [
+    line(headers.map((h, i) => padCell(h, widths[i], aligns[i]))),
+    line(widths.map((w, i) => sepCell(w, aligns[i]))),
+    ...rows.map((row) =>
+      line(row.map((cell, i) => padCell(cell, widths[i], aligns[i])))
+    ),
+  ].join('\n');
+}
+
+/** Formats a fraction (e.g. 0.32) as a percent string (e.g. "32%"). */
+function asPercent(fraction: number): string {
+  return `${+(fraction * 100).toFixed(2)}%`;
+}
+
+/** Formats a birthdate as an ISO `YYYY-MM-DD` string for the `dob` URL param. */
 function isoBirthdate(birthdate: Birthdate): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   // layBirthMonth() is 0-indexed (January = 0); the dob parameter is 1-indexed.
@@ -42,204 +99,598 @@ function isoBirthdate(birthdate: Birthdate): string {
   return `${birthdate.layBirthYear()}-${month}-${day}`;
 }
 
+function piaParam(recipient: Recipient): number {
+  return Math.round(recipient.pia().primaryInsuranceAmount().value());
+}
+
+function nameParam(name: string, defaultName: string): string | undefined {
+  return name && name !== defaultName ? name : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Per-recipient sections (reused by the single and couple exports)
+// ---------------------------------------------------------------------------
+
+/** Eligibility: 40 work credits, with a year-by-year breakdown until reached. */
+function eligibilitySection(recipient: Recipient): string {
+  const lines = [
+    '## Eligibility',
+    '',
+    'Retirement benefits require 40 Social Security credits (up to 4 per year).',
+  ];
+
+  const earned = recipient.earnedCredits();
+  if (earned >= 40) {
+    lines.push('Status: 40 of 40 credits earned — eligible.');
+  } else if (recipient.totalCredits() >= 40) {
+    lines.push(
+      `Status: ${earned} of 40 credits earned so far — projected to reach 40 with future earnings.`
+    );
+  } else {
+    lines.push(
+      `Status: ${earned} of 40 credits earned — NOT yet eligible. Benefit estimates remain $0 until 40 credits are earned.`
+    );
+  }
+
+  // Year-by-year credits, stopping once 40 are reached (the rest do not matter
+  // for eligibility).
+  const rows: string[][] = [];
+  let cumulative = 0;
+  for (const record of recipient.earningsRecords) {
+    if (cumulative >= 40) break;
+    cumulative = Math.min(40, cumulative + record.credits());
+    rows.push([
+      String(record.year),
+      record.taxedEarnings.wholeDollars(),
+      String(record.credits()),
+      String(cumulative),
+    ]);
+  }
+  if (rows.length > 0) {
+    lines.push(
+      '',
+      renderTable(['Year', 'Taxed earnings', 'Credits', 'Cumulative'], rows, [
+        'left',
+        'right',
+        'right',
+        'right',
+      ])
+    );
+  }
+
+  return lines.join('\n');
+}
+
+/** AIME: the indexed-earnings table (top 35) and the averaging formula. */
+function aimeSection(recipient: Recipient): string {
+  const lines = [
+    '## Average Indexed Monthly Earnings (AIME)',
+    '',
+    'The AIME is the monthly average of the highest 35 years of earnings, each',
+    'adjusted for national wage growth, then averaged over 420 months.',
+    '',
+    'For each year:',
+    '',
+    '    indexed earnings = capped taxed earnings × index factor',
+    '',
+    '    index factor = (average wage index for the year you turn 60)',
+    '                   ÷ (average wage index for the earning year)',
+    '',
+    'The index factor is 1.0 for the year you turn 60 and every year after, so',
+    'later earnings are counted at face value. "Capped" means earnings above the',
+    "Social Security taxable maximum for that year don't count.",
+    '',
+  ];
+
+  const rows = recipient.earningsRecords.map((record) => [
+    String(record.year),
+    record.taxedEarnings.wholeDollars(),
+    record.indexFactor().toFixed(4),
+    record.indexedEarnings().wholeDollars(),
+    record.isTop35EarningsYear ? 'yes' : 'no',
+  ]);
+  lines.push(
+    renderTable(
+      ['Year', 'Taxed earnings', 'Index factor', 'Indexed earnings', 'Top 35'],
+      rows,
+      ['left', 'right', 'right', 'right', 'center']
+    )
+  );
+
+  const total = recipient.totalIndexedEarnings();
+  const aime = recipient.monthlyIndexedEarnings();
+  lines.push(
+    '',
+    `AIME = (sum of the top 35 indexed earnings) / 35 years / 12 months`,
+    `     = ${total.wholeDollars()} / 420`,
+    `     = ${aime.wholeDollars()} / month`
+  );
+
+  return lines.join('\n');
+}
+
+/** PIA: the worked bend-point formula applied to the AIME. */
+function piaSection(recipient: Recipient): string {
+  const pia = recipient.pia();
+  const aime = recipient.monthlyIndexedEarnings();
+  const bend1 = pia.firstBendPoint();
+  const bend2 = pia.secondBendPoint();
+
+  const rows = [
+    [
+      `${asPercent(BEFORE_BENDPOINT1_MULTIPLIER)} of AIME up to ${bend1.wholeDollars()}`,
+      pia.primaryInsuranceAmountByBracket(0).string(),
+    ],
+    [
+      `${asPercent(BEFORE_BENDPOINT2_MULTIPLIER)} of AIME between ${bend1.wholeDollars()} and ${bend2.wholeDollars()}`,
+      pia.primaryInsuranceAmountByBracket(1).string(),
+    ],
+    [
+      `${asPercent(AFTER_BENDPOINT2_MULTIPLIER)} of AIME above ${bend2.wholeDollars()}`,
+      pia.primaryInsuranceAmountByBracket(2).string(),
+    ],
+    [
+      'Total (rounded down to the dime)',
+      pia.primaryInsuranceAmountUnadjusted().string(),
+    ],
+  ];
+
+  return [
+    '## Primary Insurance Amount (PIA)',
+    '',
+    `The PIA applies the SSA bend-point formula to the AIME (${aime.wholeDollars()}).`,
+    `Bend points for the eligibility year (${recipient.indexingYear()}) are ${bend1.wholeDollars()} and ${bend2.wholeDollars()}.`,
+    '',
+    renderTable(['Bracket', 'Amount'], rows, ['left', 'right']),
+    '',
+    `After cost-of-living adjustments (COLA) applied through ${MAX_COLA_YEAR}, the`,
+    `final PIA is ${pia.primaryInsuranceAmount().wholeDollars()} / month.`,
+    '',
+    'Note: the PIA is rounded down to the dime; monthly benefits are rounded',
+    'down to the dollar. Wage indexing uses data through ' +
+      `${MAX_WAGE_INDEX_YEAR}.`,
+  ].join('\n');
+}
+
+/** Explains the early-filing reduction and delayed retirement credits. */
+function filingRulesSection(recipient: Recipient): string {
+  const fra = recipient.normalRetirementAge();
+  const fraDate = recipient.normalRetirementDate();
+  const dri = recipient.delayedRetirementIncrease();
+
+  return [
+    '## Filing age adjustments',
+    '',
+    `Full Retirement Age (FRA): ${fra.toFullAgeString()} (reached ${fraDate.monthName()} ${fraDate.year()}).`,
+    'Your monthly benefit is your PIA adjusted for when you file relative to FRA:',
+    '',
+    '- Filing before FRA reduces the benefit: 5/9 of 1% per month (about',
+    '  0.556%/mo, 6.67%/yr) for the first 36 months early, then 5/12 of 1% per',
+    '  month (about 0.417%/mo, 5%/yr) for each earlier month beyond 36.',
+    `- Filing after FRA adds delayed retirement credits of ${asPercent(dri)} per year`,
+    '  (2/3 of 1% per month), up to age 70.',
+    '- Delayed retirement credits do not take effect until January of the',
+    '  following year — except at age 70, which receives them immediately. So',
+    '  someone who files mid-year may see their benefit step up the next January.',
+  ].join('\n');
+}
+
+/** Month-by-month benefit for every filing age from the earliest through 70. */
+function benefitByMonthSection(recipient: Recipient): string {
+  const start = recipient.birthdate.earliestFilingMonth().asMonths();
+  const end = 70 * 12;
+
+  const rows: string[][] = [];
+  for (let m = start; m <= end; m++) {
+    const age = new MonthDuration(m);
+    rows.push([
+      `${age.years()}y ${age.modMonths()}m`,
+      benefitAtAge(recipient, age).wholeDollars(),
+    ]);
+  }
+
+  return [
+    '## Monthly benefit by filing age',
+    '',
+    "Estimated monthly benefit (today's dollars) if you start benefits at each",
+    'age. This is the eventual steady-state amount; see the January rule above',
+    'for the first-year timing of delayed credits.',
+    '',
+    renderTable(['Filing age', 'Monthly benefit'], rows, ['left', 'right']),
+  ].join('\n');
+}
+
 /**
- * Builds the deep link back to the calculator that reloads this recipient's
- * inputs. The link is PIA-based (the same approach as the strategy share link):
- * it carries the current-dollar PIA, so reopening it reconstructs the headline
- * numbers even though the raw earnings history is not encoded in the URL.
+ * Returns the ordered markdown sections describing one recipient. PIA-only
+ * recipients skip the earnings-derived sections (eligibility, AIME, PIA
+ * formula), since their PIA was entered directly.
  */
-function deepLink(recipient: Recipient, baseUrl: string): string {
-  const pia = Math.round(recipient.pia().primaryInsuranceAmount().value());
+function recipientSections(recipient: Recipient): string[] {
+  const pia = recipient.pia();
+  const sections: string[] = [];
+
+  if (recipient.isPiaOnly) {
+    sections.push(
+      [
+        '## Primary Insurance Amount (PIA)',
+        '',
+        `The PIA was entered directly: ${pia.primaryInsuranceAmount().wholeDollars()} / month`,
+        "(in today's dollars). It was not derived from an earnings record, so",
+        'bend points, wage indexing, and COLA assumptions do not apply.',
+      ].join('\n')
+    );
+  } else {
+    sections.push(
+      eligibilitySection(recipient),
+      aimeSection(recipient),
+      piaSection(recipient)
+    );
+  }
+  sections.push(
+    filingRulesSection(recipient),
+    benefitByMonthSection(recipient)
+  );
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// Document assembly
+// ---------------------------------------------------------------------------
+
+function header(title: string, generatedDate?: string): string {
+  const lines = [title, ''];
+  lines.push(
+    generatedDate
+      ? `_Generated ${generatedDate}. All amounts in today's dollars unless noted._`
+      : "_All amounts in today's dollars unless noted._"
+  );
+  return lines.join('\n');
+}
+
+function recipientDeepLink(recipient: Recipient, baseUrl: string): string {
   const hash = buildStrategyHash({
     isSingle: true,
-    pia1: pia,
+    pia1: piaParam(recipient),
     dob1: isoBirthdate(recipient.birthdate),
-    name1:
-      recipient.name && recipient.name !== 'Self' ? recipient.name : undefined,
-    gender1: recipient.gender,
+    name1: nameParam(recipient.name, 'Self'),
+    gender1: recipient.gender as Gender,
   });
   return `${baseUrl}${hash}`;
 }
 
-function ageOf(years: number): MonthDuration {
-  return MonthDuration.initFromYearsMonths({ years, months: 0 });
+function deepLinkSection(url: string): string {
+  return [
+    '## Recompute or adjust on ssa.tools',
+    '',
+    'Open this link to reload these inputs and explore other filing ages:',
+    '',
+    url,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Embeddable interactive charts (the /embed/* routes added in PR #557)
+// ---------------------------------------------------------------------------
+
+const EMBED_BASE = 'https://ssa.tools/embed';
+
+/** Encodes a recipient's earnings history as the `earnings1` URL parameter. */
+function earningsParam(recipient: Recipient): string {
+  return recipient.earningsRecords
+    .map((r) => `${r.year}:${Math.round(r.taxedEarnings.value())}`)
+    .join(',');
+}
+
+/** A markdown link plus a ready-to-paste iframe snippet for one embed widget. */
+function embedEntry(label: string, hash: string, route: string): string[] {
+  const url = `${EMBED_BASE}/${route}${hash}`;
+  return [
+    `### ${label}`,
+    '',
+    url,
+    '',
+    '```html',
+    `<iframe src="${url}" width="100%" height="480" style="border:0" loading="lazy"></iframe>`,
+    '```',
+  ];
 }
 
 /**
- * Describes the recipient's eligibility (40 work credits) so an AI assistant
- * understands a $0 PIA as "not yet eligible" rather than a calculation error.
- * Returns null for PIA-only recipients, who have no earnings/credit history.
+ * The `&name1=...` URL segment for an embed, or '' for the default placeholder
+ * names. The embed routes display this name (e.g. on the filing-age chart).
  */
-function eligibilityLine(recipient: Recipient): string | null {
-  if (recipient.isPiaOnly) return null;
-  const earned = recipient.earnedCredits();
-  if (earned >= 40) {
-    return '- Eligibility: 40 of 40 credits earned (eligible for retirement benefits).';
+function embedNameParam(name: string): string {
+  return name && name !== 'Self' && name !== 'Spouse'
+    ? `&name1=${encodeURIComponent(name)}`
+    : '';
+}
+
+/** Per-recipient embeds: filing-age (PIA based), plus earnings-based charts. */
+function recipientEmbeds(recipient: Recipient, prefix = ''): string[] {
+  const pia = piaParam(recipient);
+  const dob = isoBirthdate(recipient.birthdate);
+  const name = embedNameParam(recipient.name);
+  const piaHash = `#pia1=${pia}&dob1=${dob}${name}`;
+  const entries: string[][] = [
+    embedEntry(`${prefix}Filing-age benefit chart`, piaHash, 'filing-age'),
+  ];
+  // indexed-earnings and bend-points require the full earnings history.
+  if (!recipient.isPiaOnly && recipient.earningsRecords.length > 0) {
+    const earnHash = `#earnings1=${earningsParam(recipient)}&dob1=${dob}${name}`;
+    entries.push(
+      embedEntry(`${prefix}Indexed earnings`, earnHash, 'indexed-earnings'),
+      embedEntry(`${prefix}Bend points`, earnHash, 'bend-points')
+    );
   }
-  if (recipient.totalCredits() >= 40) {
-    return `- Eligibility: ${earned} of 40 credits earned so far; projected to reach 40 and become eligible with future earnings.`;
-  }
-  return `- Eligibility: ${earned} of 40 credits earned — not yet eligible for retirement benefits, so the PIA and benefit estimates below remain $0 until 40 credits are earned.`;
+  return entries.flatMap((e) => ['', ...e]);
+}
+
+function embedsSection(body: string[]): string {
+  return [
+    '## Interactive charts (embeddable)',
+    '',
+    'These ssa.tools widgets render this data interactively and can be embedded',
+    'in a web page with the iframe snippet shown (adjust width/height to taste):',
+    ...body,
+  ].join('\n');
 }
 
 /**
- * Builds a self-contained markdown snippet summarizing a calculator recipient's
- * Social Security situation, intended to be pasted into an AI assistant such as
- * Claude or ChatGPT. See issue #553.
+ * Builds a self-contained markdown snippet summarizing one calculator
+ * recipient's full Social Security derivation (eligibility, AIME, PIA,
+ * filing-age rules, and a month-by-month benefit table), intended to be pasted
+ * into an AI assistant. See issue #553.
  *
- * The function performs no I/O and transmits nothing; the caller copies the
- * returned string to the clipboard only when the user asks. The only formatted
- * "as of today" value (the generated-on header line) comes from
- * {@link CalculatorAiExportOptions.generatedDate} rather than the system clock,
- * so the snippet is stable to copy. (Benefit and PIA amounts still depend on
- * `constants.CURRENT_YEAR` via the default COLA cutoff, which is resolved once
- * at module load — the same values the calculator itself displays.)
+ * The builder reads no clock; the only "as of today" value is the optional,
+ * injected `generatedDate`. Benefit and PIA amounts match what the calculator
+ * displays (they depend on `constants.CURRENT_YEAR` via the default COLA
+ * cutoff, resolved once at module load).
  */
 export function buildCalculatorAiExport(
   recipient: Recipient,
   options: CalculatorAiExportOptions = {}
 ): string {
-  const includeEarnings = options.includeEarnings ?? true;
   const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
 
-  const pia = recipient.pia();
-  const fra = recipient.normalRetirementAge();
-  const fraDate = recipient.normalRetirementDate();
-
-  const sections: string[] = [];
-
-  // --- Header ---
-  const generated = options.generatedDate
-    ? `_Generated ${options.generatedDate}. All amounts in today's dollars._`
-    : "_All amounts in today's dollars._";
-  sections.push(
-    ['# Social Security benefit summary (from ssa.tools)', '', generated].join(
-      '\n'
-    )
-  );
-
-  // --- Inputs ---
-  const inputs: string[] = [
-    '## Inputs',
-    '',
-    `- Birthdate: ${recipient.birthdate.layBirthdateString()}`,
+  const sections: string[] = [
+    header(
+      '# Social Security benefit summary (from ssa.tools)',
+      options.generatedDate
+    ),
+    [
+      '## Inputs',
+      '',
+      `- Birthdate: ${recipient.birthdate.layBirthdateString()}`,
+    ].join('\n'),
+    ...recipientSections(recipient),
+    embedsSection(recipientEmbeds(recipient)),
+    deepLinkSection(recipientDeepLink(recipient, baseUrl)),
   ];
-  if (recipient.isPiaOnly) {
-    inputs.push(
-      `- Primary Insurance Amount (PIA) entered directly: ${pia
-        .primaryInsuranceAmount()
-        .wholeDollars()} (no earnings history provided)`
-    );
-  } else if (includeEarnings && recipient.earningsRecords.length > 0) {
-    inputs.push(
-      '',
-      '### Taxed earnings history',
-      '',
-      '| Year | Taxed earnings |',
-      '| --- | --- |'
-    );
-    for (const record of recipient.earningsRecords) {
-      inputs.push(
-        `| ${record.year} | ${record.taxedEarnings.wholeDollars()} |`
-      );
-    }
-  } else {
-    inputs.push('- Earnings history omitted.');
-  }
-  sections.push(inputs.join('\n'));
-
-  // --- Computed results ---
-  const results: string[] = ['## Computed results', ''];
-  const eligibility = eligibilityLine(recipient);
-  if (eligibility) results.push(eligibility);
-  results.push(
-    `- Primary Insurance Amount (PIA): ${pia.primaryInsuranceAmount().wholeDollars()} / month`,
-    `- Full Retirement Age (FRA): ${fra.toFullAgeString()} (reached ${fraDate.monthName()} ${fraDate.year()})`
-  );
-  if (!recipient.isPiaOnly) {
-    results.push(
-      `- Average Indexed Monthly Earnings (AIME): ${recipient
-        .monthlyIndexedEarnings()
-        .wholeDollars()} / month`
-    );
-  }
-  results.push(
-    '',
-    'Estimated monthly benefit by filing age:',
-    '',
-    '| Filing age | Monthly benefit |',
-    '| --- | --- |'
-  );
-  const benefitRows: Array<[string, MonthDuration]> = [
-    ['62', ageOf(62)],
-    [`FRA (${fra.toFullAgeString()})`, fra],
-    ['70', ageOf(70)],
-  ];
-  for (const [label, filingAge] of benefitRows) {
-    results.push(
-      `| ${label} | ${benefitAtAge(recipient, filingAge).wholeDollars()} |`
-    );
-  }
-  sections.push(results.join('\n'));
-
-  // --- Methodology footnotes (the most important section for an AI: it pins
-  //     which SSA constants produced these numbers, preventing the assistant
-  //     from inventing different ones). ---
-  const methodology: string[] = ['## Methodology', ''];
-  if (recipient.isPiaOnly) {
-    // The PIA was typed in directly, so the bend-point/COLA/wage-indexing
-    // derivation does not apply; only the filing-age adjustments do.
-    methodology.push(
-      "- The Primary Insurance Amount was entered directly (in today's dollars), not derived from an earnings record, so bend points, wage indexing, and COLA assumptions do not apply."
-    );
-  } else {
-    methodology.push(
-      `- PIA uses the SSA bend-point formula wage-indexed to the eligibility year (${recipient.indexingYear()}): first bend point ${pia
-        .firstBendPoint()
-        .wholeDollars()}, second bend point ${pia.secondBendPoint().wholeDollars()}.`,
-      `- Cost-of-living adjustments (COLA) are applied through ${MAX_COLA_YEAR} (the latest published COLA).`,
-      `- Average-wage indexing uses national wage data through ${MAX_WAGE_INDEX_YEAR}.`
-    );
-  }
-  methodology.push(
-    '- Monthly benefit by filing age applies the standard early-filing reduction and delayed retirement credits to the PIA.',
-    "- Figures are estimates in today's dollars and exclude spousal and survivor benefits, taxation, and Medicare premiums."
-  );
-  sections.push(methodology.join('\n'));
-
-  // --- Deep link ---
-  sections.push(
-    [
-      '## Recompute or adjust on ssa.tools',
-      '',
-      'Open this link to reload these inputs and explore filing ages, spousal, and survivor scenarios:',
-      '',
-      deepLink(recipient, baseUrl),
-    ].join('\n')
-  );
-
-  // --- Caveats ---
-  sections.push(
-    [
-      '## Caveats',
-      '',
-      '- ssa.tools runs entirely in your browser; none of your data is sent to a server. This summary exists only because you chose to copy it.',
-      '- This is an educational estimate, not financial or legal advice.',
-      '- An AI assistant can misinterpret Social Security rules; treat its answers as a starting point and verify against ssa.gov.',
-    ].join('\n')
-  );
-
-  // --- Suggested follow-ups ---
-  sections.push(
-    [
-      '## Suggested follow-up questions',
-      '',
-      '- How do spousal benefits change the best filing age?',
-      '- What survivor benefit would my spouse receive?',
-      '- How are these benefits taxed at the federal and state level?',
-      '- How does Medicare enrollment timing interact with my filing date?',
-    ].join('\n')
-  );
 
   return `${sections.join('\n\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Couple export
+// ---------------------------------------------------------------------------
+
+function coupleDeepLink(
+  recipient: Recipient,
+  spouse: Recipient,
+  baseUrl: string
+): string {
+  const hash = buildStrategyHash({
+    isSingle: false,
+    pia1: piaParam(recipient),
+    dob1: isoBirthdate(recipient.birthdate),
+    name1: nameParam(recipient.name, 'Self'),
+    gender1: recipient.gender as Gender,
+    pia2: piaParam(spouse),
+    dob2: isoBirthdate(spouse.birthdate),
+    name2: nameParam(spouse.name, 'Spouse'),
+    gender2: spouse.gender as Gender,
+  });
+  return `${baseUrl}${hash}`;
+}
+
+function displayName(recipient: Recipient, fallback: string): string {
+  return recipient.name && recipient.name !== fallback
+    ? recipient.name
+    : fallback;
+}
+
+/**
+ * Spousal top-up by the lower earner's claiming age, isolating the early-filing
+ * reduction. The higher earner is assumed to have already filed (otherwise no
+ * spousal benefit is payable yet), so the only variable is the lower earner's
+ * own claiming age.
+ */
+function spousalClaimingTable(higher: Recipient, lower: Recipient): string {
+  const fraMonths = lower.normalRetirementAge().asMonths();
+  const earliest = lower.birthdate.earliestFilingMonth().asMonths();
+  const candidates = [earliest, 64 * 12, 66 * 12, fraMonths];
+  const ageMonths = [...new Set(candidates)]
+    .filter((m) => m >= earliest && m <= fraMonths)
+    .sort((a, b) => a - b);
+
+  const rows = ageMonths.map((m) => {
+    const age = new MonthDuration(m);
+    const filing = lower.birthdate.dateAtSsaAge(age);
+    // spouseFilingDate = filing treats the higher earner as already filed by
+    // the time the lower earner claims, so the amount reflects only the lower
+    // earner's reduction.
+    const benefit = spousalBenefitOnDate(lower, higher, filing, filing, filing);
+    return [`${age.years()}y ${age.modMonths()}m`, benefit.wholeDollars()];
+  });
+  return renderTable(
+    ['Lower earner files at', 'Spousal top-up / month'],
+    rows,
+    ['left', 'right']
+  );
+}
+
+/**
+ * Spousal benefits: eligibility, the 50%-of-higher-PIA formula, the early-filing
+ * reduction, and a claiming-age table. The lower earner is the one who can
+ * receive a spousal top-up.
+ */
+function spousalSection(higher: Recipient, lower: Recipient): string {
+  const higherName = displayName(higher, 'the higher earner');
+  const lowerName = displayName(lower, 'the lower earner');
+  const higherPia = higher.pia().primaryInsuranceAmount();
+  const lowerPia = lower.pia().primaryInsuranceAmount();
+
+  const lines = ['## Spousal benefits', ''];
+  if (!eligibleForSpousalBenefit(lower, higher)) {
+    lines.push(
+      `Neither partner qualifies for a spousal top-up: half of ${higherName}'s`,
+      `PIA (${higherPia.times(0.5).wholeDollars()}) does not exceed ${lowerName}'s own PIA`,
+      `(${lowerPia.wholeDollars()}). The lower earner simply takes their own benefit.`
+    );
+    return lines.join('\n');
+  }
+
+  lines.push(
+    `${lowerName} can receive a spousal top-up on top of their own benefit.`,
+    '',
+    'How it works:',
+    '',
+    `- At full retirement age the spousal benefit equals 50% of ${higherName}'s`,
+    `  PIA (${higherPia.wholeDollars()}) minus ${lowerName}'s own PIA (${lowerPia.wholeDollars()}):`,
+    `  ${higherPia.times(0.5).wholeDollars()} - ${lowerPia.wholeDollars()} = ${higherPia.times(0.5).sub(lowerPia).wholeDollars()} / month.`,
+    `- It is based on ${higherName}'s PIA, not their actual (delayed or reduced)`,
+    `  benefit, and ${higherName} must have filed before ${lowerName} can collect it.`,
+    '- Claiming before FRA reduces the spousal benefit by 25/36 of 1% per month',
+    '  for the first 36 months, then 5/12 of 1% per month earlier than that.',
+    '- Unlike a retirement benefit, a spousal benefit earns NO delayed retirement',
+    '  credits — it is largest at full retirement age and does not grow past it.',
+    '',
+    spousalClaimingTable(higher, lower)
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Survivor benefits: the up-to-100% rule, the widow(er)'s-limit (82.5%) floor,
+ * the separate survivor FRA, the 71.5%-at-60 reduction, switching strategies,
+ * and an illustrative computed amount.
+ */
+function survivorSection(higher: Recipient, lower: Recipient): string {
+  const higherName = displayName(higher, 'the higher earner');
+  const lowerName = displayName(lower, 'the survivor');
+  const higherPia = higher.pia().primaryInsuranceAmount();
+  const survivorFra = lower.survivorNormalRetirementAge();
+
+  // Illustrative: higher earner files at FRA and dies at 80; survivor claims at
+  // or after their survivor FRA (so unreduced).
+  const deceasedFiling = higher.normalRetirementDate();
+  const deathDate = higher.birthdate.dateAtSsaAge(
+    MonthDuration.initFromYearsMonths({ years: 80, months: 0 })
+  );
+  const claimEarliest = deathDate.addDuration(new MonthDuration(1));
+  const survivorFraDate = lower.survivorNormalRetirementDate();
+  const survivorFiling =
+    survivorFraDate.monthsSinceEpoch() >= claimEarliest.monthsSinceEpoch()
+      ? survivorFraDate
+      : claimEarliest;
+  const illustrative = survivorBenefit(
+    lower,
+    higher,
+    deceasedFiling,
+    deathDate,
+    survivorFiling
+  );
+
+  return [
+    '## Survivor benefits',
+    '',
+    `If ${higherName} dies first, ${lowerName} can claim a survivor benefit, which`,
+    'replaces (does not add to) their own retirement benefit. Key rules:',
+    '',
+    `- The survivor benefit can be as high as 100% of what ${higherName} was`,
+    `  actually receiving, INCLUDING any delayed retirement credits ${higherName}`,
+    `  earned by waiting past FRA. So delaying the higher earner's own filing also`,
+    '  raises the survivor benefit — often the most valuable reason to delay.',
+    `- If ${higherName} had instead claimed early, the survivor benefit is the`,
+    `  larger of that reduced benefit or 82.5% of ${higherName}'s PIA (the`,
+    `  "widow(er)'s limit"). For ${higherName}, 82.5% of PIA = ${higherPia.times(0.825).wholeDollars()}.`,
+    `- Survivor benefits use a separate survivor full retirement age`,
+    `  (${lowerName}'s is ${survivorFra.toFullAgeString()}), which can be earlier than the`,
+    '  retirement FRA. Claiming before it reduces the benefit proportionally, down',
+    '  to 71.5% at age 60; there are no delayed credits past survivor FRA.',
+    `- ${lowerName} can take one benefit first and switch later — e.g. claim the`,
+    '  survivor benefit while letting their own retirement benefit grow to age 70,',
+    '  then switch (or vice versa). The ssa.tools strategy tool models this.',
+    '',
+    `Illustrative: ${higherName} files at FRA and dies at 80, ${lowerName} claims at`,
+    `or after survivor FRA -> ${illustrative.wholeDollars()} / month (about 100% of`,
+    `${higherName}'s benefit).`,
+  ].join('\n');
+}
+
+/**
+ * Builds a couple's combined markdown export: each partner's full derivation
+ * followed by the spousal and survivor interactions. See issue #553.
+ */
+export function buildCoupleCalculatorAiExport(
+  recipient: Recipient,
+  spouse: Recipient,
+  options: CalculatorAiExportOptions = {}
+): string {
+  const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+
+  // Order higher/lower earner by PIA for the spousal/survivor framing.
+  const recipientPia = recipient.pia().primaryInsuranceAmount().value();
+  const spousePia = spouse.pia().primaryInsuranceAmount().value();
+  const [higher, lower] =
+    recipientPia >= spousePia ? [recipient, spouse] : [spouse, recipient];
+
+  const personSection = (person: Recipient, fallback: string): string => {
+    const name = displayName(person, fallback);
+    return [
+      `# ${name}`,
+      `- Birthdate: ${person.birthdate.layBirthdateString()}`,
+      '',
+      recipientSections(person).join('\n\n'),
+    ].join('\n');
+  };
+
+  const sections: string[] = [
+    header(
+      '# Social Security benefit summary for a couple (from ssa.tools)',
+      options.generatedDate
+    ),
+    personSection(recipient, 'Person 1'),
+    personSection(spouse, 'Person 2'),
+    spousalSection(higher, lower),
+    survivorSection(higher, lower),
+    embedsSection(coupleEmbeds(recipient, spouse)),
+    deepLinkSection(coupleDeepLink(recipient, spouse, baseUrl)),
+  ];
+
+  return `${sections.join('\n\n')}\n`;
+}
+
+/** The `&name1=`/`&name2=` segments for a couple embed (placeholders omitted). */
+function coupleNameParams(recipient: Recipient, spouse: Recipient): string {
+  const n1 = nameParam(recipient.name, 'Self');
+  const n2 = nameParam(spouse.name, 'Spouse');
+  return (
+    (n1 ? `&name1=${encodeURIComponent(n1)}` : '') +
+    (n2 ? `&name2=${encodeURIComponent(n2)}` : '')
+  );
+}
+
+/** Couple embeds: the couple filing-age chart plus each partner's own charts. */
+function coupleEmbeds(recipient: Recipient, spouse: Recipient): string[] {
+  const coupleHash =
+    `#pia1=${piaParam(recipient)}&dob1=${isoBirthdate(recipient.birthdate)}` +
+    `&pia2=${piaParam(spouse)}&dob2=${isoBirthdate(spouse.birthdate)}` +
+    coupleNameParams(recipient, spouse);
+  return [
+    '',
+    ...embedEntry('Couple filing-age chart', coupleHash, 'filing-age-couple'),
+    ...recipientEmbeds(recipient, `${displayName(recipient, 'Person 1')}: `),
+    ...recipientEmbeds(spouse, `${displayName(spouse, 'Person 2')}: `),
+  ];
 }

--- a/src/lib/ai-export.ts
+++ b/src/lib/ai-export.ts
@@ -1,4 +1,5 @@
 import {
+  baseSpousalBenefit,
   benefitAtAge,
   eligibleForSpousalBenefit,
   spousalBenefitOnDate,
@@ -548,7 +549,7 @@ function spousalSection(higher: Recipient, lower: Recipient): string {
   if (!eligibleForSpousalBenefit(lower, higher)) {
     lines.push(
       `Neither partner qualifies for a spousal top-up: half of ${higherName}'s`,
-      `PIA (${higherPia.times(0.5).wholeDollars()}) does not exceed ${lowerName}'s own PIA`,
+      `PIA (${higherPia.div(2).wholeDollars()}) does not exceed ${lowerName}'s own PIA`,
       `(${lowerPia.wholeDollars()}). The lower earner simply takes their own benefit.`
     );
     return lines.join('\n');
@@ -561,7 +562,7 @@ function spousalSection(higher: Recipient, lower: Recipient): string {
     '',
     `- At full retirement age the spousal benefit equals 50% of ${higherName}'s`,
     `  PIA (${higherPia.wholeDollars()}) minus ${lowerName}'s own PIA (${lowerPia.wholeDollars()}):`,
-    `  ${higherPia.times(0.5).wholeDollars()} - ${lowerPia.wholeDollars()} = ${higherPia.times(0.5).sub(lowerPia).wholeDollars()} / month.`,
+    `  ${higherPia.div(2).wholeDollars()} - ${lowerPia.wholeDollars()} = ${baseSpousalBenefit(higher, lower).wholeDollars()} / month.`,
     `- It is based on ${higherName}'s PIA, not their actual (delayed or reduced)`,
     `  benefit, and ${higherName} must have filed before ${lowerName} can collect it.`,
     '- Claiming before FRA reduces the spousal benefit by 25/36 of 1% per month',

--- a/src/lib/ai-export.ts
+++ b/src/lib/ai-export.ts
@@ -47,9 +47,9 @@ type Align = 'left' | 'right' | 'center';
 /**
  * Renders an aligned GitHub-flavored markdown table. Cells are padded to a
  * fixed column width so the table also lines up when read as plain monospace
- * text (e.g. before an AI renders the markdown).
+ * text (e.g. before an AI renders the markdown). Exported for unit testing.
  */
-function renderTable(
+export function renderTable(
   headers: string[],
   rows: string[][],
   aligns: Align[]
@@ -69,9 +69,13 @@ function renderTable(
   };
 
   const sepCell = (width: number, align: Align): string => {
-    if (align === 'right') return `${'-'.repeat(width - 1)}:`;
-    if (align === 'center') return `:${'-'.repeat(width - 2)}:`;
-    return '-'.repeat(width);
+    // Clamp the dash count so very narrow columns can't make repeat() throw.
+    if (align === 'right') return `${'-'.repeat(Math.max(1, width - 1))}:`;
+    if (align === 'center')
+      return width < 2
+        ? '-'.repeat(Math.max(1, width))
+        : `:${'-'.repeat(width - 2)}:`;
+    return '-'.repeat(Math.max(1, width));
   };
 
   const line = (cells: string[]): string => `| ${cells.join(' | ')} |`;
@@ -611,9 +615,11 @@ function survivorSection(higher: Recipient, lower: Recipient): string {
     `  actually receiving, INCLUDING any delayed retirement credits ${higherName}`,
     `  earned by waiting past FRA. So delaying the higher earner's own filing also`,
     '  raises the survivor benefit — often the most valuable reason to delay.',
-    `- If ${higherName} had instead claimed early, the survivor benefit is the`,
-    `  larger of that reduced benefit or 82.5% of ${higherName}'s PIA (the`,
-    `  "widow(er)'s limit"). For ${higherName}, 82.5% of PIA = ${higherPia.times(0.825).wholeDollars()}.`,
+    `- If ${higherName} had already filed at death, the survivor benefit is the`,
+    `  larger of ${higherName}'s own benefit or 82.5% of ${higherName}'s PIA (the`,
+    `  "widow(er)'s limit", or RIB-LIM). This 82.5% floor only matters when`,
+    `  ${higherName} had reduced their benefit by filing early. For ${higherName},`,
+    `  82.5% of PIA = ${higherPia.times(0.825).wholeDollars()}.`,
     `- Survivor benefits use a separate survivor full retirement age`,
     `  (${lowerName}'s is ${survivorFra.toFullAgeString()}), which can be earlier than the`,
     '  retirement FRA. Claiming before it reduces the benefit proportionally, down',

--- a/src/lib/ai-export.ts
+++ b/src/lib/ai-export.ts
@@ -87,11 +87,13 @@ function eligibilityLine(recipient: Recipient): string | null {
  * Social Security situation, intended to be pasted into an AI assistant such as
  * Claude or ChatGPT. See issue #553.
  *
- * The function is pure and deterministic: every value is derived from the
- * recipient and the fixed SSA constants, and any "as of today" value comes from
- * {@link CalculatorAiExportOptions.generatedDate} rather than the system clock.
- * Nothing is transmitted anywhere; the caller copies the returned string to the
- * clipboard only when the user asks.
+ * The function performs no I/O and transmits nothing; the caller copies the
+ * returned string to the clipboard only when the user asks. The only formatted
+ * "as of today" value (the generated-on header line) comes from
+ * {@link CalculatorAiExportOptions.generatedDate} rather than the system clock,
+ * so the snippet is stable to copy. (Benefit and PIA amounts still depend on
+ * `constants.CURRENT_YEAR` via the default COLA cutoff, which is resolved once
+ * at module load — the same values the calculator itself displays.)
  */
 export function buildCalculatorAiExport(
   recipient: Recipient,

--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -235,16 +235,32 @@ export function higherEarningsThan(a: Recipient, b: Recipient): boolean {
 }
 
 /**
+ * The base (unreduced) spousal benefit at normal retirement age: 50% of the
+ * higher earner's PIA minus the lower earner's own PIA, floored at $0. This is
+ * the spousal top-up before any early-filing reduction. A lower earner is
+ * eligible for a spousal benefit exactly when this is positive.
+ *
+ * @param higher - The higher earner (whose PIA the spousal benefit is based on)
+ * @param lower - The potential spousal claimant
+ */
+export function baseSpousalBenefit(higher: Recipient, lower: Recipient): Money {
+  const spousal = higher
+    .pia()
+    .primaryInsuranceAmount()
+    .div(2)
+    .sub(lower.pia().primaryInsuranceAmount());
+  return spousal.value() > 0 ? spousal : Money.from(0);
+}
+
+/**
  * Returns true if recipient is eligible for spousal benefits from spouse.
  */
 export function eligibleForSpousalBenefit(
   recipient: Recipient,
   spouse: Recipient
 ): boolean {
-  const piaAmount: Money = recipient.pia().primaryInsuranceAmount();
-  const spousePiaAmount: Money = spouse.pia().primaryInsuranceAmount();
-
-  return spousePiaAmount.div(2).greaterThan(piaAmount);
+  // recipient is the potential claimant; spouse is the higher earner.
+  return baseSpousalBenefit(spouse, recipient).value() > 0;
 }
 
 /**

--- a/src/lib/components/SpousalBenefit.svelte
+++ b/src/lib/components/SpousalBenefit.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-import { higherEarningsThan } from '$lib/benefit-calculator';
+import {
+  baseSpousalBenefit,
+  higherEarningsThan,
+} from '$lib/benefit-calculator';
 import HorizCurlyImg from '$lib/images/horiz-curly.png';
 import { Money } from '$lib/money';
 import { Recipient } from '$lib/recipient';
@@ -16,17 +19,8 @@ let lowerEarner: Recipient;
 $: higherEarner = higherEarningsThan($recipient, $spouse) ? $recipient : $spouse;
 $: lowerEarner = higherEarningsThan($recipient, $spouse) ? $spouse : $recipient;
 
-function spousalBenefitCalc(higher: Recipient, lower: Recipient): Money {
-  let maxSpousal = higher.pia().primaryInsuranceAmount().div(2);
-  let spousal = maxSpousal.sub(lower.pia().primaryInsuranceAmount());
-  if (spousal.value() > 0) {
-    return spousal;
-  } else {
-    return Money.from(0);
-  }
-}
 let spousalBenefit: Money = Money.from(0);
-$: spousalBenefit = spousalBenefitCalc(higherEarner, lowerEarner);
+$: spousalBenefit = baseSpousalBenefit(higherEarner, lowerEarner);
 
 /**
  * Returns the personal benefit as a percentage of personal + spousal

--- a/src/test/ai-export.test.ts
+++ b/src/test/ai-export.test.ts
@@ -1,25 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCalculatorAiExport } from '$lib/ai-export';
+import {
+  buildCalculatorAiExport,
+  buildCoupleCalculatorAiExport,
+} from '$lib/ai-export';
 import { benefitAtAge } from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
-import { MAX_COLA_YEAR, MAX_WAGE_INDEX_YEAR } from '$lib/constants';
 import { EarningRecord } from '$lib/earning-record';
 import { Money } from '$lib/money';
 import { MonthDuration } from '$lib/month-time';
 import { Recipient } from '$lib/recipient';
 
 /**
- * Tests for the "Copy for AI assistant" markdown export (issue #553, Phase 1:
- * the pure builder). The builder turns a calculator Recipient into a
- * self-contained markdown snippet a user can paste into an LLM chat.
+ * Tests for the "Copy for AI assistant" markdown export (issue #553). The
+ * builders turn a calculator Recipient (or couple) into a self-contained
+ * markdown derivation a user can paste into an LLM chat.
  *
- * Expected values are derived from the same domain APIs the builder uses, so
- * the tests stay correct across the annual constants update rather than pinning
- * hardcoded dollar amounts.
+ * Where possible, expectations are derived from the same domain APIs the
+ * builder uses, so the tests survive the annual SSA constants update rather
+ * than pinning hardcoded dollar amounts. One PIA-only literal ($2,000) anchors
+ * the suite to a known ground truth.
  */
-
-const EARNINGS_TABLE_HEADER = '### Taxed earnings history';
 
 function earningsRecord(year: number, amount: number): EarningRecord {
   return new EarningRecord({
@@ -29,13 +30,12 @@ function earningsRecord(year: number, amount: number): EarningRecord {
   });
 }
 
-/** A 35-year earner: comfortably eligible, with non-zero PIA and benefits. */
-function eligibleRecipient(): Recipient {
+/** A 35-year $60k earner: eligible, non-zero PIA. Named, male. */
+function eligibleRecipient(name = 'Alex'): Recipient {
   const r = new Recipient();
-  r.name = 'Alex';
+  r.name = name;
   r.gender = 'male';
-  // Sep 21, 1965.
-  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21); // Sep 21, 1965
   const records: EarningRecord[] = [];
   for (let year = 1990; year <= 2024; year++) {
     records.push(earningsRecord(year, 60000));
@@ -44,15 +44,20 @@ function eligibleRecipient(): Recipient {
   return r;
 }
 
-/** A 3-year earner: under 40 credits, so not eligible (PIA is $0). */
-function ineligibleRecipient(): Recipient {
+/**
+ * A low earner (12 years of $14k): eligible for their own benefit, but their
+ * PIA stays well under half the higher earner's PIA, so they qualify for a
+ * spousal top-up.
+ */
+function lowerEarner(name = 'Jordan'): Recipient {
   const r = new Recipient();
-  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
-  r.earningsRecords = [
-    earningsRecord(2016, 50000),
-    earningsRecord(2017, 55000),
-    earningsRecord(2018, 60000),
-  ];
+  r.name = name;
+  r.birthdate = Birthdate.FromYMD(1966, 2, 10);
+  const records: EarningRecord[] = [];
+  for (let year = 2005; year <= 2016; year++) {
+    records.push(earningsRecord(year, 14000));
+  }
+  r.earningsRecords = records;
   return r;
 }
 
@@ -63,200 +68,224 @@ function piaOnlyRecipient(): Recipient {
   return r;
 }
 
-/**
- * A young earner under 40 credits now, but projected to reach 40 with future
- * earnings. Exercises the middle eligibility branch.
- */
-function projectedEligibleRecipient(): Recipient {
-  const r = new Recipient();
-  r.birthdate = Birthdate.FromYMD(1990, 0, 1);
-  r.earningsRecords = [
-    earningsRecord(2022, 50000),
-    earningsRecord(2023, 55000),
-    earningsRecord(2024, 60000),
-  ];
-  r.simulateFutureEarningsYears(15, Money.from(60000));
-  return r;
-}
-
 const ageOf = (years: number) =>
   MonthDuration.initFromYearsMonths({ years, months: 0 });
 
-describe('buildCalculatorAiExport', () => {
-  it('returns a non-empty markdown document with a top-level heading', () => {
-    const md = buildCalculatorAiExport(eligibleRecipient());
-    expect(md.length).toBeGreaterThan(0);
-    expect(md).toMatch(/^#\s/m);
-  });
+/** Returns the consecutive `| ... |` table lines that begin at `headerStart`. */
+function tableLines(md: string, headerStart: string): string[] {
+  const lines = md.split('\n');
+  const start = lines.findIndex((l) => l.startsWith(headerStart));
+  if (start < 0) return [];
+  const out: string[] = [];
+  for (let i = start; i < lines.length && lines[i].startsWith('|'); i++) {
+    out.push(lines[i]);
+  }
+  return out;
+}
 
-  it('includes the PIA, FRA, and AIME', () => {
-    const r = eligibleRecipient();
-    const md = buildCalculatorAiExport(r);
-
-    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
-    expect(md).toContain(r.normalRetirementAge().toFullAgeString());
-    expect(md).toContain(r.monthlyIndexedEarnings().wholeDollars());
-  });
-
-  it('includes the monthly benefit at ages 62, FRA, and 70', () => {
-    const r = eligibleRecipient();
-    const md = buildCalculatorAiExport(r);
-
-    for (const a of [ageOf(62), r.normalRetirementAge(), ageOf(70)]) {
-      expect(md).toContain(benefitAtAge(r, a).wholeDollars());
-    }
-  });
-
-  it('includes an earnings table (years and amounts) by default', () => {
-    const md = buildCalculatorAiExport(eligibleRecipient());
-    expect(md).toContain(EARNINGS_TABLE_HEADER);
-    // Assert the full "| year | $amount |" row shape, not just the substrings.
-    expect(md).toMatch(/\| 2016 \| \$[\d,]+ \|/);
-    expect(md).toMatch(/\| 2024 \| \$[\d,]+ \|/);
-    expect(md).toContain(Money.from(60000).wholeDollars());
-  });
-
-  it('omits the earnings table when includeEarnings is false', () => {
-    const r = eligibleRecipient();
-    const md = buildCalculatorAiExport(r, { includeEarnings: false });
-    expect(md).not.toContain(EARNINGS_TABLE_HEADER);
-    // The computed results (PIA) must still be present.
-    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
-  });
-
-  it('omits the earnings table for a PIA-only recipient', () => {
-    const r = piaOnlyRecipient();
-    const md = buildCalculatorAiExport(r);
-    expect(md).not.toContain(EARNINGS_TABLE_HEADER);
-    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
-    expect(md).toMatch(/PIA/i);
-  });
-
-  it('discloses eligibility and credit count for an eligible earner', () => {
-    const r = eligibleRecipient();
-    const md = buildCalculatorAiExport(r);
-    expect(md).toMatch(/eligible/i);
-    expect(md).toMatch(/40 of 40 credits/i);
-  });
-
-  it('flags a not-yet-eligible earner so the $0 PIA is explained', () => {
-    const r = ineligibleRecipient();
-    const md = buildCalculatorAiExport(r);
-    expect(md).toMatch(/not yet eligible/i);
-    expect(md).toMatch(/\d+ of 40 credits/i);
-    // The PIA is genuinely $0 for an ineligible recipient.
-    expect(r.pia().primaryInsuranceAmount().value()).toBe(0);
-  });
-
-  it('notes when an earner is projected to reach eligibility with future earnings', () => {
-    const r = projectedEligibleRecipient();
-    // Verify the fixture really is the middle branch: not eligible by earned
-    // credits alone, but on track once projected earnings are counted.
-    expect(r.earnedCredits()).toBeLessThan(40);
-    expect(r.totalCredits()).toBeGreaterThanOrEqual(40);
-
-    const md = buildCalculatorAiExport(r);
-    expect(md).toMatch(/projected to reach 40/i);
-    expect(md).toMatch(/\d+ of 40 credits earned so far/i);
-  });
-
-  it('includes methodology footnotes with the vintage years', () => {
-    const r = eligibleRecipient();
-    const md = buildCalculatorAiExport(r);
-
-    expect(md).toContain('PIA uses the SSA bend-point formula');
-    expect(md).toContain(String(MAX_COLA_YEAR));
-    expect(md).toContain(String(MAX_WAGE_INDEX_YEAR));
-    expect(md).toContain(String(r.indexingYear()));
-  });
-
-  it('does not claim a bend-point/COLA derivation for a PIA-only recipient', () => {
-    // A PIA-only recipient entered the PIA directly, so the bend-point formula
-    // and COLA assumptions were NOT used to derive it. Saying otherwise would
-    // feed the AI a false methodology.
-    const md = buildCalculatorAiExport(piaOnlyRecipient());
-    expect(md).not.toContain('PIA uses the SSA bend-point formula');
-    expect(md).not.toMatch(
-      /Cost-of-living adjustments \(COLA\) are applied through/i
-    );
-    expect(md).toMatch(/not derived from an earnings record/i);
-  });
-
-  it('includes a /calculator deep link with pia/dob/name/gender params', () => {
-    const r = eligibleRecipient();
-    const md = buildCalculatorAiExport(r);
-
-    expect(md).toContain('https://ssa.tools/calculator#');
-    // dob1 must be ISO YYYY-MM-DD (1-indexed month): Sep 21, 1965.
-    expect(md).toContain('dob1=1965-09-21');
-    expect(md).toContain('name1=Alex');
-    expect(md).toContain('gender1=male');
-    expect(md).toMatch(/pia1=\d+/);
-  });
-
-  it('honors a custom baseUrl for the deep link', () => {
+describe('buildCalculatorAiExport (single, earnings-based)', () => {
+  it('has a top-level heading and an injected generated date', () => {
     const md = buildCalculatorAiExport(eligibleRecipient(), {
-      baseUrl: 'https://example.test/calculator',
+      generatedDate: '2026-06-18',
     });
-    expect(md).toContain('https://example.test/calculator#');
+    expect(md).toMatch(/^# Social Security benefit summary/m);
+    expect(md).toContain('2026-06-18');
   });
 
-  it('omits name1 from the deep link for the default "Self" name', () => {
-    const r = eligibleRecipient();
-    r.name = 'Self';
-    expect(buildCalculatorAiExport(r)).not.toContain('name1=');
-
-    r.name = '';
-    expect(buildCalculatorAiExport(r)).not.toContain('name1=');
-  });
-
-  it('omits gender1 from the deep link for the default blended gender', () => {
-    const r = eligibleRecipient();
-    r.gender = 'blended';
-    expect(buildCalculatorAiExport(r)).not.toContain('gender1=');
-  });
-
-  it('builds a correct deep link for a PIA-only recipient (ground-truth anchor)', () => {
-    // PIA-only PIA is an input ($2,000), not computed from constants, so these
-    // literals are stable across the annual constants update and anchor the
-    // otherwise self-referential dollar assertions. Jan birthdate also pins the
-    // month 0-index -> 1-index conversion at the lower boundary.
-    const md = buildCalculatorAiExport(piaOnlyRecipient());
-    expect(md).toContain('$2,000');
-    expect(md).toContain('pia1=2000');
-    expect(md).toContain('dob1=1960-01-01');
-  });
-
-  it('includes privacy and not-advice caveats', () => {
-    const md = buildCalculatorAiExport(eligibleRecipient());
-    expect(md).toMatch(/not .*(financial|legal).*advice/i);
-    expect(md).toMatch(/browser|client-side/i);
-  });
-
-  it('includes suggested follow-up topics', () => {
-    const md = buildCalculatorAiExport(eligibleRecipient());
-    expect(md).toMatch(/spousal/i);
-    expect(md).toMatch(/survivor/i);
-    expect(md).toMatch(/tax/i);
-    expect(md).toMatch(/medicare/i);
-  });
-
-  it('produces identical output for identical inputs', () => {
-    const r = eligibleRecipient();
-    expect(buildCalculatorAiExport(r)).toEqual(buildCalculatorAiExport(r));
-  });
-
-  it('omits the generated-on line when no generatedDate is given', () => {
-    // The only formatted "as of today" value is gated on options.generatedDate;
-    // without it, nothing clock-derived should appear in the output.
+  it('omits the generated-on line when no date is given (no clock read)', () => {
     const md = buildCalculatorAiExport(eligibleRecipient());
     expect(md).not.toMatch(/Generated/);
   });
 
-  it('includes an injected generated date when provided', () => {
-    const md = buildCalculatorAiExport(eligibleRecipient(), {
-      generatedDate: '2026-06-19',
-    });
-    expect(md).toContain('2026-06-19');
+  it('orders the sections with AIME before PIA', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    const idx = (h: string) => md.indexOf(h);
+    expect(idx('## Eligibility')).toBeGreaterThan(-1);
+    expect(idx('## Average Indexed Monthly Earnings')).toBeGreaterThan(
+      idx('## Eligibility')
+    );
+    expect(idx('## Primary Insurance Amount')).toBeGreaterThan(
+      idx('## Average Indexed Monthly Earnings')
+    );
+    expect(idx('## Filing age adjustments')).toBeGreaterThan(
+      idx('## Primary Insurance Amount')
+    );
+    expect(idx('## Monthly benefit by filing age')).toBeGreaterThan(
+      idx('## Filing age adjustments')
+    );
+  });
+
+  it('drops the old caveats and follow-up sections', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).not.toMatch(/## Caveats/i);
+    expect(md).not.toMatch(/follow-up/i);
+  });
+
+  it('shows eligibility with a credit table and 40-credit status', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).toMatch(/40 of 40 credits earned/);
+    expect(md).toContain('| Year | Taxed earnings | Credits | Cumulative |');
+  });
+
+  it('includes the indexed-earnings formula and the AIME averaging', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+    expect(md).toContain(
+      'indexed earnings = capped taxed earnings × index factor'
+    );
+    expect(md).toMatch(/index factor =/);
+    // AIME table columns and the /420 average.
+    expect(md).toContain('| Index factor | Indexed earnings | Top 35 |');
+    expect(md).toContain('/ 420');
+    expect(md).toContain(r.monthlyIndexedEarnings().wholeDollars());
+  });
+
+  it('includes the worked PIA bend-point formula', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+    expect(md).toContain('90% of AIME up to');
+    expect(md).toContain('32% of AIME between');
+    expect(md).toContain('15% of AIME above');
+    expect(md).toMatch(/rounded down to the dime/);
+    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
+  });
+
+  it('explains the early/delayed filing rules and the January DRC rule', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    // Phrases may wrap across lines in the prose, so allow internal whitespace.
+    expect(md).toMatch(/5\/9 of 1% per\s+month/);
+    expect(md).toMatch(/5\/12 of 1% per\s+month/);
+    expect(md).toMatch(/delayed retirement credits/i);
+    expect(md).toMatch(/do not take effect until January/i);
+  });
+
+  it('lists the benefit for every filing month from earliest through 70', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+    const benefitRows = md.match(/^\|\s*\d+y \d+m\s*\|\s*\$[\d,]+ \|$/gm) ?? [];
+    // Earliest filing (62y1m here) through 70y0m is ~96 months.
+    expect(benefitRows.length).toBeGreaterThan(90);
+    // Use ages that are in the table (it starts at the earliest filing month,
+    // 62y1m for a birthday after the 2nd, not 62y0m).
+    const ages = [
+      r.birthdate.earliestFilingMonth(),
+      r.normalRetirementAge(),
+      ageOf(70),
+    ];
+    for (const a of ages) {
+      expect(md).toContain(benefitAtAge(r, a).wholeDollars());
+    }
+  });
+
+  it('aligns table columns to a fixed width (monospace-readable)', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    const lines = tableLines(md, '| Year | Taxed earnings | Index factor');
+    expect(lines.length).toBeGreaterThan(3);
+    const width = lines[0].length;
+    for (const line of lines) {
+      expect(line.length).toBe(width);
+    }
+  });
+
+  it('includes embeddable chart links (with the name) and iframe snippets', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).toContain('## Interactive charts (embeddable)');
+    expect(md).toContain('https://ssa.tools/embed/filing-age#pia1=');
+    expect(md).toContain('name1=Alex');
+    expect(md).toContain('https://ssa.tools/embed/indexed-earnings#earnings1=');
+    expect(md).toContain('https://ssa.tools/embed/bend-points#earnings1=');
+    expect(md).toMatch(/<iframe src="https:\/\/ssa\.tools\/embed\/filing-age/);
+  });
+
+  it('includes a /calculator deep link with ISO dob and name', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).toContain('https://ssa.tools/calculator#');
+    expect(md).toContain('dob1=1965-09-21'); // pins the month 0->1 conversion
+    expect(md).toContain('name1=Alex');
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const r = eligibleRecipient();
+    expect(buildCalculatorAiExport(r)).toEqual(buildCalculatorAiExport(r));
+  });
+});
+
+describe('buildCalculatorAiExport (PIA-only)', () => {
+  it('states the PIA was entered directly and skips earnings sections', () => {
+    const md = buildCalculatorAiExport(piaOnlyRecipient());
+    expect(md).toContain('$2,000'); // ground-truth anchor (input, not computed)
+    expect(md).toMatch(/entered directly/i);
+    expect(md).toMatch(/not derived from an earnings record/i);
+    expect(md).not.toContain('## Eligibility');
+    expect(md).not.toContain('## Average Indexed Monthly Earnings');
+    expect(md).not.toContain('PIA uses the SSA bend-point formula');
+  });
+
+  it('still shows filing rules, a benefit table, and a filing-age embed only', () => {
+    const md = buildCalculatorAiExport(piaOnlyRecipient());
+    expect(md).toContain('## Filing age adjustments');
+    expect(md).toContain('## Monthly benefit by filing age');
+    expect(md).toContain('dob1=1960-01-01'); // January birthdate, lower boundary
+    // No earnings means no indexed-earnings/bend-points embeds.
+    expect(md).toContain('https://ssa.tools/embed/filing-age#');
+    expect(md).not.toContain('https://ssa.tools/embed/indexed-earnings');
+    expect(md).not.toContain('https://ssa.tools/embed/bend-points');
+  });
+});
+
+describe('buildCoupleCalculatorAiExport', () => {
+  it('includes both partners full breakdowns and a couple heading', () => {
+    const md = buildCoupleCalculatorAiExport(
+      eligibleRecipient('Alex'),
+      lowerEarner('Jordan')
+    );
+    expect(md).toMatch(/summary for a couple/i);
+    expect(md).toContain('# Alex');
+    expect(md).toContain('# Jordan');
+    // Each partner has the per-recipient sections (two of each header).
+    expect(md.match(/## Monthly benefit by filing age/g)?.length).toBe(2);
+  });
+
+  it('details spousal benefits with the formula and a claiming table', () => {
+    const md = buildCoupleCalculatorAiExport(
+      eligibleRecipient('Alex'),
+      lowerEarner('Jordan')
+    );
+    expect(md).toContain('## Spousal benefits');
+    expect(md).toMatch(/50% of/);
+    expect(md).toMatch(/25\/36 of 1% per month/);
+    expect(md).toMatch(/NO delayed retirement\s+credits/i);
+    expect(md).toContain('| Lower earner files at | Spousal top-up / month |');
+  });
+
+  it('details survivor benefits (100%, widow limit, survivor FRA, switching)', () => {
+    const md = buildCoupleCalculatorAiExport(
+      eligibleRecipient('Alex'),
+      lowerEarner('Jordan')
+    );
+    expect(md).toContain('## Survivor benefits');
+    expect(md).toMatch(/100% of what/i);
+    expect(md).toMatch(/82\.5% of/);
+    expect(md).toMatch(/71\.5% at age 60/);
+    expect(md).toMatch(/survivor full retirement age/i);
+    expect(md).toMatch(/switch/i);
+  });
+
+  it('includes the couple deep link and couple + per-person embeds with names', () => {
+    const md = buildCoupleCalculatorAiExport(
+      eligibleRecipient('Alex'),
+      lowerEarner('Jordan')
+    );
+    // The deep link carries both recipients (name1/gender1 may sit between
+    // params, so assert each param individually rather than in sequence).
+    const deepLink =
+      md.match(/https:\/\/ssa\.tools\/calculator#\S+/)?.[0] ?? '';
+    expect(deepLink).toMatch(/pia1=\d+/);
+    expect(deepLink).toMatch(/dob1=[\d-]+/);
+    expect(deepLink).toMatch(/pia2=\d+/);
+    expect(deepLink).toMatch(/dob2=[\d-]+/);
+    expect(md).toContain('https://ssa.tools/embed/filing-age-couple#');
+    expect(md).toContain('name1=Alex');
+    expect(md).toContain('name2=Jordan');
   });
 });

--- a/src/test/ai-export.test.ts
+++ b/src/test/ai-export.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   buildCalculatorAiExport,
   buildCoupleCalculatorAiExport,
+  renderTable,
 } from '$lib/ai-export';
-import { benefitAtAge } from '$lib/benefit-calculator';
+import {
+  benefitAtAge,
+  eligibleForSpousalBenefit,
+} from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
 import { EarningRecord } from '$lib/earning-record';
 import { Money } from '$lib/money';
@@ -68,6 +72,44 @@ function piaOnlyRecipient(): Recipient {
   return r;
 }
 
+/** Under 40 credits: not eligible, PIA is $0. */
+function ineligibleRecipient(): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  r.earningsRecords = [
+    earningsRecord(2016, 50000),
+    earningsRecord(2017, 55000),
+    earningsRecord(2018, 60000),
+  ];
+  return r;
+}
+
+/** Under 40 earned credits now, but projected past 40 with future earnings. */
+function projectedEligibleRecipient(): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(1990, 0, 1);
+  r.earningsRecords = [
+    earningsRecord(2022, 50000),
+    earningsRecord(2023, 55000),
+    earningsRecord(2024, 60000),
+  ];
+  r.simulateFutureEarningsYears(15, Money.from(60000));
+  return r;
+}
+
+/** A second high earner so that neither partner qualifies for a spousal top-up. */
+function nearEqualEarner(name: string): Recipient {
+  const r = new Recipient();
+  r.name = name;
+  r.birthdate = Birthdate.FromYMD(1966, 3, 5);
+  const records: EarningRecord[] = [];
+  for (let year = 1990; year <= 2024; year++) {
+    records.push(earningsRecord(year, 58000));
+  }
+  r.earningsRecords = records;
+  return r;
+}
+
 const ageOf = (years: number) =>
   MonthDuration.initFromYearsMonths({ years, months: 0 });
 
@@ -127,6 +169,28 @@ describe('buildCalculatorAiExport (single, earnings-based)', () => {
     expect(md).toContain('| Year | Taxed earnings | Credits | Cumulative |');
   });
 
+  it('flags a not-yet-eligible earner so the $0 PIA is explained', () => {
+    const r = ineligibleRecipient();
+    expect(r.pia().primaryInsuranceAmount().value()).toBe(0);
+    const md = buildCalculatorAiExport(r);
+    expect(md).toMatch(/NOT yet eligible/i);
+    expect(md).toMatch(/\$0 until 40 credits/);
+  });
+
+  it('notes projected eligibility with future earnings', () => {
+    const r = projectedEligibleRecipient();
+    // Self-verify the fixture sits in the middle branch.
+    expect(r.earnedCredits()).toBeLessThan(40);
+    expect(r.totalCredits()).toBeGreaterThanOrEqual(40);
+    expect(buildCalculatorAiExport(r)).toMatch(/projected to reach 40/i);
+  });
+
+  it('does not throw for a recipient with no earnings records', () => {
+    const r = new Recipient();
+    r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+    expect(() => buildCalculatorAiExport(r)).not.toThrow();
+  });
+
   it('includes the indexed-earnings formula and the AIME averaging', () => {
     const r = eligibleRecipient();
     const md = buildCalculatorAiExport(r);
@@ -163,8 +227,12 @@ describe('buildCalculatorAiExport (single, earnings-based)', () => {
     const r = eligibleRecipient();
     const md = buildCalculatorAiExport(r);
     const benefitRows = md.match(/^\|\s*\d+y \d+m\s*\|\s*\$[\d,]+ \|$/gm) ?? [];
-    // Earliest filing (62y1m here) through 70y0m is ~96 months.
+    // Earliest filing (62y1m here) through 70y0m is ~96 months; bound both ends
+    // so a runaway loop past 70 would also fail.
     expect(benefitRows.length).toBeGreaterThan(90);
+    expect(benefitRows.length).toBeLessThan(110);
+    // The table ends exactly at age 70.
+    expect(benefitRows[benefitRows.length - 1]).toMatch(/\|\s*70y 0m\s*\|/);
     // Use ages that are in the table (it starts at the earliest filing month,
     // 62y1m for a birthday after the 2nd, not 62y0m).
     const ages = [
@@ -287,5 +355,92 @@ describe('buildCoupleCalculatorAiExport', () => {
     expect(md).toContain('https://ssa.tools/embed/filing-age-couple#');
     expect(md).toContain('name1=Alex');
     expect(md).toContain('name2=Jordan');
+  });
+
+  it('keeps the spousal fixture eligible (guards against silent drift)', () => {
+    // If the annual constants update ever flips this, the eligible-branch tests
+    // above would silently start exercising the wrong branch.
+    expect(eligibleForSpousalBenefit(lowerEarner(), eligibleRecipient())).toBe(
+      true
+    );
+  });
+
+  it('handles a couple where neither partner qualifies for a spousal top-up', () => {
+    const md = buildCoupleCalculatorAiExport(
+      eligibleRecipient('Alex'),
+      nearEqualEarner('Sam')
+    );
+    expect(md).toContain('## Spousal benefits');
+    expect(md).toMatch(/Neither partner qualifies/i);
+    expect(md).not.toContain('| Lower earner files at |');
+  });
+
+  it('handles a couple with a PIA-only partner without throwing', () => {
+    const build = () =>
+      buildCoupleCalculatorAiExport(
+        eligibleRecipient('Alex'),
+        piaOnlyRecipient()
+      );
+    expect(build).not.toThrow();
+    const md = build();
+    expect(md).toContain('## Spousal benefits');
+    expect(md).toContain('## Survivor benefits');
+  });
+
+  it('numerically anchors the survivor widow-limit (82.5% of PIA)', () => {
+    const higher = eligibleRecipient('Alex');
+    const md = buildCoupleCalculatorAiExport(higher, lowerEarner('Jordan'));
+    const widowLimit = higher
+      .pia()
+      .primaryInsuranceAmount()
+      .times(0.825)
+      .wholeDollars();
+    expect(md).toContain(widowLimit);
+  });
+
+  it('orders the spousal/survivor framing by PIA regardless of argument order', () => {
+    const region = (md: string) =>
+      md.slice(
+        md.indexOf('## Spousal benefits'),
+        md.indexOf('## Interactive charts')
+      );
+    const a = buildCoupleCalculatorAiExport(
+      eligibleRecipient('Alex'),
+      lowerEarner('Jordan')
+    );
+    const b = buildCoupleCalculatorAiExport(
+      lowerEarner('Jordan'),
+      eligibleRecipient('Alex')
+    );
+    expect(region(a)).toEqual(region(b));
+  });
+});
+
+describe('renderTable', () => {
+  it('pads every column to a consistent per-column width', () => {
+    const t = renderTable(
+      ['Year', 'Amount'],
+      [
+        ['2020', '$5'],
+        ['1999', '$1,234'],
+      ],
+      ['left', 'right']
+    );
+    const lines = t.split('\n');
+    const cols = (l: string) =>
+      l
+        .split('|')
+        .slice(1, -1)
+        .map((c) => c.length);
+    const header = cols(lines[0]);
+    for (const line of lines) {
+      expect(line.length).toBe(lines[0].length);
+      expect(cols(line)).toEqual(header);
+    }
+  });
+
+  it('does not throw on a single-character center column or empty rows', () => {
+    expect(() => renderTable(['X'], [['a'], ['b']], ['center'])).not.toThrow();
+    expect(() => renderTable(['A', 'B'], [], ['left', 'right'])).not.toThrow();
   });
 });

--- a/src/test/ai-export.test.ts
+++ b/src/test/ai-export.test.ts
@@ -164,9 +164,22 @@ describe('buildCalculatorAiExport', () => {
     const r = eligibleRecipient();
     const md = buildCalculatorAiExport(r);
 
+    expect(md).toContain('PIA uses the SSA bend-point formula');
     expect(md).toContain(String(MAX_COLA_YEAR));
     expect(md).toContain(String(MAX_WAGE_INDEX_YEAR));
     expect(md).toContain(String(r.indexingYear()));
+  });
+
+  it('does not claim a bend-point/COLA derivation for a PIA-only recipient', () => {
+    // A PIA-only recipient entered the PIA directly, so the bend-point formula
+    // and COLA assumptions were NOT used to derive it. Saying otherwise would
+    // feed the AI a false methodology.
+    const md = buildCalculatorAiExport(piaOnlyRecipient());
+    expect(md).not.toContain('PIA uses the SSA bend-point formula');
+    expect(md).not.toMatch(
+      /Cost-of-living adjustments \(COLA\) are applied through/i
+    );
+    expect(md).toMatch(/not derived from an earnings record/i);
   });
 
   it('includes a /calculator deep link with pia/dob/name/gender params', () => {

--- a/src/test/ai-export.test.ts
+++ b/src/test/ai-export.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCalculatorAiExport } from '$lib/ai-export';
+import { benefitAtAge } from '$lib/benefit-calculator';
+import { Birthdate } from '$lib/birthday';
+import { MAX_COLA_YEAR, MAX_WAGE_INDEX_YEAR } from '$lib/constants';
+import { EarningRecord } from '$lib/earning-record';
+import { Money } from '$lib/money';
+import { MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+
+/**
+ * Tests for the "Copy for AI assistant" markdown export (issue #553, Phase 1:
+ * the pure builder). The builder turns a calculator Recipient into a
+ * self-contained markdown snippet a user can paste into an LLM chat.
+ *
+ * Expected values are derived from the same domain APIs the builder uses, so
+ * the tests stay correct across the annual constants update rather than pinning
+ * hardcoded dollar amounts.
+ */
+
+const EARNINGS_TABLE_HEADER = '### Taxed earnings history';
+
+function earningsRecord(year: number, amount: number): EarningRecord {
+  return new EarningRecord({
+    year,
+    taxedEarnings: Money.from(amount),
+    taxedMedicareEarnings: Money.from(amount),
+  });
+}
+
+/** A 35-year earner: comfortably eligible, with non-zero PIA and benefits. */
+function eligibleRecipient(): Recipient {
+  const r = new Recipient();
+  r.name = 'Alex';
+  r.gender = 'male';
+  // Sep 21, 1965.
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  const records: EarningRecord[] = [];
+  for (let year = 1990; year <= 2024; year++) {
+    records.push(earningsRecord(year, 60000));
+  }
+  r.earningsRecords = records;
+  return r;
+}
+
+/** A 3-year earner: under 40 credits, so not eligible (PIA is $0). */
+function ineligibleRecipient(): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  r.earningsRecords = [
+    earningsRecord(2016, 50000),
+    earningsRecord(2017, 55000),
+    earningsRecord(2018, 60000),
+  ];
+  return r;
+}
+
+function piaOnlyRecipient(): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(1960, 0, 1);
+  r.setPia(Money.from(2000));
+  return r;
+}
+
+const ageOf = (years: number) =>
+  MonthDuration.initFromYearsMonths({ years, months: 0 });
+
+describe('buildCalculatorAiExport', () => {
+  it('returns a non-empty markdown document with a top-level heading', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md.length).toBeGreaterThan(0);
+    expect(md).toMatch(/^#\s/m);
+  });
+
+  it('includes the PIA, FRA, and AIME', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+
+    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
+    expect(md).toContain(r.normalRetirementAge().toFullAgeString());
+    expect(md).toContain(r.monthlyIndexedEarnings().wholeDollars());
+  });
+
+  it('includes the monthly benefit at ages 62, FRA, and 70', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+
+    for (const a of [ageOf(62), r.normalRetirementAge(), ageOf(70)]) {
+      expect(md).toContain(benefitAtAge(r, a).wholeDollars());
+    }
+  });
+
+  it('includes an earnings table (years and amounts) by default', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).toContain(EARNINGS_TABLE_HEADER);
+    expect(md).toContain('| 2016 |');
+    expect(md).toContain('| 2024 |');
+    expect(md).toContain(Money.from(60000).wholeDollars());
+  });
+
+  it('omits the earnings table when includeEarnings is false', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r, { includeEarnings: false });
+    expect(md).not.toContain(EARNINGS_TABLE_HEADER);
+    // The computed results (PIA) must still be present.
+    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
+  });
+
+  it('omits the earnings table for a PIA-only recipient', () => {
+    const r = piaOnlyRecipient();
+    const md = buildCalculatorAiExport(r);
+    expect(md).not.toContain(EARNINGS_TABLE_HEADER);
+    expect(md).toContain(r.pia().primaryInsuranceAmount().wholeDollars());
+    expect(md).toMatch(/PIA/i);
+  });
+
+  it('discloses eligibility and credit count for an eligible earner', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+    expect(md).toMatch(/eligible/i);
+    expect(md).toMatch(/40 of 40 credits/i);
+  });
+
+  it('flags a not-yet-eligible earner so the $0 PIA is explained', () => {
+    const r = ineligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+    expect(md).toMatch(/not yet eligible/i);
+    expect(md).toMatch(/\d+ of 40 credits/i);
+    // The PIA is genuinely $0 for an ineligible recipient.
+    expect(r.pia().primaryInsuranceAmount().value()).toBe(0);
+  });
+
+  it('includes methodology footnotes with the vintage years', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+
+    expect(md).toContain(String(MAX_COLA_YEAR));
+    expect(md).toContain(String(MAX_WAGE_INDEX_YEAR));
+    expect(md).toContain(String(r.indexingYear()));
+  });
+
+  it('includes a /calculator deep link with pia/dob/name/gender params', () => {
+    const r = eligibleRecipient();
+    const md = buildCalculatorAiExport(r);
+
+    expect(md).toContain('https://ssa.tools/calculator#');
+    // dob1 must be ISO YYYY-MM-DD (1-indexed month): Sep 21, 1965.
+    expect(md).toContain('dob1=1965-09-21');
+    expect(md).toContain('name1=Alex');
+    expect(md).toContain('gender1=male');
+    expect(md).toMatch(/pia1=\d+/);
+  });
+
+  it('honors a custom baseUrl for the deep link', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient(), {
+      baseUrl: 'https://example.test/calculator',
+    });
+    expect(md).toContain('https://example.test/calculator#');
+  });
+
+  it('includes privacy and not-advice caveats', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).toMatch(/not .*(financial|legal).*advice/i);
+    expect(md).toMatch(/browser|client-side/i);
+  });
+
+  it('includes suggested follow-up topics', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).toMatch(/spousal/i);
+    expect(md).toMatch(/survivor/i);
+    expect(md).toMatch(/tax/i);
+    expect(md).toMatch(/medicare/i);
+  });
+
+  it('is deterministic for the same recipient (no hidden clock reads)', () => {
+    const r = eligibleRecipient();
+    expect(buildCalculatorAiExport(r)).toEqual(buildCalculatorAiExport(r));
+  });
+
+  it('includes an injected generated date when provided', () => {
+    const md = buildCalculatorAiExport(eligibleRecipient(), {
+      generatedDate: '2026-06-19',
+    });
+    expect(md).toContain('2026-06-19');
+  });
+});

--- a/src/test/ai-export.test.ts
+++ b/src/test/ai-export.test.ts
@@ -63,6 +63,22 @@ function piaOnlyRecipient(): Recipient {
   return r;
 }
 
+/**
+ * A young earner under 40 credits now, but projected to reach 40 with future
+ * earnings. Exercises the middle eligibility branch.
+ */
+function projectedEligibleRecipient(): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(1990, 0, 1);
+  r.earningsRecords = [
+    earningsRecord(2022, 50000),
+    earningsRecord(2023, 55000),
+    earningsRecord(2024, 60000),
+  ];
+  r.simulateFutureEarningsYears(15, Money.from(60000));
+  return r;
+}
+
 const ageOf = (years: number) =>
   MonthDuration.initFromYearsMonths({ years, months: 0 });
 
@@ -94,8 +110,9 @@ describe('buildCalculatorAiExport', () => {
   it('includes an earnings table (years and amounts) by default', () => {
     const md = buildCalculatorAiExport(eligibleRecipient());
     expect(md).toContain(EARNINGS_TABLE_HEADER);
-    expect(md).toContain('| 2016 |');
-    expect(md).toContain('| 2024 |');
+    // Assert the full "| year | $amount |" row shape, not just the substrings.
+    expect(md).toMatch(/\| 2016 \| \$[\d,]+ \|/);
+    expect(md).toMatch(/\| 2024 \| \$[\d,]+ \|/);
     expect(md).toContain(Money.from(60000).wholeDollars());
   });
 
@@ -131,6 +148,18 @@ describe('buildCalculatorAiExport', () => {
     expect(r.pia().primaryInsuranceAmount().value()).toBe(0);
   });
 
+  it('notes when an earner is projected to reach eligibility with future earnings', () => {
+    const r = projectedEligibleRecipient();
+    // Verify the fixture really is the middle branch: not eligible by earned
+    // credits alone, but on track once projected earnings are counted.
+    expect(r.earnedCredits()).toBeLessThan(40);
+    expect(r.totalCredits()).toBeGreaterThanOrEqual(40);
+
+    const md = buildCalculatorAiExport(r);
+    expect(md).toMatch(/projected to reach 40/i);
+    expect(md).toMatch(/\d+ of 40 credits earned so far/i);
+  });
+
   it('includes methodology footnotes with the vintage years', () => {
     const r = eligibleRecipient();
     const md = buildCalculatorAiExport(r);
@@ -159,6 +188,32 @@ describe('buildCalculatorAiExport', () => {
     expect(md).toContain('https://example.test/calculator#');
   });
 
+  it('omits name1 from the deep link for the default "Self" name', () => {
+    const r = eligibleRecipient();
+    r.name = 'Self';
+    expect(buildCalculatorAiExport(r)).not.toContain('name1=');
+
+    r.name = '';
+    expect(buildCalculatorAiExport(r)).not.toContain('name1=');
+  });
+
+  it('omits gender1 from the deep link for the default blended gender', () => {
+    const r = eligibleRecipient();
+    r.gender = 'blended';
+    expect(buildCalculatorAiExport(r)).not.toContain('gender1=');
+  });
+
+  it('builds a correct deep link for a PIA-only recipient (ground-truth anchor)', () => {
+    // PIA-only PIA is an input ($2,000), not computed from constants, so these
+    // literals are stable across the annual constants update and anchor the
+    // otherwise self-referential dollar assertions. Jan birthdate also pins the
+    // month 0-index -> 1-index conversion at the lower boundary.
+    const md = buildCalculatorAiExport(piaOnlyRecipient());
+    expect(md).toContain('$2,000');
+    expect(md).toContain('pia1=2000');
+    expect(md).toContain('dob1=1960-01-01');
+  });
+
   it('includes privacy and not-advice caveats', () => {
     const md = buildCalculatorAiExport(eligibleRecipient());
     expect(md).toMatch(/not .*(financial|legal).*advice/i);
@@ -173,9 +228,16 @@ describe('buildCalculatorAiExport', () => {
     expect(md).toMatch(/medicare/i);
   });
 
-  it('is deterministic for the same recipient (no hidden clock reads)', () => {
+  it('produces identical output for identical inputs', () => {
     const r = eligibleRecipient();
     expect(buildCalculatorAiExport(r)).toEqual(buildCalculatorAiExport(r));
+  });
+
+  it('omits the generated-on line when no generatedDate is given', () => {
+    // The only formatted "as of today" value is gated on options.generatedDate;
+    // without it, nothing clock-derived should appear in the output.
+    const md = buildCalculatorAiExport(eligibleRecipient());
+    expect(md).not.toMatch(/Generated/);
   });
 
   it('includes an injected generated date when provided', () => {

--- a/src/test/benefit-calculator.test.ts
+++ b/src/test/benefit-calculator.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   allBenefitsOnDate,
   allBenefitsOnDateNominal,
+  baseSpousalBenefit,
   benefitOnDate,
   benefitOnDateNominal,
+  eligibleForSpousalBenefit,
   spousalBenefitOnDate,
 } from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
@@ -271,5 +273,38 @@ describe('allBenefitsOnDateNominal (spousal)', () => {
     ).value();
     expect(today).toBeGreaterThan(0);
     expect(nominal).toBeLessThan(today);
+  });
+});
+
+describe('baseSpousalBenefit', () => {
+  function piaOnly(pia: number): Recipient {
+    const r = new Recipient();
+    r.birthdate = Birthdate.FromYMD(1960, 0, 1);
+    r.setPia(Money.from(pia));
+    return r;
+  }
+
+  it('is 50% of the higher PIA minus the lower PIA when eligible', () => {
+    // 50% of $2,000 = $1,000; minus $400 = $600.
+    expect(baseSpousalBenefit(piaOnly(2000), piaOnly(400)).wholeDollars()).toBe(
+      '$600'
+    );
+  });
+
+  it('floors at $0 when half the higher PIA does not exceed the lower PIA', () => {
+    expect(baseSpousalBenefit(piaOnly(2000), piaOnly(1000)).value()).toBe(0);
+    expect(baseSpousalBenefit(piaOnly(2000), piaOnly(1500)).value()).toBe(0);
+  });
+
+  it('is positive exactly when eligibleForSpousalBenefit is true', () => {
+    const higher = piaOnly(2000);
+    const eligibleLower = piaOnly(400);
+    const ineligibleLower = piaOnly(1200);
+    expect(baseSpousalBenefit(higher, eligibleLower).value()).toBeGreaterThan(
+      0
+    );
+    expect(eligibleForSpousalBenefit(eligibleLower, higher)).toBe(true);
+    expect(baseSpousalBenefit(higher, ineligibleLower).value()).toBe(0);
+    expect(eligibleForSpousalBenefit(ineligibleLower, higher)).toBe(false);
   });
 });


### PR DESCRIPTION
Implements issue #553 ("Copy for AI assistant"). Phase 1 is the pure builder layer (no UI/page wiring yet — that follows in a later PR). Two exported builders in `src/lib/ai-export.ts` turn a calculator `Recipient` (or couple) into a self-contained markdown **derivation** a user can paste into Claude/ChatGPT.

## What the export contains

Designed with the issue author over several review rounds into a full, self-explaining derivation (the point: give the AI the complete worked calculation so it can't hallucinate different numbers).

**Single recipient — `buildCalculatorAiExport(recipient, options?)`:**
- **Eligibility** — 40-credit rule with a year-by-year credit table; discloses not-yet-eligible / projected-eligible so a $0 PIA is never bare.
- **AIME** — the indexed-earnings formula (`capped earnings × index factor`, factor = wage index at 60 ÷ wage index at the earning year), a per-year table (index factor, indexed earnings, top-35 flag), and the `/420` averaging.
- **PIA** — the worked bend-point formula (90/32/15% brackets) with each bracket's dollar contribution; dime/dollar rounding noted.
- **Filing-age rules** — 5/9 & 5/12 of 1% early reduction, delayed retirement credits, and the **January-only DRC rule** (except age 70).
- **Monthly benefit by filing age** — every month from the earliest filing age through 70.
- **Interactive charts** — embeddable `/embed/*` links (filing-age, indexed-earnings, bend-points) from #557, with iframe snippets and the recipient's `name1`.
- **Deep link** back to `/calculator`.

**Couple — `buildCoupleCalculatorAiExport(recipient, spouse, options?)`:** each partner's full breakdown, then detailed **Spousal** (50%-of-higher-PIA formula, early-filing reduction, claiming-age table) and **Survivor** (up-to-100%, the 82.5% widow's-limit/RIB-LIM, separate survivor FRA, 71.5%-at-60, switching) sections, the `filing-age-couple` embed, and a couple deep link.

## Design notes

- **Pure & clock-free:** the only "as of today" value is the injected `options.generatedDate` (the builder reads no clock; PIA/benefit figures track `constants.CURRENT_YEAR` exactly as the calculator displays them).
- **Aligned tables:** a `renderTable()` helper pads columns so tables line up in monospace *and* render as markdown.
- **Reuses existing infra:** `buildStrategyHash` for deep links; `/embed/*` routes (#557); the same domain APIs the on-screen calculator uses, so the emitted numbers match the site.
- **PIA-only recipients** skip the earnings-derived sections and don't claim a bend-point/COLA derivation they didn't use.

## Tests / verification

- 29 unit tests (`src/test/ai-export.test.ts`): section order, every formula, month-by-month bounds, table alignment (incl. direct `renderTable` edge cases), embeds-with-names, spousal/survivor (eligible, not-eligible, PIA-only partner, argument-order invariance), PIA-only and empty-earnings paths, determinism, and a self-verifying spousal-eligibility fixture guard.
- Reviewed by the `review-pr` agents (code, tests, comment/payload accuracy); fixes applied: corrected the widow's-limit rule prose, guarded `renderTable` against narrow columns, and covered the missing branches.
- Full suite **2020 passing**; `npm run quality` (Biome + svelte-check) clean.

## Follow-ups (not in this PR)

- `<CopyForAiButton>` + preview modal (clones the `LockedSummary` clipboard pattern).
- Wire into the calculator (and couple) report area.
