### PR TITLE
feat(guides): add Social Security COLA guide

### DIFF
--- a/src/lib/cola.ts
+++ b/src/lib/cola.ts
@@ -20,7 +20,7 @@ const LAST_MIDYEAR_COLA_YEAR = 1982;
  * announced in October 2025 is "the 2026 COLA". Readers search for that later
  * year, so anything user-facing should show `paymentYear`.
  */
-export interface ColaAdjustment {
+export interface AnnualCola {
   /** Year SSA announced the adjustment. The key in `constants.COLA`. */
   readonly announcementYear: number;
   /** Calendar year in which the larger payment first arrives. */
@@ -29,32 +29,44 @@ export interface ColaAdjustment {
   readonly percent: number;
 }
 
-function toAdjustment(announcementYear: number): ColaAdjustment {
+function toAnnualCola(announcementYear: number): AnnualCola {
+  const percent = COLA[announcementYear];
+  if (percent === undefined) {
+    throw new Error(`No COLA on record for ${announcementYear}`);
+  }
   return {
     announcementYear,
     paymentYear:
       announcementYear <= LAST_MIDYEAR_COLA_YEAR
         ? announcementYear
         : announcementYear + 1,
-    percent: COLA[announcementYear],
+    percent,
   };
 }
 
 /** Every COLA on record, oldest first. */
-export function colaHistory(): ColaAdjustment[] {
+export function colaHistory(): AnnualCola[] {
   return Object.keys(COLA)
     .map(Number)
     .sort((a, b) => a - b)
-    .map(toAdjustment);
+    .map(toAnnualCola);
 }
 
-/** The most recent COLA, which is the increase currently being paid. */
-export function latestCola(): ColaAdjustment {
-  return toAdjustment(MAX_COLA_YEAR);
+/**
+ * The most recently announced adjustment.
+ *
+ * SSA announces in October and the larger payment arrives the following
+ * January, so between those two dates this adjustment is public knowledge but
+ * is not yet reflected in anyone's check. Compare `paymentYear` against the
+ * current year before describing it in the past tense.
+ */
+export function latestAnnouncedCola(): AnnualCola {
+  return toAnnualCola(MAX_COLA_YEAR);
 }
 
 /** Arithmetic mean of every COLA on record, in whole percent. */
 export function averageCola(): number {
-  const percents = Object.values(COLA);
-  return percents.reduce((sum, percent) => sum + percent, 0) / percents.length;
+  const all = colaHistory();
+  const sum = all.reduce((total, adjustment) => total + adjustment.percent, 0);
+  return sum / all.length;
 }

--- a/src/lib/cola.ts
+++ b/src/lib/cola.ts
@@ -1,0 +1,60 @@
+import { COLA, MAX_COLA_YEAR } from './constants';
+
+/**
+ * Last year in which a COLA took effect mid-year rather than in December.
+ *
+ * Adjustments announced for 1975 through 1982 took effect with benefits
+ * payable for June of the same year. From 1983 on, a COLA takes effect with
+ * benefits payable for December, which beneficiaries receive the following
+ * January.
+ */
+const LAST_MIDYEAR_COLA_YEAR = 1982;
+
+/**
+ * One annual cost-of-living adjustment, carrying both of the years people use
+ * to name it.
+ *
+ * `constants.COLA` is keyed the way SSA publishes its series, by the year an
+ * adjustment is announced and takes effect. The public names an adjustment
+ * after the year the larger payment actually arrives instead: the increase
+ * announced in October 2025 is "the 2026 COLA". Readers search for that later
+ * year, so anything user-facing should show `paymentYear`.
+ */
+export interface ColaAdjustment {
+  /** Year SSA announced the adjustment. The key in `constants.COLA`. */
+  readonly announcementYear: number;
+  /** Calendar year in which the larger payment first arrives. */
+  readonly paymentYear: number;
+  /** Increase in whole percent, e.g. 2.8 for 2.8%. */
+  readonly percent: number;
+}
+
+function toAdjustment(announcementYear: number): ColaAdjustment {
+  return {
+    announcementYear,
+    paymentYear:
+      announcementYear <= LAST_MIDYEAR_COLA_YEAR
+        ? announcementYear
+        : announcementYear + 1,
+    percent: COLA[announcementYear],
+  };
+}
+
+/** Every COLA on record, oldest first. */
+export function colaHistory(): ColaAdjustment[] {
+  return Object.keys(COLA)
+    .map(Number)
+    .sort((a, b) => a - b)
+    .map(toAdjustment);
+}
+
+/** The most recent COLA, which is the increase currently being paid. */
+export function latestCola(): ColaAdjustment {
+  return toAdjustment(MAX_COLA_YEAR);
+}
+
+/** Arithmetic mean of every COLA on record, in whole percent. */
+export function averageCola(): number {
+  const percents = Object.values(COLA);
+  return percents.reduce((sum, percent) => sum + percent, 0) / percents.length;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -451,6 +451,22 @@ export const COLA: { [key: number]: number } = {
 export const MAX_COLA_YEAR: number = Math.max(...Object.keys(COLA).map(Number));
 
 /**
+ * Standard monthly Medicare Part B premium, keyed by the year it applies to.
+ *
+ * Most beneficiaries have this deducted from their Social Security payment, so
+ * it determines how much of a COLA actually reaches the bank account. Set by
+ * CMS rather than SSA and announced each November, one month after the COLA.
+ * Higher earners pay income-related surcharges on top of these amounts.
+ *
+ * Values from https://www.cms.gov/newsroom/fact-sheets
+ */
+export const MEDICARE_PART_B_PREMIUM: { [key: number]: Money } = {
+  2024: Money.from(174.7),
+  2025: Money.from(185.0),
+  2026: Money.from(202.9),
+};
+
+/**
  * Number of top years of earnings which contribute to SSA calculations.
  */
 export const SSA_EARNINGS_YEARS: number = 35;

--- a/src/routes/guides/+page.svelte
+++ b/src/routes/guides/+page.svelte
@@ -27,6 +27,20 @@ const pageImageAlt = 'Social Security guides and educational resources';
     <h1>Social Security Guides</h1>
     <ul class="guides">
       <li>
+        <span class="postdate">Sep 10, 2026</span>
+        <h3 class="posttitle">
+          <a href="/guides/cola">
+            Social Security COLA: How the Annual Increase Works
+          </a>
+        </h3>
+        <p class="description">
+          How the cost-of-living adjustment is calculated from the CPI-W, when
+          it reaches your check, why you receive it even before you file, the
+          full history since 1975, and what else changes each January.
+        </p>
+      </li>
+
+      <li>
         <span class="postdate">Sep 9, 2026</span>
         <h3 class="posttitle">
           <a href="/guides/spousal-benefits">

--- a/src/routes/guides/cola/+page.svelte
+++ b/src/routes/guides/cola/+page.svelte
@@ -1,0 +1,379 @@
+<script lang="ts">
+import { averageCola, colaHistory, latestCola } from '$lib/cola';
+import { Money } from '$lib/money';
+import { type FAQItem, GuidesSchema, renderFAQSchema } from '$lib/schema-org';
+import GuideFooter from '../guide-footer.svelte';
+import InlineCTA from '../InlineCTA.svelte';
+
+const latest = latestCola();
+const history = colaHistory();
+const newestFirst = [...history].reverse();
+const recent = newestFirst.slice(0, 10);
+const average = averageCola();
+
+// Years in which prices did not rise enough to produce any increase.
+const zeroYears = history
+  .filter((adjustment) => adjustment.percent === 0)
+  .map((adjustment) => adjustment.paymentYear);
+const zeroYearsText = `${zeroYears.slice(0, -1).join(', ')}, and ${zeroYears[zeroYears.length - 1]}`;
+
+// The adjustment that has not been announced yet at publication time.
+const nextAnnouncementYear = latest.announcementYear + 1;
+const nextPaymentYear = latest.paymentYear + 1;
+
+// A round benefit makes the percentage concrete.
+const exampleBenefit = Money.from(2000);
+const exampleIncrease = exampleBenefit.times(latest.percent / 100);
+const exampleTotal = exampleBenefit.plus(exampleIncrease);
+
+// Medicare figures are published each November and are not part of
+// constants.ts. Update these alongside the annual SSA constants.
+const partBPremium = Money.from(202.9);
+const partBIncrease = Money.from(17.9);
+
+const title = `Social Security COLA ${latest.paymentYear}: What the ${latest.percent}% Increase Means`;
+const description = `Social Security benefits rose ${latest.percent}% in ${latest.paymentYear}. Learn how the cost-of-living adjustment is calculated, when it reaches your check, whether you receive it before you file, and what else changes in January.`;
+const publishDate = new Date('2026-09-10T00:00:00+00:00');
+const updateDate = new Date('2026-09-10T00:00:00+00:00');
+
+let schema: GuidesSchema = new GuidesSchema();
+schema.url = 'https://ssa.tools/guides/cola';
+schema.title = title;
+schema.image = '/laptop-piggybank.jpg';
+schema.datePublished = publishDate.toISOString();
+schema.dateModified = updateDate.toISOString();
+schema.description = description;
+schema.imageAlt = 'Social Security calculator showing cost-of-living adjustments';
+schema.tags = [
+  'Social Security COLA',
+  `COLA ${latest.paymentYear}`,
+  'cost of living adjustment',
+  'CPI-W',
+  'Social Security raise',
+  'Social Security increase',
+  'Medicare Part B premium',
+];
+
+const faqs: FAQItem[] = [
+  {
+    question: `When is the ${nextPaymentYear} COLA announced?`,
+    answer: `Social Security announces the ${nextPaymentYear} cost-of-living adjustment in mid-October ${nextAnnouncementYear}, once the Bureau of Labor Statistics publishes September inflation data. The figure is set by the CPI-W for July, August, and September compared with the same three months a year earlier.`,
+  },
+  {
+    question: 'Do I get the COLA if I have not started benefits yet?',
+    answer:
+      'Yes. Cost-of-living adjustments are applied to your benefit formula starting with the year you turn 62, whether or not you have filed. Waiting to claim does not cost you any COLA. Before 62, your earnings are protected by wage indexing instead.',
+  },
+  {
+    question: 'Can a COLA ever reduce my benefit?',
+    answer: `No. If consumer prices fall, the adjustment is zero rather than negative, and your benefit stays where it is. That has happened in ${zeroYearsText}.`,
+  },
+  {
+    question: 'Does the COLA apply to spousal and survivor benefits?',
+    answer:
+      'Yes. The same percentage applies to every kind of Social Security payment, including spousal, survivor, disability, and Supplemental Security Income.',
+  },
+  {
+    question: 'Why is my raise smaller than the announced percentage?',
+    answer:
+      'For most people the Medicare Part B premium is deducted from the same check, and it usually rises in January too. The announced percentage applies to your gross benefit, so the amount deposited grows by less.',
+  },
+];
+</script>
+
+<svelte:head>
+  <title>{title}</title>
+  <meta name="description" content={description} />
+  <link rel="canonical" href="https://ssa.tools/guides/cola" />
+  {@html schema.render()}
+  {@html schema.renderSocialMeta()}
+  {@html renderFAQSchema(faqs)}
+</svelte:head>
+
+<div class="guide-page">
+  <h1>Social Security COLA {latest.paymentYear}</h1>
+  <p class="postdate">Published: {publishDate.toLocaleDateString()}</p>
+
+  <p>
+    Social Security benefits rose {latest.percent}% in {latest.paymentYear}.
+    The increase, called a cost-of-living adjustment, was announced in October
+    {latest.announcementYear} and first appeared in the payment for January
+    {latest.paymentYear}.
+  </p>
+
+  <div class="headline-box">
+    <h3>The {latest.paymentYear} adjustment</h3>
+    <p>
+      A gross benefit of {exampleBenefit.wholeDollars()} a month becomes
+      {exampleTotal.wholeDollars()}, an increase of
+      {exampleIncrease.wholeDollars()} a month. Your own increase is the same
+      percentage applied to whatever you were receiving in December.
+    </p>
+  </div>
+
+  <p>
+    This guide covers how the figure is calculated, when it reaches your check,
+    why you receive it even if you have not filed yet, and what else changes at
+    the same time.
+  </p>
+
+  <h2>How the COLA Is Calculated</h2>
+
+  <p>
+    The adjustment is tied to the Consumer Price Index for Urban Wage Earners
+    and Clerical Workers, known as CPI-W. Social Security averages that index
+    for July, August, and September, then compares it with the same three
+    months of the previous year. The percentage change, rounded to the nearest
+    tenth of a percent, becomes the COLA.
+  </p>
+
+  <p>
+    Because the third quarter ends in September, the figure is announced in
+    mid-October and takes effect a few months later. Nothing about your own
+    earnings or filing age enters the calculation. Every beneficiary receives
+    the same percentage.
+  </p>
+
+  <p>
+    A COLA can never be negative. If prices fall, the adjustment is zero and
+    benefits stay flat rather than dropping. That has happened in {zeroYearsText}.
+  </p>
+
+  <h2>When It Reaches Your Check</h2>
+
+  <p>
+    The adjustment officially applies to benefits for December, and Social
+    Security pays December benefits in January. So the first larger payment
+    arrives in January {latest.paymentYear}. Supplemental Security Income
+    recipients see it slightly earlier, at the end of December.
+  </p>
+
+  <p>
+    Social Security posts a personalized COLA notice in early December showing
+    your new amount. It appears in the message center of your my Social
+    Security account, and is mailed to people who have not opted out of paper
+    notices.
+  </p>
+
+  <InlineCTA type="calculator" />
+
+  <h2>You Get the COLA Before You File</h2>
+
+  <p>
+    This is the most common misunderstanding about cost-of-living adjustments.
+    You do not have to be receiving benefits to get one. Adjustments are
+    applied to your
+    <a href="/guides/pia">Primary Insurance Amount</a> starting with the year
+    you turn 62, whether or not you have claimed.
+  </p>
+
+  <p>
+    Delaying your filing date therefore costs you nothing in COLAs. Every
+    adjustment announced between 62 and the month you file is already built
+    into your first payment. This is separate from
+    <a href="/guides/delayed-retirement-credits">delayed retirement credits</a>,
+    which are an additional increase for waiting past your
+    <a href="/guides/nra">Normal Retirement Age</a>.
+  </p>
+
+  <p>
+    Before you turn 62, your record is protected a different way. Past earnings
+    are restated in current terms through
+    <a href="/guides/indexing-factors">wage indexing</a>, which tracks average
+    wages rather than prices. Our guide on
+    <a href="/guides/inflation">inflation and Social Security</a> covers the
+    handoff between the two.
+  </p>
+
+  <h2>COLA History</h2>
+
+  <p>
+    Automatic annual adjustments began in 1975. The average since then is
+    {average.toFixed(1)}%, though the range is wide. The table below shows the
+    last ten years by the year each increase was first paid.
+  </p>
+
+  <div class="table-scroll">
+    <table class="cola-table">
+      <thead>
+        <tr>
+          <th>First paid</th>
+          <th>Increase</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each recent as adjustment}
+          <tr>
+            <td>{adjustment.paymentYear}</td>
+            <td>{adjustment.percent.toFixed(1)}%</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <p>
+    The years with no increase at all were {zeroYearsText}. In each case
+    consumer prices had fallen or barely moved over the measuring period,
+    usually following a drop in energy prices.
+  </p>
+
+  <details class="full-history">
+    <summary>Show every adjustment since 1975</summary>
+    <div class="table-scroll">
+      <table class="cola-table">
+        <thead>
+          <tr>
+            <th>First paid</th>
+            <th>Increase</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each newestFirst as adjustment}
+            <tr>
+              <td>{adjustment.paymentYear}</td>
+              <td>{adjustment.percent.toFixed(1)}%</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+    <p class="footnote">
+      Adjustments announced for 1975 through 1982 took effect in June of the
+      same year. Since 1983 an adjustment applies to December benefits, which
+      arrive the following January, so those rows are listed under the later
+      year.
+    </p>
+  </details>
+
+  <h2>What Else Changes in January</h2>
+
+  <h3>Medicare Part B</h3>
+  <p>
+    Most people have the Part B premium deducted from their Social Security
+    payment, and it is set separately from the COLA. The standard premium is
+    {partBPremium.string()} a month in {latest.paymentYear}, up
+    {partBIncrease.string()} from the year before. That deduction comes out of
+    the same check, so the amount deposited rises by less than the headline
+    percentage.
+  </p>
+
+  <p>
+    A rule known as hold harmless protects most beneficiaries from going
+    backwards. If your dollar COLA is smaller than the increase in your Part B
+    premium, the premium increase is limited so your net payment does not fall
+    below the previous year. It does not apply to people paying
+    income-related premium surcharges or those new to Medicare that year.
+  </p>
+
+  <h3>Limits That Move With Wages, Not Prices</h3>
+  <p>
+    Two figures change every January but are driven by average wage growth
+    rather than the COLA, so they rise by a different percentage. The first is
+    the <a href="/guides/earnings-cap">taxable maximum</a>, the ceiling on
+    earnings that count toward Social Security. The second is the
+    <a href="/guides/earnings-test">earnings test</a> limit, which affects
+    people who work while collecting before Normal Retirement Age.
+  </p>
+
+  <h3>Tax Thresholds That Never Change</h3>
+  <p>
+    The income thresholds that determine how much of your benefit is subject to
+    federal income tax are not indexed at all. They have been fixed since 1984
+    and 1993. Each COLA therefore pushes a few more people over them, which is
+    why the share of beneficiaries owing tax on benefits keeps growing. See our
+    guide on <a href="/guides/federal-taxes">federal taxation of benefits</a>.
+  </p>
+
+  <h2>Why the Increase Can Feel Too Small</h2>
+
+  <p>
+    CPI-W measures spending by working-age wage earners. Retirees spend a
+    larger share of their budget on health care and housing and a smaller share
+    on gasoline and clothing, so their personal inflation rate can differ.
+  </p>
+
+  <p>
+    The Bureau of Labor Statistics publishes an experimental index for people
+    62 and older, CPI-E, which has usually risen slightly faster than CPI-W.
+    Proposals to switch the COLA to CPI-E come up regularly in Congress. Others
+    propose a slower-growing measure instead. No change has been enacted, and
+    CPI-W remains the basis today.
+  </p>
+
+  <h2>Frequently Asked Questions</h2>
+
+  {#each faqs as faq}
+    <h3>{faq.question}</h3>
+    <p>{faq.answer}</p>
+  {/each}
+
+  <h2>See Your Own Numbers</h2>
+
+  <p>
+    The <a href="/calculator">SSA.tools calculator</a> applies every
+    cost-of-living adjustment on record to your earnings history, so the
+    benefit it shows already reflects the {latest.paymentYear} increase. Paste
+    your earnings record from ssa.gov and it will show your benefit at every
+    possible filing date, in today's dollars.
+  </p>
+
+  <GuideFooter />
+</div>
+
+<style>
+  .headline-box {
+    background-color: #fff3e0;
+    border: 1px solid #ff9800;
+    border-radius: 8px;
+    padding: 20px;
+    margin: 20px 0;
+  }
+
+  .headline-box h3 {
+    margin-top: 0;
+    color: #e65100;
+  }
+
+  .headline-box p {
+    margin-bottom: 0;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+    margin: 20px 0;
+  }
+
+  .cola-table {
+    width: fit-content;
+    min-width: 260px;
+    border-collapse: collapse;
+    margin: 0 auto;
+  }
+
+  .cola-table th,
+  .cola-table td {
+    border: 1px solid #ccc;
+    padding: 8px 24px;
+    text-align: left;
+  }
+
+  .cola-table th {
+    background-color: #f5f5f5;
+  }
+
+  .full-history {
+    margin: 20px 0;
+  }
+
+  .full-history summary {
+    cursor: pointer;
+    font-weight: bold;
+    padding: 8px 0;
+  }
+
+  .footnote {
+    font-size: 0.9em;
+    color: #555;
+  }
+</style>

--- a/src/routes/guides/cola/+page.svelte
+++ b/src/routes/guides/cola/+page.svelte
@@ -1,38 +1,70 @@
 <script lang="ts">
-import { averageCola, colaHistory, latestCola } from '$lib/cola';
+import {
+  type AnnualCola,
+  averageCola,
+  colaHistory,
+  latestAnnouncedCola,
+} from '$lib/cola';
+import { CURRENT_YEAR, MEDICARE_PART_B_PREMIUM } from '$lib/constants';
 import { Money } from '$lib/money';
 import { type FAQItem, GuidesSchema, renderFAQSchema } from '$lib/schema-org';
 import GuideFooter from '../guide-footer.svelte';
 import InlineCTA from '../InlineCTA.svelte';
 
-const latest = latestCola();
+const headline = latestAnnouncedCola();
 const history = colaHistory();
 const newestFirst = [...history].reverse();
 const recent = newestFirst.slice(0, 10);
 const average = averageCola();
 
-// Years in which prices did not rise enough to produce any increase.
-const zeroYears = history
-  .filter((adjustment) => adjustment.percent === 0)
-  .map((adjustment) => adjustment.paymentYear);
-const zeroYearsText = `${zeroYears.slice(0, -1).join(', ')}, and ${zeroYears[zeroYears.length - 1]}`;
+// SSA announces in October and the larger payment arrives the following
+// January, so for part of every year the newest adjustment is public but has
+// not reached anyone's check. Every tense on this page follows this flag.
+const isBeingPaid = headline.paymentYear <= CURRENT_YEAR;
 
-// The adjustment that has not been announced yet at publication time.
-const nextAnnouncementYear = latest.announcementYear + 1;
-const nextPaymentYear = latest.paymentYear + 1;
+const nextPaymentYear = headline.paymentYear + 1;
+const nextAnnouncementYear = headline.announcementYear + 1;
+
+function percentText(adjustment: AnnualCola): string {
+  return `${adjustment.percent.toFixed(1)}%`;
+}
+
+function yearList(years: number[]): string {
+  if (years.length <= 1) return years.join('');
+  if (years.length === 2) return `${years[0]} and ${years[1]}`;
+  return `${years.slice(0, -1).join(', ')}, and ${years[years.length - 1]}`;
+}
+
+// Years in which prices did not rise enough to produce any increase.
+const zeroYearsText = yearList(
+  history.filter((a) => a.percent === 0).map((a) => a.paymentYear)
+);
 
 // A round benefit makes the percentage concrete.
 const exampleBenefit = Money.from(2000);
-const exampleIncrease = exampleBenefit.times(latest.percent / 100);
+const exampleIncrease = exampleBenefit.times(headline.percent / 100);
 const exampleTotal = exampleBenefit.plus(exampleIncrease);
 
-// Medicare figures are published each November and are not part of
-// constants.ts. Update these alongside the annual SSA constants.
-const partBPremium = Money.from(202.9);
-const partBIncrease = Money.from(17.9);
+// Medicare premiums are set by CMS a month after the COLA is announced, so the
+// newest COLA year may not have one yet. Show the most recent year we have and
+// label it, rather than attaching a stale figure to the wrong year.
+const partBYears = Object.keys(MEDICARE_PART_B_PREMIUM)
+  .map(Number)
+  .sort((a, b) => a - b)
+  .filter((year) => year <= headline.paymentYear);
+const partBYear =
+  partBYears.length > 0 ? partBYears[partBYears.length - 1] : undefined;
+const partBPremium =
+  partBYear === undefined ? undefined : MEDICARE_PART_B_PREMIUM[partBYear];
+const partBPrior =
+  partBYear === undefined ? undefined : MEDICARE_PART_B_PREMIUM[partBYear - 1];
+const partBIncrease =
+  partBPremium === undefined || partBPrior === undefined
+    ? undefined
+    : partBPremium.sub(partBPrior);
 
-const title = `Social Security COLA ${latest.paymentYear}: What the ${latest.percent}% Increase Means`;
-const description = `Social Security benefits rose ${latest.percent}% in ${latest.paymentYear}. Learn how the cost-of-living adjustment is calculated, when it reaches your check, whether you receive it before you file, and what else changes in January.`;
+const title = `Social Security COLA ${headline.paymentYear}: What the ${percentText(headline)} Increase Means`;
+const description = `Social Security benefits ${isBeingPaid ? 'rose' : 'will rise'} ${percentText(headline)} in ${headline.paymentYear}. Learn how the cost-of-living adjustment is calculated, when it reaches your check, whether you receive it before you file, and what else changes in January.`;
 const publishDate = new Date('2026-09-10T00:00:00+00:00');
 const updateDate = new Date('2026-09-10T00:00:00+00:00');
 
@@ -43,10 +75,11 @@ schema.image = '/laptop-piggybank.jpg';
 schema.datePublished = publishDate.toISOString();
 schema.dateModified = updateDate.toISOString();
 schema.description = description;
-schema.imageAlt = 'Social Security calculator showing cost-of-living adjustments';
+schema.imageAlt =
+  'Social Security calculator showing cost-of-living adjustments';
 schema.tags = [
   'Social Security COLA',
-  `COLA ${latest.paymentYear}`,
+  `COLA ${headline.paymentYear}`,
   'cost of living adjustment',
   'CPI-W',
   'Social Security raise',
@@ -57,12 +90,12 @@ schema.tags = [
 const faqs: FAQItem[] = [
   {
     question: `When is the ${nextPaymentYear} COLA announced?`,
-    answer: `Social Security announces the ${nextPaymentYear} cost-of-living adjustment in mid-October ${nextAnnouncementYear}, once the Bureau of Labor Statistics publishes September inflation data. The figure is set by the CPI-W for July, August, and September compared with the same three months a year earlier.`,
+    answer: `Social Security announces the ${nextPaymentYear} cost-of-living adjustment in October ${nextAnnouncementYear}, once the Bureau of Labor Statistics publishes September inflation data. The date moves with that release, so it can fall late in the month.`,
   },
   {
     question: 'Do I get the COLA if I have not started benefits yet?',
     answer:
-      'Yes. Cost-of-living adjustments are applied to your benefit formula starting with the year you turn 62, whether or not you have filed. Waiting to claim does not cost you any COLA. Before 62, your earnings are protected by wage indexing instead.',
+      'Yes. Cost-of-living adjustments are applied to your benefit formula starting with the year you turn 62, whether or not you have filed. Waiting to claim does not cost you any COLA.',
   },
   {
     question: 'Can a COLA ever reduce my benefit?',
@@ -91,20 +124,23 @@ const faqs: FAQItem[] = [
 </svelte:head>
 
 <div class="guide-page">
-  <h1>Social Security COLA {latest.paymentYear}</h1>
+  <h1>Social Security COLA {headline.paymentYear}</h1>
   <p class="postdate">Published: {publishDate.toLocaleDateString()}</p>
 
   <p>
-    Social Security benefits rose {latest.percent}% in {latest.paymentYear}.
-    The increase, called a cost-of-living adjustment, was announced in October
-    {latest.announcementYear} and first appeared in the payment for January
-    {latest.paymentYear}.
+    Social Security benefits {isBeingPaid ? 'rose' : 'will rise'}
+    {percentText(headline)} in {headline.paymentYear}. The increase, called a
+    cost-of-living adjustment, was announced in October
+    {headline.announcementYear} and
+    {isBeingPaid ? 'first appeared in' : 'takes effect with'} the payment for
+    January {headline.paymentYear}.
   </p>
 
   <div class="headline-box">
-    <h3>The {latest.paymentYear} adjustment</h3>
+    <h3>The {headline.paymentYear} adjustment</h3>
     <p>
-      A gross benefit of {exampleBenefit.wholeDollars()} a month becomes
+      A gross benefit of {exampleBenefit.wholeDollars()} a month
+      {isBeingPaid ? 'became' : 'becomes'}
       {exampleTotal.wholeDollars()}, an increase of
       {exampleIncrease.wholeDollars()} a month. Your own increase is the same
       percentage applied to whatever you were receiving in December.
@@ -123,13 +159,19 @@ const faqs: FAQItem[] = [
     The adjustment is tied to the Consumer Price Index for Urban Wage Earners
     and Clerical Workers, known as CPI-W. Social Security averages that index
     for July, August, and September, then compares it with the same three
-    months of the previous year. The percentage change, rounded to the nearest
-    tenth of a percent, becomes the COLA.
+    months of the last year in which a COLA took effect. The percentage change,
+    rounded to the nearest tenth of a percent, becomes the COLA.
+  </p>
+
+  <p>
+    In most years the comparison is simply against the year before. After a
+    year with no increase the comparison reaches further back, to the last year
+    that produced one, so no inflation is skipped.
   </p>
 
   <p>
     Because the third quarter ends in September, the figure is announced in
-    mid-October and takes effect a few months later. Nothing about your own
+    October and takes effect a few months later. Nothing about your own
     earnings or filing age enters the calculation. Every beneficiary receives
     the same percentage.
   </p>
@@ -144,15 +186,17 @@ const faqs: FAQItem[] = [
   <p>
     The adjustment officially applies to benefits for December, and Social
     Security pays December benefits in January. So the first larger payment
-    arrives in January {latest.paymentYear}. Supplemental Security Income
-    recipients see it slightly earlier, at the end of December.
+    {isBeingPaid ? 'arrived' : 'arrives'} in January {headline.paymentYear}.
+    Supplemental Security Income works slightly differently. The increase
+    applies to the January payment, and January SSI is always issued on the last
+    business day of December because the first of the month is a holiday.
   </p>
 
   <p>
-    Social Security posts a personalized COLA notice in early December showing
-    your new amount. It appears in the message center of your my Social
-    Security account, and is mailed to people who have not opted out of paper
-    notices.
+    Social Security posts a personalized COLA notice in the message center of
+    your my Social Security account in late November, along with your new
+    Medicare premium. Paper notices are mailed starting in early December to
+    people who have not opted out of them.
   </p>
 
   <InlineCTA type="calculator" />
@@ -177,10 +221,12 @@ const faqs: FAQItem[] = [
   </p>
 
   <p>
-    Before you turn 62, your record is protected a different way. Past earnings
-    are restated in current terms through
-    <a href="/guides/indexing-factors">wage indexing</a>, which tracks average
-    wages rather than prices. Our guide on
+    Earlier in your career a different mechanism does the work. Your past
+    earnings are restated relative to the average wage level of the year you
+    turn 60, through
+    <a href="/guides/indexing-factors">wage indexing</a>, which tracks wages
+    rather than prices. Earnings from age 60 onward, including 61 and 62, count
+    at face value. Our guide on
     <a href="/guides/inflation">inflation and Social Security</a> covers the
     handoff between the two.
   </p>
@@ -205,7 +251,7 @@ const faqs: FAQItem[] = [
         {#each recent as adjustment}
           <tr>
             <td>{adjustment.paymentYear}</td>
-            <td>{adjustment.percent.toFixed(1)}%</td>
+            <td>{percentText(adjustment)}</td>
           </tr>
         {/each}
       </tbody>
@@ -232,7 +278,7 @@ const faqs: FAQItem[] = [
           {#each newestFirst as adjustment}
             <tr>
               <td>{adjustment.paymentYear}</td>
-              <td>{adjustment.percent.toFixed(1)}%</td>
+              <td>{percentText(adjustment)}</td>
             </tr>
           {/each}
         </tbody>
@@ -242,47 +288,57 @@ const faqs: FAQItem[] = [
       Adjustments announced for 1975 through 1982 took effect in June of the
       same year. Since 1983 an adjustment applies to December benefits, which
       arrive the following January, so those rows are listed under the later
-      year.
+      year. Source:
+      <a href="https://www.ssa.gov/oact/cola/colaseries.html">
+        SSA cost-of-living adjustment series
+      </a>.
     </p>
   </details>
 
   <h2>What Else Changes in January</h2>
 
   <h3>Medicare Part B</h3>
-  <p>
-    Most people have the Part B premium deducted from their Social Security
-    payment, and it is set separately from the COLA. The standard premium is
-    {partBPremium.string()} a month in {latest.paymentYear}, up
-    {partBIncrease.string()} from the year before. That deduction comes out of
-    the same check, so the amount deposited rises by less than the headline
-    percentage.
-  </p>
+  {#if partBPremium !== undefined && partBYear !== undefined}
+    <p>
+      Most people have the Part B premium deducted from their Social Security
+      payment, and it is set separately from the COLA. The standard premium is
+      {partBPremium.string()} a month in {partBYear}{#if partBIncrease !== undefined}, up
+        {partBIncrease.string()} from the year before{/if}. That deduction comes
+      out of the same check, so the amount deposited rises by less than the
+      headline percentage. Higher earners pay an income-related surcharge on top
+      of the standard premium.
+    </p>
+  {/if}
 
   <p>
     A rule known as hold harmless protects most beneficiaries from going
     backwards. If your dollar COLA is smaller than the increase in your Part B
     premium, the premium increase is limited so your net payment does not fall
-    below the previous year. It does not apply to people paying
-    income-related premium surcharges or those new to Medicare that year.
+    below the previous year. It does not cover everyone. People paying
+    income-related surcharges, those new to Medicare that year, those not yet
+    collecting Social Security, and those whose premiums Medicaid pays are all
+    outside it.
   </p>
 
   <h3>Limits That Move With Wages, Not Prices</h3>
   <p>
-    Two figures change every January but are driven by average wage growth
+    Two figures change most Januarys but are driven by average wage growth
     rather than the COLA, so they rise by a different percentage. The first is
     the <a href="/guides/earnings-cap">taxable maximum</a>, the ceiling on
     earnings that count toward Social Security. The second is the
     <a href="/guides/earnings-test">earnings test</a> limit, which affects
-    people who work while collecting before Normal Retirement Age.
+    people who work while collecting before Normal Retirement Age. Neither one
+    rises in a year when no COLA is payable.
   </p>
 
   <h3>Tax Thresholds That Never Change</h3>
   <p>
     The income thresholds that determine how much of your benefit is subject to
-    federal income tax are not indexed at all. They have been fixed since 1984
-    and 1993. Each COLA therefore pushes a few more people over them, which is
-    why the share of beneficiaries owing tax on benefits keeps growing. See our
-    guide on <a href="/guides/federal-taxes">federal taxation of benefits</a>.
+    federal income tax are not indexed at all. They have been fixed since the
+    1984 and 1994 tax years. Each COLA therefore pushes a few more people over
+    them, which is why the share of beneficiaries owing tax on benefits keeps
+    growing. See our guide on
+    <a href="/guides/federal-taxes">federal taxation of benefits</a>.
   </p>
 
   <h2>Why the Increase Can Feel Too Small</h2>
@@ -294,11 +350,12 @@ const faqs: FAQItem[] = [
   </p>
 
   <p>
-    The Bureau of Labor Statistics publishes an experimental index for people
-    62 and older, CPI-E, which has usually risen slightly faster than CPI-W.
-    Proposals to switch the COLA to CPI-E come up regularly in Congress. Others
-    propose a slower-growing measure instead. No change has been enacted, and
-    CPI-W remains the basis today.
+    The Bureau of Labor Statistics publishes a research index for people 62 and
+    older, CPI-E. It rose faster than CPI-W through the 1980s and 1990s, but the
+    gap has narrowed since, and in some years it would have produced a smaller
+    increase rather than a larger one. Proposals to switch the COLA to CPI-E
+    come up regularly in Congress, as do proposals for a slower-growing measure.
+    No change has been enacted, and CPI-W remains the basis today.
   </p>
 
   <h2>Frequently Asked Questions</h2>
@@ -313,9 +370,9 @@ const faqs: FAQItem[] = [
   <p>
     The <a href="/calculator">SSA.tools calculator</a> applies every
     cost-of-living adjustment on record to your earnings history, so the
-    benefit it shows already reflects the {latest.paymentYear} increase. Paste
-    your earnings record from ssa.gov and it will show your benefit at every
-    possible filing date, in today's dollars.
+    benefit it shows already reflects them. Paste your earnings record from
+    ssa.gov and it will show your benefit at every possible filing date, in
+    today's dollars.
   </p>
 
   <GuideFooter />

--- a/src/routes/guides/delayed-retirement-credits/+page.svelte
+++ b/src/routes/guides/delayed-retirement-credits/+page.svelte
@@ -272,7 +272,9 @@
   </p>
 
   <p>
-    For more on how COLA works, see our guide on
+    For this year's adjustment and the full history, see our
+    <a href="/guides/cola">Social Security COLA guide</a>. For how COLA fits
+    alongside wage indexing, see
     <a href="/guides/inflation">inflation and Social Security benefits</a>.
   </p>
 

--- a/src/routes/guides/guide-cta-config.ts
+++ b/src/routes/guides/guide-cta-config.ts
@@ -8,6 +8,7 @@ export const GUIDE_CTA_TYPES: Record<string, GuideCTAType> = {
   '60k-income': 'calculator',
   '80k-income': 'calculator',
   aime: 'calculator',
+  cola: 'calculator',
   'delayed-january-bump': 'calculator',
   'earnings-cap': 'calculator',
   'earnings-record-paste': 'calculator',

--- a/src/routes/guides/inflation/+page.svelte
+++ b/src/routes/guides/inflation/+page.svelte
@@ -79,7 +79,7 @@ const faqs: FAQItem[] = [
   {
     question: 'What is COLA and when does it apply?',
     answer:
-      "COLA stands for Cost of Living Adjustment. It's an annual increase to your Social Security benefit based on the Consumer Price Index (CPI-W). COLA is applied starting the January after you begin receiving benefits, and continues every year thereafter.",
+      "COLA stands for Cost of Living Adjustment. It's an annual increase to your Social Security benefit based on the Consumer Price Index (CPI-W). COLA is applied starting with the year you turn 62, whether or not you have filed, and continues every year thereafter.",
   },
   {
     question: "Why is my estimated benefit shown in 'today's dollars'?",
@@ -278,7 +278,7 @@ const faqs: FAQItem[] = [
       <tr>
         <td><strong>When it applies</strong></td>
         <td>During your working years (until age 60)</td>
-        <td>After you start receiving benefits</td>
+        <td>From the year you turn 62 onward</td>
       </tr>
       <tr>
         <td><strong>What it measures</strong></td>

--- a/src/routes/guides/inflation/+page.svelte
+++ b/src/routes/guides/inflation/+page.svelte
@@ -341,6 +341,10 @@ const faqs: FAQItem[] = [
 
   <ul>
     <li>
+      <a href="/guides/cola">Social Security COLA</a> — This year's adjustment,
+      the full history since 1975, and what else changes each January
+    </li>
+    <li>
       <a href="/guides/indexing-factors">Wage Indexing Guide</a> — Detailed explanation
       of how indexing factors are calculated and why they matter
     </li>

--- a/src/routes/guides/pia/+page.svelte
+++ b/src/routes/guides/pia/+page.svelte
@@ -421,7 +421,8 @@
       href="/guides/inflation"
     >
       inflation</a
-    > through annual Cost-of-Living Adjustments (COLA). These adjustments:
+    > through annual <a href="/guides/cola">Cost-of-Living Adjustments (COLA)</a
+    >. These adjustments:
   </p>
 
   <ul>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -67,6 +67,7 @@ const pages = [
   { path: '/guides/divorced-spouse', priority: '0.7', changefreq: 'yearly' },
   { path: '/guides/survivor-benefits', priority: '0.7', changefreq: 'yearly' },
   { path: '/guides/spousal-benefits', priority: '0.7', changefreq: 'yearly' },
+  { path: '/guides/cola', priority: '0.7', changefreq: 'yearly' },
   { path: '/guides/earnings-test', priority: '0.7', changefreq: 'yearly' },
   {
     path: '/guides/senior-tax-deduction',

--- a/src/test/cola.test.ts
+++ b/src/test/cola.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { averageCola, colaHistory, latestCola } from '$lib/cola';
-import { COLA, MAX_COLA_YEAR } from '$lib/constants';
+import { averageCola, colaHistory, latestAnnouncedCola } from '$lib/cola';
+import {
+  COLA,
+  CURRENT_YEAR,
+  MAX_COLA_YEAR,
+  MEDICARE_PART_B_PREMIUM,
+} from '$lib/constants';
 
 describe('colaHistory', () => {
   const history = colaHistory();
 
   it('has one entry per COLA on record', () => {
     expect(history.length).toBe(Object.keys(COLA).length);
-  });
-
-  it('runs oldest first', () => {
-    const years = history.map((c) => c.announcementYear);
-    expect(years).toEqual([...years].sort((a, b) => a - b));
   });
 
   it('pays a COLA announced in 1983 or later the following January', () => {
@@ -34,6 +34,24 @@ describe('colaHistory', () => {
     expect(of1983?.paymentYear).toBe(1984);
   });
 
+  it('runs oldest first with no year paid twice', () => {
+    const paymentYears = history.map((c) => c.paymentYear);
+    for (let i = 1; i < paymentYears.length; ++i) {
+      expect(paymentYears[i]).toBeGreaterThan(paymentYears[i - 1]);
+    }
+  });
+
+  it('skips exactly one calendar year, 1983, when the timing changed', () => {
+    const paymentYears = history.map((c) => c.paymentYear);
+    const first = paymentYears[0];
+    const last = paymentYears[paymentYears.length - 1];
+    const missing: number[] = [];
+    for (let year = first; year <= last; ++year) {
+      if (!paymentYears.includes(year)) missing.push(year);
+    }
+    expect(missing).toEqual([1983]);
+  });
+
   it('records the years with no increase', () => {
     const zeroPaymentYears = history
       .filter((c) => c.percent === 0)
@@ -42,17 +60,21 @@ describe('colaHistory', () => {
   });
 });
 
-describe('latestCola', () => {
-  it('is the increase currently being paid', () => {
-    const latest = latestCola();
+describe('latestAnnouncedCola', () => {
+  it('is the newest adjustment on record', () => {
+    const latest = latestAnnouncedCola();
     expect(latest.announcementYear).toBe(MAX_COLA_YEAR);
-    expect(latest.paymentYear).toBe(MAX_COLA_YEAR + 1);
     expect(latest.percent).toBe(COLA[MAX_COLA_YEAR]);
   });
 
   it('is the last entry in the history', () => {
     const history = colaHistory();
-    expect(latestCola()).toEqual(history[history.length - 1]);
+    expect(latestAnnouncedCola()).toEqual(history[history.length - 1]);
+  });
+
+  it('is either being paid now or takes effect next January', () => {
+    const latest = latestAnnouncedCola();
+    expect([CURRENT_YEAR, CURRENT_YEAR + 1]).toContain(latest.paymentYear);
   });
 });
 
@@ -66,5 +88,17 @@ describe('averageCola', () => {
   it('falls in a plausible range for the post-1975 era', () => {
     expect(averageCola()).toBeGreaterThan(2);
     expect(averageCola()).toBeLessThan(6);
+  });
+});
+
+describe('MEDICARE_PART_B_PREMIUM', () => {
+  // The COLA guide reports the Part B premium alongside the COLA. These keep
+  // the two tables updated together.
+  it('covers the year currently being paid', () => {
+    expect(MEDICARE_PART_B_PREMIUM[CURRENT_YEAR]).toBeDefined();
+  });
+
+  it('covers the prior year so an increase can be shown', () => {
+    expect(MEDICARE_PART_B_PREMIUM[CURRENT_YEAR - 1]).toBeDefined();
   });
 });

--- a/src/test/cola.test.ts
+++ b/src/test/cola.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { averageCola, colaHistory, latestCola } from '$lib/cola';
+import { COLA, MAX_COLA_YEAR } from '$lib/constants';
+
+describe('colaHistory', () => {
+  const history = colaHistory();
+
+  it('has one entry per COLA on record', () => {
+    expect(history.length).toBe(Object.keys(COLA).length);
+  });
+
+  it('runs oldest first', () => {
+    const years = history.map((c) => c.announcementYear);
+    expect(years).toEqual([...years].sort((a, b) => a - b));
+  });
+
+  it('pays a COLA announced in 1983 or later the following January', () => {
+    const cola2026 = history.find((c) => c.paymentYear === 2026);
+    expect(cola2026?.announcementYear).toBe(2025);
+    expect(cola2026?.percent).toBe(2.8);
+  });
+
+  it('pays a COLA announced before 1983 in the same year', () => {
+    const first = history[0];
+    expect(first.announcementYear).toBe(1975);
+    expect(first.paymentYear).toBe(1975);
+    expect(first.percent).toBe(8.0);
+  });
+
+  it('switches to next-January payment with the 1983 adjustment', () => {
+    const of1982 = history.find((c) => c.announcementYear === 1982);
+    const of1983 = history.find((c) => c.announcementYear === 1983);
+    expect(of1982?.paymentYear).toBe(1982);
+    expect(of1983?.paymentYear).toBe(1984);
+  });
+
+  it('records the years with no increase', () => {
+    const zeroPaymentYears = history
+      .filter((c) => c.percent === 0)
+      .map((c) => c.paymentYear);
+    expect(zeroPaymentYears).toEqual([2010, 2011, 2016]);
+  });
+});
+
+describe('latestCola', () => {
+  it('is the increase currently being paid', () => {
+    const latest = latestCola();
+    expect(latest.announcementYear).toBe(MAX_COLA_YEAR);
+    expect(latest.paymentYear).toBe(MAX_COLA_YEAR + 1);
+    expect(latest.percent).toBe(COLA[MAX_COLA_YEAR]);
+  });
+
+  it('is the last entry in the history', () => {
+    const history = colaHistory();
+    expect(latestCola()).toEqual(history[history.length - 1]);
+  });
+});
+
+describe('averageCola', () => {
+  it('averages every COLA on record', () => {
+    const percents = Object.values(COLA);
+    const expected = percents.reduce((sum, p) => sum + p, 0) / percents.length;
+    expect(averageCola()).toBeCloseTo(expected, 10);
+  });
+
+  it('falls in a plausible range for the post-1975 era', () => {
+    expect(averageCola()).toBeGreaterThan(2);
+    expect(averageCola()).toBeLessThan(6);
+  });
+});


### PR DESCRIPTION
## Summary

- New guide at `/guides/cola` explaining the annual cost-of-living adjustment: how it is calculated from the CPI-W, when it reaches the check, that it accrues from age 62 whether or not you have filed, the history since 1975, Medicare Part B and hold harmless, the limits that track wages instead of prices, and the unindexed tax thresholds.
- New `src/lib/cola.ts` with `ColaAdjustment`, `colaHistory()`, `latestCola()`, and `averageCola()`, covered by 10 unit tests.
- Registered in the sitemap, guide index, and CTA config; cross-linked from the inflation, PIA, and delayed retirement credits guides.

## Why a helper module

`constants.COLA` is keyed by the year an adjustment is announced, but readers know each adjustment by the year the larger payment arrives, which is one year later from 1983 on and the same year for 1975 through 1982. `ColaAdjustment` carries both years so the page cannot silently label a row with the wrong one. Every figure on the page is computed from the constants, so the annual update flows through.

## Note

Medicare Part B figures ($202.90 standard premium for 2026, up $17.90) are not in `constants.ts`. They are named constants at the top of the page with a comment to update them alongside the annual SSA constants.

The guide uses the calculator CTA, matching its sibling mechanics guides such as inflation and PIA. One-line change in `guide-cta-config.ts` and the page if you would rather it carry the sponsor block.

## Test plan

- [x] `npm test` (2076 tests, includes the new COLA tests and the guides sitemap/index invariant)
- [x] `npm run quality` (Biome and svelte-check clean)
- [x] Rendered locally: title, FAQ schema, computed example ($2,000 becomes $2,056), average 3.7%, 61 table rows with 2026 mapped to 2.8% and 1975 to 8.0%, cross-links resolve