### PR TITLE
feat(calculator): add "Copy for AI assistant" export button (#553)

### DIFF
--- a/src/lib/components/CopyForAiButton.svelte
+++ b/src/lib/components/CopyForAiButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import posthog from "posthog-js";
   import type { Recipient } from "$lib/recipient";
   import { buildCalculatorExport, localIsoDate } from "$lib/components/copy-for-ai";
@@ -11,6 +12,13 @@
   let copied = false;
   let copyError = false;
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Clear the pending "Copied!" reset timer if the component is destroyed
+  // before it fires, so the callback can't assign to state on a torn-down
+  // component (matches the timer cleanup in Sidebar / MobileDesktopPrompt).
+  onDestroy(() => {
+    if (copyTimer) clearTimeout(copyTimer);
+  });
 
   function openPreview() {
     // Build lazily, only when the user asks to see it, so editing earnings
@@ -315,6 +323,7 @@
     line-height: 1.4;
   }
 
+  /* The button is interactive-only; omit it from printouts / PDFs. */
   @media print {
     .copy-for-ai {
       display: none;

--- a/src/lib/components/CopyForAiButton.svelte
+++ b/src/lib/components/CopyForAiButton.svelte
@@ -1,0 +1,323 @@
+<script lang="ts">
+  import posthog from "posthog-js";
+  import type { Recipient } from "$lib/recipient";
+  import { buildCalculatorExport, localIsoDate } from "$lib/components/copy-for-ai";
+
+  export let recipient: Recipient;
+  export let spouse: Recipient | null = null;
+
+  let dialogEl: HTMLDialogElement;
+  let markdown = "";
+  let copied = false;
+  let copyError = false;
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function openPreview() {
+    // Build lazily, only when the user asks to see it, so editing earnings
+    // doesn't rebuild the full export on every store update.
+    markdown = buildCalculatorExport(recipient, spouse, {
+      generatedDate: localIsoDate(new Date()),
+    });
+    copied = false;
+    copyError = false;
+    dialogEl.showModal();
+  }
+
+  function closePreview() {
+    dialogEl.close();
+  }
+
+  function onDialogClick(event: MouseEvent) {
+    // Native <dialog> doesn't close on backdrop click; emulate it by closing
+    // only when the click lands on the dialog element itself (the backdrop),
+    // not on its content.
+    if (event.target === dialogEl) closePreview();
+  }
+
+  async function handleCopy() {
+    if (!markdown) return;
+    copyError = false;
+    try {
+      await navigator.clipboard.writeText(markdown);
+      copied = true;
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => {
+        copied = false;
+        copyTimer = null;
+      }, 2000);
+    } catch {
+      copyError = true;
+      return;
+    }
+    try {
+      posthog.capture("Calculator: AI Export Copied", {
+        mode: spouse ? "couple" : "single",
+      });
+    } catch {
+      // analytics must not affect copy UX
+    }
+  }
+</script>
+
+<div class="copy-for-ai">
+  <button type="button" class="trigger-btn" on:click={openPreview}>
+    <svg
+      viewBox="0 0 16 16"
+      width="15"
+      height="15"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.4"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M8 1.5l1.4 3.6L13 6.5 9.4 7.9 8 11.5 6.6 7.9 3 6.5l3.6-1.4z" />
+      <path d="M12.6 10.4l.5 1.3 1.3.5-1.3.5-.5 1.3-.5-1.3-1.3-.5 1.3-.5z" />
+    </svg>
+    Copy for AI assistant
+  </button>
+
+  <dialog bind:this={dialogEl} class="preview" on:click={onDialogClick}>
+    <div class="panel">
+      <header class="panel-header">
+        <h2>Copy for AI assistant</h2>
+        <button
+          type="button"
+          class="close-btn"
+          aria-label="Close"
+          on:click={closePreview}
+        >
+          <svg
+            viewBox="0 0 16 16"
+            width="16"
+            height="16"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.75"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
+            <path d="M3 3l10 10M13 3L3 13" />
+          </svg>
+        </button>
+      </header>
+
+      <p class="intro">
+        A self-contained summary of this benefit calculation, formatted as
+        markdown. Paste it into ChatGPT, Claude, or another AI assistant to ask
+        follow-up questions about your Social Security benefits.
+      </p>
+
+      <p class="disclosure">
+        This includes your birthdate, earnings, and PIA. It stays on your device
+        until you paste it somewhere — only share it with tools you trust.
+      </p>
+
+      <pre class="markdown" aria-label="AI export preview">{markdown}</pre>
+
+      <div class="actions">
+        <button type="button" class="copy-btn" on:click={handleCopy}>
+          {#if copied}
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M2 8l4 4 8-8" />
+            </svg>
+            Copied!
+          {:else}
+            <svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="5" y="2" width="9" height="11" rx="1.5" />
+              <path d="M11 2V1a1 1 0 00-1-1H2a1 1 0 00-1 1v11a1 1 0 001 1h1" />
+            </svg>
+            Copy to clipboard
+          {/if}
+        </button>
+        <button type="button" class="dismiss-btn" on:click={closePreview}>
+          Close
+        </button>
+        {#if copyError}
+          <p class="copy-error">
+            Could not copy — select the text above and copy it manually.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </dialog>
+</div>
+
+<style>
+  .copy-for-ai {
+    margin: 0.5rem 0 1rem;
+  }
+
+  /* Matches the report's primary CTA style (see StrategyPromo). */
+  .trigger-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: #081d88;
+    color: #fff;
+    border: none;
+    padding: 0.55rem 1rem;
+    border-radius: 5px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+  .trigger-btn:hover,
+  .trigger-btn:focus-visible {
+    background: #0a23a8;
+    outline: none;
+  }
+  .trigger-btn:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 3px;
+  }
+
+  .preview {
+    border: none;
+    border-radius: 8px;
+    padding: 0;
+    max-width: min(720px, 92vw);
+    width: 100%;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+  }
+  .preview::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    max-height: min(80vh, 720px);
+    padding: 1.25rem 1.4rem 1.4rem;
+  }
+
+  .panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+  }
+  .panel-header h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #0b0c0c;
+  }
+
+  .close-btn {
+    flex: 0 0 auto;
+    background: transparent;
+    border: none;
+    color: #6b7280;
+    padding: 0.25rem;
+    border-radius: 4px;
+    cursor: pointer;
+    display: inline-flex;
+    transition: color 0.15s ease;
+  }
+  .close-btn:hover,
+  .close-btn:focus-visible {
+    color: #081d88;
+    outline: none;
+  }
+  .close-btn:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 2px;
+  }
+
+  .intro {
+    margin: 0 0 0.6rem;
+    font-size: 0.9rem;
+    color: #4b5563;
+    line-height: 1.5;
+  }
+
+  .disclosure {
+    margin: 0 0 0.8rem;
+    font-size: 0.82rem;
+    color: #6b7280;
+    line-height: 1.45;
+  }
+
+  .markdown {
+    flex: 1 1 auto;
+    overflow: auto;
+    margin: 0 0 0.9rem;
+    padding: 0.8rem;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    white-space: pre;
+    color: #0b0c0c;
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .copy-btn {
+    background: #081d88;
+    border: 1px solid #081d88;
+    color: #fff;
+    padding: 0.4rem 0.85rem;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    transition: background 0.15s ease;
+  }
+  .copy-btn:hover,
+  .copy-btn:focus-visible {
+    background: #0a25ad;
+    outline: none;
+  }
+  .copy-btn:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 2px;
+  }
+
+  .dismiss-btn {
+    background: transparent;
+    border: 1px solid #d1d5db;
+    color: #4b5563;
+    padding: 0.4rem 0.85rem;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+  .dismiss-btn:hover,
+  .dismiss-btn:focus-visible {
+    color: #081d88;
+    border-color: #081d88;
+    outline: none;
+  }
+
+  .copy-error {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #d4351c;
+    line-height: 1.4;
+  }
+
+  @media print {
+    .copy-for-ai {
+      display: none;
+    }
+  }
+</style>

--- a/src/lib/components/copy-for-ai.ts
+++ b/src/lib/components/copy-for-ai.ts
@@ -24,7 +24,9 @@ export function localIsoDate(d: Date): string {
  * Builds the "Copy for AI assistant" markdown for the calculator report. Uses
  * the single-recipient builder, or the couple builder when a spouse is present.
  * Options (baseUrl, generatedDate) are forwarded unchanged to the underlying
- * builder, keeping this function deterministic for a given set of inputs.
+ * builder, which is deterministic for a given set of inputs (see
+ * buildCalculatorAiExport; amounts depend on constants.CURRENT_YEAR resolved
+ * at module load, not on the wall clock).
  */
 export function buildCalculatorExport(
   recipient: Recipient,

--- a/src/lib/components/copy-for-ai.ts
+++ b/src/lib/components/copy-for-ai.ts
@@ -1,0 +1,37 @@
+import {
+  buildCalculatorAiExport,
+  buildCoupleCalculatorAiExport,
+  type CalculatorAiExportOptions,
+} from '$lib/ai-export';
+import type { Recipient } from '$lib/recipient';
+
+/**
+ * Formats a Date as `YYYY-MM-DD` using its LOCAL calendar parts.
+ *
+ * Deliberately not `new Date().toISOString().slice(0, 10)`: that yields the UTC
+ * day, which can be one calendar day off from the user's local day near
+ * midnight. The AI export stamps a human-facing "Generated" date, so it must
+ * match the day the user is actually looking at the page.
+ */
+export function localIsoDate(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Builds the "Copy for AI assistant" markdown for the calculator report. Uses
+ * the single-recipient builder, or the couple builder when a spouse is present.
+ * Options (baseUrl, generatedDate) are forwarded unchanged to the underlying
+ * builder, keeping this function deterministic for a given set of inputs.
+ */
+export function buildCalculatorExport(
+  recipient: Recipient,
+  spouse: Recipient | null,
+  options: CalculatorAiExportOptions = {}
+): string {
+  return spouse
+    ? buildCoupleCalculatorAiExport(recipient, spouse, options)
+    : buildCalculatorAiExport(recipient, options);
+}

--- a/src/routes/calculator/+page.svelte
+++ b/src/routes/calculator/+page.svelte
@@ -3,6 +3,7 @@ import type { ComponentType, SvelteComponent } from 'svelte';
 import { onMount } from 'svelte';
 import CombinedChart from '$lib/components/CombinedChart.svelte';
 import CombinedHeading from '$lib/components/CombinedHeading.svelte';
+import CopyForAiButton from '$lib/components/CopyForAiButton.svelte';
 import EarningsReport from '$lib/components/EarningsReport.svelte';
 import EligibilityReport from '$lib/components/EligibilityReport.svelte';
 import FilingDateReport from '$lib/components/FilingDateReport.svelte';
@@ -372,6 +373,17 @@ async function loadIntegrationComponents(
           />
         </SidebarSection>
       {/if}
+      <SidebarSection label="Copy for AI" heading={true}>
+        <div class="copyForAiSection">
+          <h2>Copy for AI assistant</h2>
+          <p>
+            Turn this entire report into a self-contained markdown summary you
+            can paste into ChatGPT, Claude, or another AI assistant — then ask
+            follow-up questions about your own Social Security benefits.
+          </p>
+          <CopyForAiButton recipient={$recipient} spouse={$spouse} />
+        </div>
+      </SidebarSection>
       <SidebarSection label="More Reading" heading={true}>
         <MoreResources />
       </SidebarSection>
@@ -395,6 +407,13 @@ async function loadIntegrationComponents(
   }
   .recipientName {
     text-decoration: underline;
+  }
+  .copyForAiSection {
+    margin: 0 0.5em;
+  }
+  .copyForAiSection p {
+    max-width: 640px;
+    line-height: 1.5;
   }
   @media screen {
     .printFooter {

--- a/src/stories/CopyForAiButton.stories.ts
+++ b/src/stories/CopyForAiButton.stories.ts
@@ -1,0 +1,48 @@
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '$lib/birthday';
+import demo from '$lib/pastes/averagepaste.txt?raw';
+import demo_spouse_low from '$lib/pastes/averagepaste-spouse.txt?raw';
+import { Recipient } from '$lib/recipient';
+import { parsePaste } from '$lib/ssa-parse';
+import CopyForAiButton from '../lib/components/CopyForAiButton.svelte';
+
+const recipient = new Recipient();
+recipient.name = 'Alex';
+recipient.markFirst();
+recipient.earningsRecords = parsePaste(demo);
+recipient.birthdate = Birthdate.FromYMD(1950, 6, 1);
+
+const spouse = new Recipient();
+spouse.name = 'Chris';
+spouse.markSecond();
+spouse.earningsRecords = parsePaste(demo_spouse_low);
+spouse.birthdate = Birthdate.FromYMD(1950, 6, 1);
+
+const meta: Meta<CopyForAiButton> = {
+  component: CopyForAiButton,
+  title: 'Report/CopyForAiButton',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+};
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: CopyForAiButton,
+  props: args,
+});
+
+// Single recipient: the export uses the single-person builder.
+export const Single = Template.bind({});
+Single.args = {
+  recipient: recipient,
+  spouse: null,
+};
+
+// Couple: the export uses the couple builder (adds spousal/survivor sections).
+export const Couple = Template.bind({});
+Couple.args = {
+  recipient: recipient,
+  spouse: spouse,
+};

--- a/src/test/components/copy-for-ai.test.ts
+++ b/src/test/components/copy-for-ai.test.ts
@@ -70,7 +70,8 @@ describe('localIsoDate', () => {
 
   it('reads the local calendar day, not the UTC day', () => {
     // Mirror the contract against the local getters. A toISOString()-based
-    // implementation would diverge from this in any non-UTC timezone.
+    // implementation would diverge from this in timezones east of UTC near
+    // local midnight, where the local day and the UTC day differ.
     const d = new Date(2026, 5, 18, 23, 30);
     const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
     expect(localIsoDate(d)).toBe(expected);
@@ -103,6 +104,13 @@ describe('buildCalculatorExport', () => {
       baseUrl: 'https://example.test/calculator',
     });
     expect(out).toContain('https://example.test/calculator');
+  });
+
+  it('uses the production calculator URL when no baseUrl is given', () => {
+    // The live button calls this with only generatedDate, so the default
+    // deep-link target must resolve to the production URL.
+    const out = buildCalculatorExport(eligibleRecipient(), null);
+    expect(out).toContain('https://ssa.tools/calculator');
   });
 
   it('is deterministic given the same inputs and options', () => {

--- a/src/test/components/copy-for-ai.test.ts
+++ b/src/test/components/copy-for-ai.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { Birthdate } from '$lib/birthday';
+import {
+  buildCalculatorExport,
+  localIsoDate,
+} from '$lib/components/copy-for-ai';
+import { EarningRecord } from '$lib/earning-record';
+import { Money } from '$lib/money';
+import { Recipient } from '$lib/recipient';
+
+/**
+ * Tests for the importable logic behind the "Copy for AI assistant" button
+ * (issue #553, Phase 2). The Svelte component is a thin shell over these two
+ * helpers, so the meaningful branches are tested here rather than by rendering.
+ */
+
+function earningsRecord(year: number, amount: number): EarningRecord {
+  return new EarningRecord({
+    year,
+    taxedEarnings: Money.from(amount),
+    taxedMedicareEarnings: Money.from(amount),
+  });
+}
+
+/** A 35-year $60k earner: eligible, non-zero PIA. */
+function eligibleRecipient(name = 'Alex'): Recipient {
+  const r = new Recipient();
+  r.name = name;
+  r.gender = 'male';
+  r.birthdate = Birthdate.FromYMD(1965, 8, 21);
+  const records: EarningRecord[] = [];
+  for (let year = 1990; year <= 2024; year++) {
+    records.push(earningsRecord(year, 60000));
+  }
+  r.earningsRecords = records;
+  return r;
+}
+
+/** A low earner who qualifies for a spousal top-up against the higher earner. */
+function lowerEarner(name = 'Jordan'): Recipient {
+  const r = new Recipient();
+  r.name = name;
+  r.gender = 'female';
+  r.birthdate = Birthdate.FromYMD(1966, 2, 10);
+  const records: EarningRecord[] = [];
+  for (let year = 2005; year <= 2016; year++) {
+    records.push(earningsRecord(year, 14000));
+  }
+  r.earningsRecords = records;
+  return r;
+}
+
+describe('localIsoDate', () => {
+  // The ai-export builder docs warn against deriving the "Generated" date from
+  // new Date().toISOString(), whose UTC value can be a calendar day off from
+  // the user's local day. localIsoDate must read the LOCAL calendar parts.
+  it('formats a local date as YYYY-MM-DD', () => {
+    // Constructed in local time, so the local parts are exactly (2026, Mar, 7).
+    expect(localIsoDate(new Date(2026, 2, 7))).toBe('2026-03-07');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    expect(localIsoDate(new Date(2026, 0, 5))).toBe('2026-01-05');
+  });
+
+  it('handles a two-digit month and day (December 31)', () => {
+    expect(localIsoDate(new Date(2026, 11, 31))).toBe('2026-12-31');
+  });
+
+  it('reads the local calendar day, not the UTC day', () => {
+    // Mirror the contract against the local getters. A toISOString()-based
+    // implementation would diverge from this in any non-UTC timezone.
+    const d = new Date(2026, 5, 18, 23, 30);
+    const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    expect(localIsoDate(d)).toBe(expected);
+  });
+});
+
+describe('buildCalculatorExport', () => {
+  it('uses the single-recipient builder when there is no spouse', () => {
+    const out = buildCalculatorExport(eligibleRecipient(), null);
+    // The single export has no couple-only analysis sections.
+    expect(out).not.toContain('## Spousal benefits');
+    expect(out).not.toContain('## Survivor benefits');
+  });
+
+  it('uses the couple builder when a spouse is present', () => {
+    const out = buildCalculatorExport(eligibleRecipient(), lowerEarner());
+    expect(out).toContain('## Spousal benefits');
+    expect(out).toContain('## Survivor benefits');
+  });
+
+  it('stamps the provided generatedDate into the header', () => {
+    const out = buildCalculatorExport(eligibleRecipient(), null, {
+      generatedDate: '2026-03-07',
+    });
+    expect(out).toContain('Generated 2026-03-07');
+  });
+
+  it('forwards a custom baseUrl into the deep link', () => {
+    const out = buildCalculatorExport(eligibleRecipient(), null, {
+      baseUrl: 'https://example.test/calculator',
+    });
+    expect(out).toContain('https://example.test/calculator');
+  });
+
+  it('is deterministic given the same inputs and options', () => {
+    const opts = { generatedDate: '2026-03-07' };
+    const a = buildCalculatorExport(eligibleRecipient(), lowerEarner(), opts);
+    const b = buildCalculatorExport(eligibleRecipient(), lowerEarner(), opts);
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Copy for AI** section to the calculator report (just above *More Reading*) with a button that opens a preview modal of the full benefit-derivation markdown and copies it to the clipboard — for pasting into ChatGPT, Claude, or another AI assistant. Works for both single recipients and couples.

This is the Phase 2 UI for #553; it builds on the `ai-export` builder merged in #568.

## What's included

- **`copy-for-ai.ts`** (importable, unit-tested):
  - `localIsoDate()` — formats the "Generated" date from local calendar parts (avoids the `toISOString()` UTC off-by-one the builder docs warn about).
  - `buildCalculatorExport(recipient, spouse | null, options)` — dispatches to the single vs couple builder.
- **`CopyForAiButton.svelte`** — trigger button styled as the report's primary CTA (matches `StrategyPromo`), opening a native `<dialog>` preview with: scrollable markdown, "Copy to clipboard" (→ "Copied!"), a PII disclosure, a copy-failure fallback, and a posthog event. The export is built lazily on open for determinism.
- Wired into the calculator report (`+page.svelte`) as its own section + sidebar-nav entry.
- **Storybook story** (single + couple) for Chromatic visual-regression coverage.

## Privacy

All data stays client-side. The markdown is only built on demand and never leaves the device until the user pastes it; the modal warns about the birthdate/earnings/PIA it contains.

## Testing

- 9 new TDD unit tests (`copy-for-ai.test.ts`): date formatting/locality, single-vs-couple dispatch, `generatedDate`/`baseUrl` passthrough, determinism.
- Full suite green: **2032 passed**. `npm run quality` clean (Biome + svelte-check 0/0).
- Manually verified end-to-end against a production preview build (button → modal → 23k-char couple export rendering with aligned tables).

## Follow-ups (not in this PR)

- Wire the same export into the `/strategy` report.
- Optional: a one-line dev-server fix so `npm run dev` works with the COEP header (currently the dev runtime fails to load dynamic modules under `require-corp`).