### PR TITLE
feat(calculator): add recommended filing ages card to Strategy Optimizer

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,6 +2,10 @@ import type { StorybookConfig } from "@storybook/svelte-vite";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx|svelte)"],
+  // Serve the SvelteKit `static/` dir so components that fetch static assets
+  // (e.g. RecommendedFilingCard loading /data/processed/*.json life tables)
+  // work in Storybook and render in Chromatic snapshots.
+  staticDirs: ["../static"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -14,9 +14,16 @@
     singleResult?: FilingAgeResult;
     coupleResult?: CoupleFilingAgeResult;
     recipients: [Recipient, Recipient];
+    showInfoTip?: boolean;
   }
 
-  let { isSingle, singleResult, coupleResult, recipients }: Props = $props();
+  let {
+    isSingle,
+    singleResult,
+    coupleResult,
+    recipients,
+    showInfoTip = true,
+  }: Props = $props();
 
   function formatAge(age: MonthDuration): string {
     return age.toFullAgeString();
@@ -125,12 +132,14 @@
             {formatMoney(coupleResult.expectedNPVCents)}
           {/if}
         </strong>
-        <InfoTip label="About expected NPV">
-          The recommended strategy's expected lifetime benefits, weighted by
-          each person's survival probability at every age and discounted to
-          today's dollars at the rate set above. It updates as you tune
-          health and discount rate.
-        </InfoTip>
+        {#if showInfoTip}
+          <InfoTip label="About expected NPV">
+            The recommended strategy's expected lifetime benefits, weighted by
+            each person's survival probability at every age and discounted to
+            today's dollars at the rate set above. It updates as you tune
+            health and discount rate.
+          </InfoTip>
+        {/if}
       </div>
       <p class="explanation">
         {#if isSingle}
@@ -141,6 +150,10 @@
           Maximizes your expected combined lifetime benefits, weighted by
           each person's probability of surviving to each age and adjusted for
           the discount rate.
+        {/if}
+        {#if !showInfoTip}
+          Based on default assumptions — a 2.5% discount rate and blended life
+          expectancy. Open the optimizer to adjust.
         {/if}
       </p>
     </div>

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -63,6 +63,29 @@
     }
   }
 
+  function compute(
+    d1: DeathProbability[],
+    d2: DeathProbability[] | null
+  ): void {
+    try {
+      // Reads the latest component-scope recipient/spouse. d1/d2 are passed in:
+      // they are keyed to recipient identity via distKey and stay valid across
+      // the PIA changes that trigger a recompute.
+      result = recommendedFromDistributions(
+        recipient,
+        spouse,
+        d1,
+        d2,
+        currentMonthDate()
+      );
+    } catch (e) {
+      // The optimizer returns an empty array for edge cases rather than
+      // throwing, so a throw here signals a real bug, not expected input.
+      console.error("RecommendedFilingCard: compute failed", e);
+      result = null;
+    }
+  }
+
   function scheduleRecompute(
     _r: Recipient,
     _s: Recipient | null,
@@ -71,28 +94,22 @@
   ): void {
     // _r/_s are unused by name: they only register recipient/spouse as reactive
     // dependencies so this block re-runs on store updates (e.g. PIA changes).
-    // The debounced callback intentionally reads the latest component-scope
-    // recipient/spouse when it fires, not these scheduled-time values. d1/d2 are
-    // safe to close over: they are keyed to recipient identity via distKey and
-    // are stable across the PIA changes that trigger a recompute.
     if (!d1) return;
-    if (debounceTimer) clearTimeout(debounceTimer);
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    // Compute the first result immediately so the card appears as soon as the
+    // distributions load (also makes it deterministic for Chromatic, which
+    // would otherwise snapshot before the debounce fires). Debounce only
+    // subsequent recomputes so rapid PIA edits don't thrash the optimizer.
+    if (result === null) {
+      compute(d1, d2);
+      return;
+    }
     debounceTimer = setTimeout(() => {
       debounceTimer = null;
-      try {
-        result = recommendedFromDistributions(
-          recipient,
-          spouse,
-          d1,
-          d2,
-          currentMonthDate()
-        );
-      } catch (e) {
-        // The optimizer returns an empty array for edge cases rather than
-        // throwing, so a throw here signals a real bug, not expected input.
-        console.error("RecommendedFilingCard: compute failed", e);
-        result = null;
-      }
+      compute(d1, d2);
     }, RECOMPUTE_DEBOUNCE_MS);
   }
 

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import OptimalStrategyHeadline from "$lib/components/OptimalStrategyHeadline.svelte";
+  import {
+    buildStrategyUrl,
+    currentMonthDate,
+    loadDeathDistributions,
+    recommendedFromDistributions,
+    type RecommendedFiling,
+  } from "$lib/components/recommended-filing-card";
+  import type { DeathProbability } from "$lib/life-tables";
+  import type { Recipient } from "$lib/recipient";
+
+  export let recipient: Recipient;
+  export let spouse: Recipient | null = null;
+
+  const RECOMPUTE_DEBOUNCE_MS = 250;
+
+  let dist1: DeathProbability[] | null = null;
+  let dist2: DeathProbability[] | null = null;
+  let result: RecommendedFiling | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  // Key the loaded distributions to gender+birthYear so that PIA changes
+  // (earnings sliders) do not trigger a life-table refetch.
+  let distKey = "";
+
+  function mortalityKey(r: Recipient): string {
+    return `${r.gender}:${r.birthdate.layBirthYear()}`;
+  }
+
+  // Recipient/spouse are store-backed object props; Svelte re-runs these
+  // reactive blocks on every store notification.
+  $: void maybeLoadDistributions(recipient, spouse);
+  $: scheduleRecompute(recipient, spouse, dist1, dist2);
+  $: strategyUrl = buildStrategyUrl(recipient, spouse);
+
+  async function maybeLoadDistributions(
+    r: Recipient,
+    s: Recipient | null
+  ): Promise<void> {
+    const key = `${mortalityKey(r)}|${s ? mortalityKey(s) : "none"}`;
+    if (key === distKey) return;
+    distKey = key;
+    try {
+      const loaded = await loadDeathDistributions(r, s);
+      dist1 = loaded.dist1;
+      dist2 = loaded.dist2;
+    } catch (e) {
+      console.warn("RecommendedFilingCard: failed to load mortality data", e);
+      // Reset the key so an identical recipient retries on the next update,
+      // rather than staying blank after a transient load failure.
+      distKey = "";
+      dist1 = null;
+      dist2 = null;
+      result = null;
+    }
+  }
+
+  function scheduleRecompute(
+    _r: Recipient,
+    _s: Recipient | null,
+    d1: DeathProbability[] | null,
+    d2: DeathProbability[] | null
+  ): void {
+    // _r/_s are unused by name: they only register recipient/spouse as reactive
+    // dependencies so this block re-runs on store updates (e.g. PIA changes).
+    // The debounced callback intentionally reads the latest module-level
+    // recipient/spouse when it fires, not these scheduled-time values.
+    if (!d1) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      try {
+        result = recommendedFromDistributions(
+          recipient,
+          spouse,
+          d1,
+          d2,
+          currentMonthDate()
+        );
+      } catch (e) {
+        console.warn("RecommendedFilingCard: compute failed", e);
+        result = null;
+      }
+    }, RECOMPUTE_DEBOUNCE_MS);
+  }
+
+  onDestroy(() => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+  });
+
+  // OptimalStrategyHeadline always takes a [Recipient, Recipient] tuple; for a
+  // single recipient it only reads index 0, so duplicate the recipient.
+  $: recipientsTuple = (
+    spouse ? [recipient, spouse] : [recipient, recipient]
+  ) as [Recipient, Recipient];
+</script>
+
+{#if result}
+  <a
+    class="card-link pageBreakAvoid"
+    href={strategyUrl}
+    aria-label="Open the strategy optimizer to explore filing dates"
+  >
+    <OptimalStrategyHeadline
+      isSingle={result.isSingle}
+      singleResult={result.single}
+      coupleResult={result.couple}
+      recipients={recipientsTuple}
+      showInfoTip={false}
+    />
+  </a>
+{/if}
+
+<style>
+  .card-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    border-radius: 14px;
+    transition: transform 0.12s ease;
+  }
+  .card-link:hover,
+  .card-link:focus-visible {
+    transform: translateY(-2px);
+    outline: none;
+  }
+  .card-link:focus-visible {
+    outline: 2px solid #081d88;
+    outline-offset: 3px;
+  }
+</style>

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -20,16 +20,19 @@
   let dist2: DeathProbability[] | null = null;
   let result: RecommendedFiling | null = null;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  // Key the loaded distributions to gender+birthYear so that PIA changes
-  // (earnings sliders) do not trigger a life-table refetch.
+  // Key the loaded distributions to the inputs that actually affect mortality
+  // (gender, birth year, health multiplier) so that PIA changes (earnings
+  // sliders) do not trigger a life-table refetch. healthMultiplier is keyed for
+  // correctness even though the calculator does not currently expose it.
   let distKey = "";
 
   function mortalityKey(r: Recipient): string {
-    return `${r.gender}:${r.birthdate.layBirthYear()}`;
+    return `${r.gender}:${r.birthdate.layBirthYear()}:${r.healthMultiplier}`;
   }
 
-  // Recipient/spouse are store-backed object props; Svelte re-runs these
-  // reactive blocks on every store notification.
+  // Recipient/spouse implement the Svelte store contract; the parent re-passes
+  // them on each store update, which invalidates these reactive blocks (e.g. on
+  // a PIA, gender, or health change).
   $: void maybeLoadDistributions(recipient, spouse);
   $: scheduleRecompute(recipient, spouse, dist1, dist2);
   $: strategyUrl = buildStrategyUrl(recipient, spouse);
@@ -43,12 +46,16 @@
     distKey = key;
     try {
       const loaded = await loadDeathDistributions(r, s);
+      // A newer load may have started while this one was in flight; if so, let
+      // the latest win rather than applying out-of-order (stale) data.
+      if (distKey !== key) return;
       dist1 = loaded.dist1;
       dist2 = loaded.dist2;
     } catch (e) {
+      if (distKey !== key) return;
       console.warn("RecommendedFilingCard: failed to load mortality data", e);
-      // Reset the key so an identical recipient retries on the next update,
-      // rather than staying blank after a transient load failure.
+      // Reset the key so the next store update retries the fetch rather than
+      // treating the failed state as current.
       distKey = "";
       dist1 = null;
       dist2 = null;
@@ -64,8 +71,10 @@
   ): void {
     // _r/_s are unused by name: they only register recipient/spouse as reactive
     // dependencies so this block re-runs on store updates (e.g. PIA changes).
-    // The debounced callback intentionally reads the latest module-level
-    // recipient/spouse when it fires, not these scheduled-time values.
+    // The debounced callback intentionally reads the latest component-scope
+    // recipient/spouse when it fires, not these scheduled-time values. d1/d2 are
+    // safe to close over: they are keyed to recipient identity via distKey and
+    // are stable across the PIA changes that trigger a recompute.
     if (!d1) return;
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
@@ -79,7 +88,9 @@
           currentMonthDate()
         );
       } catch (e) {
-        console.warn("RecommendedFilingCard: compute failed", e);
+        // The optimizer returns an empty array for edge cases rather than
+        // throwing, so a throw here signals a real bug, not expected input.
+        console.error("RecommendedFilingCard: compute failed", e);
         result = null;
       }
     }, RECOMPUTE_DEBOUNCE_MS);

--- a/src/lib/components/StrategyPromo.svelte
+++ b/src/lib/components/StrategyPromo.svelte
@@ -1,66 +1,28 @@
 <script lang="ts">
   import type { Recipient } from "$lib/recipient";
-  import { buildStrategyHash } from "$lib/url-params";
-  import RecipientName from "$lib/components/RecipientName.svelte";
+  import { buildStrategyUrl } from "$lib/components/recommended-filing-card";
+  import RecommendedFilingCard from "$lib/components/RecommendedFilingCard.svelte";
 
   export let recipient: Recipient;
   export let spouse: Recipient | null = null;
 
-  function formatDob(r: Recipient): string {
-    const bd = r.birthdate;
-    const y = bd.layBirthYear();
-    const m = (bd.layBirthMonth() + 1).toString().padStart(2, "0");
-    const d = bd.layBirthDayOfMonth().toString().padStart(2, "0");
-    return `${y}-${m}-${d}`;
-  }
-
-  function formatPia(r: Recipient): string {
-    return r.pia().primaryInsuranceAmount().roundToDollar().wholeDollars();
-  }
-
   $: strategyUrl = buildStrategyUrl(recipient, spouse);
-
-  function buildStrategyUrl(r: Recipient, s: Recipient | null): string {
-    const isSingle = !s;
-    const name1 =
-      r.name && r.name !== "Self" ? r.name : undefined;
-    const name2 =
-      s && s.name && s.name !== "Spouse" ? s.name : undefined;
-    const hash = buildStrategyHash({
-      isSingle,
-      pia1: r.pia().primaryInsuranceAmount().roundToDollar().value(),
-      dob1: formatDob(r),
-      name1,
-      gender1: r.gender === "male" || r.gender === "female" ? r.gender : "blended",
-      pia2: s
-        ? s.pia().primaryInsuranceAmount().roundToDollar().value()
-        : undefined,
-      dob2: s ? formatDob(s) : undefined,
-      name2,
-      gender2:
-        s && (s.gender === "male" || s.gender === "female")
-          ? s.gender
-          : "blended",
-    });
-    return `/strategy${hash}`;
-  }
 </script>
 
 <div class="pageBreakAvoid">
   <h3 class="subheading">Strategy Optimizer</h3>
-  {#if spouse}
-    <p class="pia-summary">
-      Your PIAs are <strong>{formatPia(recipient)}</strong> for
-      <RecipientName r={recipient} /> and
-      <strong>{formatPia(spouse)}</strong> for
-      <RecipientName r={spouse} /> — already pre-filled in the optimizer.
-    </p>
-  {:else}
-    <p class="pia-summary">
-      Your PIA is <strong>{formatPia(recipient)}</strong> — already
-      pre-filled in the optimizer.
-    </p>
-  {/if}
+  <p class="promo-intro">
+    {#if spouse}
+      The Strategy Optimizer finds the filing ages with the highest expected
+      combined lifetime benefit, and lets you explore how the answer shifts as
+      you adjust each person's health and your discount-rate assumptions.
+    {:else}
+      The Strategy Optimizer finds the filing age with the highest expected
+      lifetime benefit, and lets you explore how the answer shifts as you adjust
+      your health and discount-rate assumptions.
+    {/if}
+  </p>
+  <RecommendedFilingCard {recipient} {spouse} />
   <a class="cta-btn" href={strategyUrl}>
     Open Strategy Optimizer
     <svg
@@ -88,7 +50,7 @@
     color: #0b0c0c;
   }
 
-  .pia-summary {
+  .promo-intro {
     margin: 0 0.5rem 1rem;
     line-height: 1.5;
     color: #4b5563;

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -31,8 +31,9 @@ export function currentMonthDate(now: Date = new Date()): MonthDate {
 
 /**
  * Loads mortality (death-probability) distributions for the recipient and, if
- * present, the spouse. Depends only on birth year + gender, so callers can load
- * once and reuse across PIA changes.
+ * present, the spouse. The result depends on birth year, gender, and health
+ * multiplier (not PIA), so callers can cache it and skip reloading when only
+ * PIA changes.
  */
 export async function loadDeathDistributions(
   recipient: Recipient,

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -1,0 +1,129 @@
+import type { DeathProbability } from '$lib/life-tables';
+import { getDeathProbabilityDistribution } from '$lib/life-tables';
+import { MonthDate } from '$lib/month-time';
+import type { Recipient } from '$lib/recipient';
+import type {
+  CoupleFilingAgeResult,
+  FilingAgeResult,
+} from '$lib/strategy/calculations/expected-npv';
+import {
+  expectedNPVCoupleOptimized,
+  expectedNPVSingle,
+} from '$lib/strategy/calculations/expected-npv';
+import { buildStrategyHash } from '$lib/url-params';
+
+/** Default assumptions matching the strategy optimizer's initial state. */
+export const DEFAULT_DISCOUNT_RATE = 0.025;
+
+export interface RecommendedFiling {
+  readonly isSingle: boolean;
+  readonly single?: FilingAgeResult;
+  readonly couple?: CoupleFilingAgeResult;
+}
+
+/** Today's date as a MonthDate (SSA calculations operate on months). */
+export function currentMonthDate(now: Date = new Date()): MonthDate {
+  return MonthDate.initFromYearsMonths({
+    years: now.getFullYear(),
+    months: now.getMonth(),
+  });
+}
+
+/**
+ * Loads mortality (death-probability) distributions for the recipient and, if
+ * present, the spouse. Depends only on birth year + gender, so callers can load
+ * once and reuse across PIA changes.
+ */
+export async function loadDeathDistributions(
+  recipient: Recipient,
+  spouse: Recipient | null,
+  currentYear: number = new Date().getFullYear()
+): Promise<{ dist1: DeathProbability[]; dist2: DeathProbability[] | null }> {
+  if (!spouse) {
+    const dist1 = await getDeathProbabilityDistribution(recipient, currentYear);
+    return { dist1, dist2: null };
+  }
+  const [dist1, dist2] = await Promise.all([
+    getDeathProbabilityDistribution(recipient, currentYear),
+    getDeathProbabilityDistribution(spouse, currentYear),
+  ]);
+  return { dist1, dist2 };
+}
+
+/**
+ * Computes the single best filing recommendation from already-loaded
+ * distributions. Pure and synchronous so it is cheap to re-run on PIA changes.
+ * Returns null when inputs are insufficient or the optimizer yields nothing.
+ */
+export function recommendedFromDistributions(
+  recipient: Recipient,
+  spouse: Recipient | null,
+  dist1: DeathProbability[],
+  dist2: DeathProbability[] | null,
+  currentDate: MonthDate,
+  discountRate: number = DEFAULT_DISCOUNT_RATE
+): RecommendedFiling | null {
+  if (!spouse) {
+    const results = expectedNPVSingle(
+      recipient,
+      currentDate,
+      discountRate,
+      dist1
+    );
+    if (results.length === 0) return null;
+    return { isSingle: true, single: results[0] };
+  }
+  if (!dist2) return null;
+  const results = expectedNPVCoupleOptimized(
+    [recipient, spouse],
+    currentDate,
+    discountRate,
+    [dist1, dist2]
+  );
+  if (results.length === 0) return null;
+  return { isSingle: false, couple: results[0] };
+}
+
+function formatDob(r: Recipient): string {
+  const bd = r.birthdate;
+  const y = bd.layBirthYear();
+  const m = (bd.layBirthMonth() + 1).toString().padStart(2, '0');
+  const d = bd.layBirthDayOfMonth().toString().padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Builds the pre-filled `/strategy` URL for the recipient (and optional spouse).
+ * Shared by RecommendedFilingCard and StrategyPromo so both links stay in sync.
+ */
+export function buildStrategyUrl(
+  recipient: Recipient,
+  spouse: Recipient | null
+): string {
+  const isSingle = !spouse;
+  const name1 =
+    recipient.name && recipient.name !== 'Self' ? recipient.name : undefined;
+  const name2 =
+    spouse?.name && spouse.name !== 'Spouse' ? spouse.name : undefined;
+  const hash = buildStrategyHash({
+    isSingle,
+    pia1: recipient.pia().primaryInsuranceAmount().roundToDollar().value(),
+    dob1: formatDob(recipient),
+    name1,
+    gender1:
+      recipient.gender === 'male' || recipient.gender === 'female'
+        ? recipient.gender
+        : 'blended',
+    pia2: spouse
+      ? spouse.pia().primaryInsuranceAmount().roundToDollar().value()
+      : undefined,
+    dob2: spouse ? formatDob(spouse) : undefined,
+    name2,
+    gender2: spouse
+      ? spouse.gender === 'male' || spouse.gender === 'female'
+        ? spouse.gender
+        : 'blended'
+      : undefined,
+  });
+  return `/strategy${hash}`;
+}

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -35,7 +35,7 @@
     type FilingAgeResult,
     type CoupleFilingAgeResult,
   } from "$lib/strategy/calculations/expected-npv";
-  import OptimalStrategyHeadline from "./components/OptimalStrategyHeadline.svelte";
+  import OptimalStrategyHeadline from "$lib/components/OptimalStrategyHeadline.svelte";
   import SupportPrompt from "$lib/components/SupportPrompt.svelte";
   import {
     WebApplicationSchema,

--- a/src/stories/FullReport.stories.ts
+++ b/src/stories/FullReport.stories.ts
@@ -12,7 +12,7 @@ const r = new Recipient();
 r.name = 'Alex';
 r.markFirst();
 r.earningsRecords = parsePaste(demo);
-r.birthdate = Birthdate.FromYMD(1950, 6, 1);
+r.birthdate = Birthdate.FromYMD(1962, 6, 1);
 recipient.set(r);
 
 // This data is such that the spouse has a low enough PIA that they can claim
@@ -21,7 +21,7 @@ const spouseLowEarner = new Recipient();
 spouseLowEarner.name = 'Chris';
 spouseLowEarner.markSecond();
 spouseLowEarner.earningsRecords = parsePaste(demo_spouse_low);
-spouseLowEarner.birthdate = Birthdate.FromYMD(1950, 6, 1);
+spouseLowEarner.birthdate = Birthdate.FromYMD(1962, 6, 1);
 spouse.set(spouseLowEarner);
 
 const meta: Meta<App> = {

--- a/src/test/components/recommended-filing-card.test.ts
+++ b/src/test/components/recommended-filing-card.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Birthdate } from '$lib/birthday';
+import {
+  buildStrategyUrl,
+  currentMonthDate,
+  DEFAULT_DISCOUNT_RATE,
+  loadDeathDistributions,
+  recommendedFromDistributions,
+} from '$lib/components/recommended-filing-card';
+import type { DeathProbability } from '$lib/life-tables';
+import { Money } from '$lib/money';
+import { MonthDate } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+import {
+  expectedNPVCoupleOptimized,
+  expectedNPVSingle,
+} from '$lib/strategy/calculations/expected-npv';
+
+vi.mock('$lib/life-tables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/life-tables')>();
+  return { ...actual, getDeathProbabilityDistribution: vi.fn() };
+});
+
+import { getDeathProbabilityDistribution } from '$lib/life-tables';
+
+// Filing window is fixed at 62-70 when "now" is before the birthdate, matching
+// the existing expected-npv tests (FAR_PAST removes the "filing in the past"
+// truncation so results are deterministic).
+const FAR_PAST = MonthDate.initFromYearsMonths({ years: 200, months: 0 });
+
+function makeRecipient(
+  piaDollars: number,
+  birthYear: number,
+  opts: { name?: string; gender?: 'male' | 'female' | 'blended' } = {}
+): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(birthYear, 3, 15);
+  r.setPia(Money.from(piaDollars));
+  if (opts.name) r.name = opts.name;
+  if (opts.gender) r.gender = opts.gender;
+  return r;
+}
+
+describe('DEFAULT_DISCOUNT_RATE', () => {
+  it('is 2.5%', () => {
+    expect(DEFAULT_DISCOUNT_RATE).toBe(0.025);
+  });
+});
+
+describe('currentMonthDate', () => {
+  it('maps a JS Date to a MonthDate (month is 0-based)', () => {
+    const md = currentMonthDate(new Date(2025, 0, 15));
+    expect(md.year()).toBe(2025);
+    expect(md.monthName()).toBe('Jan');
+  });
+
+  it('maps December correctly (month index 11)', () => {
+    const md = currentMonthDate(new Date(2025, 11, 1));
+    expect(md.year()).toBe(2025);
+    expect(md.monthName()).toBe('Dec');
+  });
+});
+
+describe('loadDeathDistributions', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('single: loads only the recipient, dist2 is null', async () => {
+    const r = makeRecipient(1500, 1960);
+    const marker = [{ age: 80, probability: 1 }];
+    vi.mocked(getDeathProbabilityDistribution).mockResolvedValue(marker);
+
+    const { dist1, dist2 } = await loadDeathDistributions(r, null, 2025);
+
+    expect(dist1).toBe(marker);
+    expect(dist2).toBeNull();
+    expect(getDeathProbabilityDistribution).toHaveBeenCalledTimes(1);
+    expect(getDeathProbabilityDistribution).toHaveBeenCalledWith(r, 2025);
+  });
+
+  it('couple: loads both recipient and spouse', async () => {
+    const r1 = makeRecipient(2000, 1960);
+    const r2 = makeRecipient(800, 1962);
+    const m1 = [{ age: 80, probability: 1 }];
+    const m2 = [{ age: 82, probability: 1 }];
+    vi.mocked(getDeathProbabilityDistribution).mockImplementation(
+      async (rec) => (rec === r1 ? m1 : m2)
+    );
+
+    const { dist1, dist2 } = await loadDeathDistributions(r1, r2, 2025);
+
+    expect(dist1).toBe(m1);
+    expect(dist2).toBe(m2);
+    expect(getDeathProbabilityDistribution).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('recommendedFromDistributions', () => {
+  it('single: returns the top expectedNPVSingle result', () => {
+    const r = makeRecipient(1500, 1960);
+    const dist: DeathProbability[] = [
+      { age: 80, probability: 0.5 },
+      { age: 90, probability: 0.5 },
+    ];
+
+    const got = recommendedFromDistributions(r, null, dist, null, FAR_PAST, 0);
+    const expected = expectedNPVSingle(r, FAR_PAST, 0, dist)[0];
+
+    expect(got).not.toBeNull();
+    expect(got!.isSingle).toBe(true);
+    expect(got!.single!.filingAge.asMonths()).toBe(
+      expected.filingAge.asMonths()
+    );
+    expect(got!.single!.expectedNPVCents).toBe(expected.expectedNPVCents);
+  });
+
+  it('couple: returns the top expectedNPVCoupleOptimized result', () => {
+    const r1 = makeRecipient(2000, 1960);
+    const r2 = makeRecipient(800, 1962);
+    const dist1: DeathProbability[] = [
+      { age: 80, probability: 0.5 },
+      { age: 90, probability: 0.5 },
+    ];
+    const dist2: DeathProbability[] = [
+      { age: 82, probability: 0.5 },
+      { age: 92, probability: 0.5 },
+    ];
+
+    const got = recommendedFromDistributions(r1, r2, dist1, dist2, FAR_PAST, 0);
+    const expected = expectedNPVCoupleOptimized([r1, r2], FAR_PAST, 0, [
+      dist1,
+      dist2,
+    ])[0];
+
+    expect(got).not.toBeNull();
+    expect(got!.isSingle).toBe(false);
+    expect(got!.couple!.filingAges[0].asMonths()).toBe(
+      expected.filingAges[0].asMonths()
+    );
+    expect(got!.couple!.filingAges[1].asMonths()).toBe(
+      expected.filingAges[1].asMonths()
+    );
+    expect(got!.couple!.expectedNPVCents).toBe(expected.expectedNPVCents);
+  });
+
+  it('couple with missing spouse distribution returns null', () => {
+    const r1 = makeRecipient(2000, 1960);
+    const r2 = makeRecipient(800, 1962);
+    const dist1: DeathProbability[] = [{ age: 85, probability: 1.0 }];
+
+    const got = recommendedFromDistributions(r1, r2, dist1, null, FAR_PAST, 0);
+    expect(got).toBeNull();
+  });
+});
+
+describe('buildStrategyUrl', () => {
+  it('single: omits default name and blended gender', () => {
+    const r = makeRecipient(2000, 1960, { name: 'Self', gender: 'blended' });
+    expect(buildStrategyUrl(r, null)).toBe(
+      '/strategy#pia1=2000&dob1=1960-04-15'
+    );
+  });
+
+  it('couple: includes names and non-blended genders, pre-filled', () => {
+    const r1 = makeRecipient(2000, 1960, { name: 'Alex', gender: 'male' });
+    const r2 = makeRecipient(800, 1962, { name: 'Chris', gender: 'female' });
+    expect(buildStrategyUrl(r1, r2)).toBe(
+      '/strategy#pia1=2000&dob1=1960-04-15&name1=Alex&gender1=male' +
+        '&pia2=800&dob2=1962-04-15&name2=Chris&gender2=female'
+    );
+  });
+
+  it('couple: strips default "Spouse" name and blended gender', () => {
+    const r1 = makeRecipient(2000, 1960, { name: 'Self', gender: 'blended' });
+    const r2 = makeRecipient(800, 1962, { name: 'Spouse', gender: 'blended' });
+    expect(buildStrategyUrl(r1, r2)).toBe(
+      '/strategy#pia1=2000&dob1=1960-04-15&pia2=800&dob2=1962-04-15'
+    );
+  });
+});

--- a/src/test/components/recommended-filing-card.test.ts
+++ b/src/test/components/recommended-filing-card.test.ts
@@ -151,6 +151,41 @@ describe('recommendedFromDistributions', () => {
     const got = recommendedFromDistributions(r1, r2, dist1, null, FAR_PAST, 0);
     expect(got).toBeNull();
   });
+
+  it('single: returns null when the distribution is empty', () => {
+    const r = makeRecipient(1500, 1960);
+    const got = recommendedFromDistributions(r, null, [], null, FAR_PAST, 0);
+    expect(got).toBeNull();
+  });
+
+  it('defaults the discount rate to DEFAULT_DISCOUNT_RATE when omitted', () => {
+    const r = makeRecipient(1500, 1960);
+    const dist: DeathProbability[] = [
+      { age: 80, probability: 0.5 },
+      { age: 90, probability: 0.5 },
+    ];
+
+    const withDefault = recommendedFromDistributions(
+      r,
+      null,
+      dist,
+      null,
+      FAR_PAST
+    );
+    const withExplicit = recommendedFromDistributions(
+      r,
+      null,
+      dist,
+      null,
+      FAR_PAST,
+      DEFAULT_DISCOUNT_RATE
+    );
+
+    expect(withDefault).not.toBeNull();
+    expect(withDefault!.single!.expectedNPVCents).toBe(
+      withExplicit!.single!.expectedNPVCents
+    );
+  });
 });
 
 describe('buildStrategyUrl', () => {


### PR DESCRIPTION
## Summary

Adds a display-only "Recommended filing" card to the calculator's **Strategy Optimizer** section. It surfaces the strategy optimizer's best filing age (single) or ages (couple), computed with the optimizer's default assumptions (2.5% discount rate, blended life expectancy), and the whole card links into the pre-filled `/strategy` optimizer.

The card sits inside the Strategy Optimizer block: header → short explanatory copy → card → "Open Strategy Optimizer" button. The previous PIA summary line was replaced with copy that explains what the optimizer does and what clicking through offers.

## What changed

- **Move** `OptimalStrategyHeadline` from `routes/strategy/components/` into `$lib/components/` (it's now shared) and add an optional `showInfoTip` prop. The strategy page keeps the tooltip (default `true`); the calculator variant passes `false`, which hides the tooltip and appends a short default-assumptions note.
- **New** `recommended-filing-card.ts` — pure, unit-tested logic: optimal-result computation (reusing `expectedNPVSingle` / `expectedNPVCoupleOptimized`), mortality-distribution loading, and a shared `buildStrategyUrl`.
- **New** `RecommendedFilingCard.svelte` — thin shell that loads mortality once (keyed on gender + birth year), recomputes the recommendation on PIA changes (debounced), renders nothing until a result is ready, and wraps the shared card in the optimizer link.
- **Refactor** `StrategyPromo.svelte` to render the card and reuse the shared `buildStrategyUrl` (removing its private duplicate). The calculator page itself is unchanged (the card lives inside `StrategyPromo`).

## Notes

- Privacy preserved: all computation is client-side; nothing is logged or persisted.
- Single vs. couple copy/layout is handled by the shared `OptimalStrategyHeadline`.

## Test plan

- `npm run test` — all 2056 tests pass, incl. 13 new tests for the logic module (compute equivalence to `expectedNPV*`, exact pre-filled URL strings, mortality-load behavior).
- `npm run quality` — Biome + svelte-check clean.
- `npm run build` — all routes prerender.
- Manual: verified the card renders for both single and couple (pre-filled via URL hash), links to the matching pre-filled `/strategy`, and updates when earnings/PIA change.
