### PR TITLE
feat(guides): use the sponsor CTA on the COLA guide

### DIFF
--- a/src/routes/guides/cola/+page.svelte
+++ b/src/routes/guides/cola/+page.svelte
@@ -8,6 +8,7 @@ import {
 import { CURRENT_YEAR, MEDICARE_PART_B_PREMIUM } from '$lib/constants';
 import { Money } from '$lib/money';
 import { type FAQItem, GuidesSchema, renderFAQSchema } from '$lib/schema-org';
+import type { SponsorCopy } from '$lib/sponsor';
 import GuideFooter from '../guide-footer.svelte';
 import InlineCTA from '../InlineCTA.svelte';
 
@@ -62,6 +63,17 @@ const partBIncrease =
   partBPremium === undefined || partBPrior === undefined
     ? undefined
     : partBPremium.sub(partBPrior);
+
+const sponsorCopy: SponsorCopy = {
+  intro:
+    'A COLA raises every year of benefits ahead of you, so the bigger the benefit it lands on, the more it is worth. You can work through that with a Social Security specialist at',
+  outro: 'before you settle on a filing date.',
+  bullets: [
+    'They look at how your filing age sets the base that every future adjustment compounds on.',
+    'Medicare premiums and the tax thresholds above decide how much of the increase you actually keep.',
+    'The first call is free, and you pick the time.',
+  ],
+};
 
 const title = `Social Security COLA ${headline.paymentYear}: What the ${percentText(headline)} Increase Means`;
 const description = `Social Security benefits ${isBeingPaid ? 'rose' : 'will rise'} ${percentText(headline)} in ${headline.paymentYear}. Learn how the cost-of-living adjustment is calculated, when it reaches your check, whether you receive it before you file, and what else changes in January.`;
@@ -199,7 +211,7 @@ const faqs: FAQItem[] = [
     people who have not opted out of them.
   </p>
 
-  <InlineCTA type="calculator" />
+  <InlineCTA type="sponsor" {sponsorCopy} />
 
   <h2>You Get the COLA Before You File</h2>
 

--- a/src/routes/guides/guide-cta-config.ts
+++ b/src/routes/guides/guide-cta-config.ts
@@ -16,7 +16,6 @@ export const GUIDE_CTA_TYPES: Record<string, GuideCTAType> = {
   '60k-income': 'calculator',
   '80k-income': 'calculator',
   aime: 'calculator',
-  cola: 'calculator',
   'delayed-january-bump': 'calculator',
   'earnings-cap': 'calculator',
   'earnings-record-paste': 'calculator',
@@ -32,6 +31,7 @@ export const GUIDE_CTA_TYPES: Record<string, GuideCTAType> = {
   'work-credits': 'calculator',
   // Sponsor: broader retirement topics
   'agency-changes': 'sponsor',
+  cola: 'sponsor',
   'covid-awi-drop': 'sponsor',
   'divorced-spouse': 'sponsor',
   'federal-taxes': 'sponsor',


### PR DESCRIPTION
## Summary

- Moves `cola` from the calculator block to the sponsor block in `guide-cta-config.ts`, so the inline block on the COLA guide is Social Security Advisors rather than the calculator.
- Adds a pitch tied to this guide's subject: a COLA compounds on whatever base your filing age sets, and Medicare premiums and the tax thresholds decide how much of it you keep.

The guide keeps its standard footer link to the calculator, and the "See Your Own Numbers" section at the end is unchanged.

## Test plan

- [x] `npm test` (2131 tests)
- [x] `npm run quality` (Biome and svelte-check clean)
- [x] Rendered locally: the inline block is `inline-cta sponsor`, links to the sponsor scheduling page, and shows the tailored copy