### PR TITLE
fix(strategy): handle recipients who are already past age 70

### DIFF
--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -11,6 +11,19 @@ import type { Recipient } from '$lib/recipient';
 export const MAX_BENEFIT_AGE_MONTHS = 70 * 12;
 
 /**
+ * A survivor benefit claimed at age 60 is reduced to this fraction of the
+ * base amount, scaling linearly to 100% at survivor full retirement age.
+ *
+ * Shared with the fast paths in strategy/calculations so all three copies of
+ * the survivor formula multiply by the same floating-point value. They must
+ * agree to the last rounding step, and `1 - 0.715` is not `0.285` in IEEE
+ * arithmetic — a literal 0.285 in one copy rounded a half-cent case the other
+ * way, giving a $1/month survivor benefit the grid-cell NPV and the scenario
+ * detail then disagreed on.
+ */
+export const MIN_SURVIVOR_BENEFIT_RATIO = 0.715;
+
+/**
  * Returns benefit multiplier at a given age relative to normal retirement age.
  *
  * The early retirement reduction factor changes from 6.67%/yr for years
@@ -542,9 +555,9 @@ export function survivorBenefit(
       0,
       monthsBetweenAge60AndSurvivorAge / monthsBetween60AndNRA
     );
-    const minSurvivorBenefitRatio = 0.715;
     const result = baseSurvivorBenefit.times(
-      minSurvivorBenefitRatio + (1 - minSurvivorBenefitRatio) * reductionRatio
+      MIN_SURVIVOR_BENEFIT_RATIO +
+        (1 - MIN_SURVIVOR_BENEFIT_RATIO) * reductionRatio
     );
     return result.floorToDollar();
   }

--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -4,11 +4,21 @@ import { MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
 
 /**
+ * The oldest age at which filing still changes the benefit amount. Delayed
+ * retirement credits stop accruing the month a recipient turns 70, so waiting
+ * beyond it only forgoes payments.
+ */
+export const MAX_BENEFIT_AGE_MONTHS = 70 * 12;
+
+/**
  * Returns benefit multiplier at a given age relative to normal retirement age.
  *
  * The early retirement reduction factor changes from 6.67%/yr for years
  * earlier than 3 years before normal retirement age to 5%/yr for the 3 years
  * immediately before normal retirement age.
+ *
+ * Delayed credits are capped at age 70; an age past 70 yields the same
+ * multiplier as age 70 exactly.
  */
 function benefitMultiplierAtAge(
   nra: MonthDuration,
@@ -24,9 +34,10 @@ function benefitMultiplierAtAge(
         (Math.max(0, before.asMonths() - 36) * 5) / 1200)
     );
   } else {
-    // Increased benefits due to taking benefits late.
-    const after = age.subtract(nra);
-    return (delayedRetirementIncrease / 12) * after.asMonths();
+    // Increased benefits due to taking benefits late, up to age 70.
+    const creditedMonths = Math.min(age.asMonths(), MAX_BENEFIT_AGE_MONTHS);
+    const after = creditedMonths - nra.asMonths();
+    return (delayedRetirementIncrease / 12) * after;
   }
 }
 
@@ -457,6 +468,14 @@ export function survivorBenefit(
     );
   }
 
+  // The base amount is read at a date late enough that every delayed credit
+  // has taken effect. A year after filing always qualifies (delayed credits
+  // land the January after filing at the latest). A fixed age-71 date does
+  // not: someone who files past 71 would be read *before* they filed, and
+  // benefitOnDate returns $0 for a date before filing.
+  const afterAllCredits = (filingDate: MonthDate): MonthDate =>
+    filingDate.addDuration(MonthDuration.OneYear());
+
   if (deceasedFilingDate.greaterThanOrEqual(deceasedDeathDate)) {
     // If the deceased recipient did not file for benefits before death:
     if (deceasedDeathDate.lessThan(deceased.normalRetirementDate())) {
@@ -475,9 +494,7 @@ export function survivorBenefit(
       baseSurvivorBenefit = benefitOnDate(
         deceased,
         effectiveFilingDate,
-        deceased.birthdate.dateAtSsaAge(
-          MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
-        )
+        afterAllCredits(effectiveFilingDate)
       );
     }
   } else {
@@ -489,9 +506,7 @@ export function survivorBenefit(
       benefitOnDate(
         deceased,
         deceasedFilingDate,
-        deceased.birthdate.dateAtSsaAge(
-          MonthDuration.initFromYearsMonths({ years: 71, months: 0 })
-        )
+        afterAllCredits(deceasedFilingDate)
       )
     );
     baseSurvivorBenefit = Money.fromCents(

--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -56,7 +56,9 @@
    */
   function isAlreadyPast(index: number, filingAge: MonthDuration): boolean {
     const filingDate = recipients[index].birthdate.dateAtSsaAge(filingAge);
-    return !filingDate.greaterThan(currentDate);
+    // Strictly before: a recommendation for the current month is "file this
+    // month", with nothing to backdate, and reads correctly as a date.
+    return filingDate.lessThan(currentDate);
   }
 
   function formatAge(age: MonthDuration): string {

--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -2,7 +2,7 @@
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
   import { Money } from "$lib/money";
-  import type { MonthDuration } from "$lib/month-time";
+  import type { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import type {
     FilingAgeResult,
@@ -16,13 +16,22 @@
     recipients: [Recipient, Recipient];
     showInfoTip?: boolean;
     /**
-     * Per recipient: false once they are past 70 and filing immediately is
-     * their only remaining option. Such a recipient gets a "file now" card
-     * rather than a future filing date, because the optimizer's answer for
-     * them is a date in the past (the most retroactive month SSA allows),
-     * which reads as advice to wait when shown as a date.
+     * Per recipient: false once filing immediately is their only remaining
+     * option. Such a recipient gets a "file now" card rather than a filing
+     * date, because the optimizer's answer for them is the most retroactive
+     * month SSA allows — a month that has already passed, which under a
+     * "File in" label reads as a bug rather than as advice.
+     *
+     * Required rather than defaulted: defaulting it to [true, true] would
+     * silently reinstate that already-passed date for any caller that forgot
+     * to pass it.
      */
-    hasFilingChoice?: [boolean, boolean];
+    hasFilingChoice: [boolean, boolean];
+    /**
+     * The month the recommendation was computed for. Used to tell a filing
+     * date that is still ahead from one that has already passed.
+     */
+    currentDate: MonthDate;
   }
 
   let {
@@ -31,8 +40,24 @@
     coupleResult,
     recipients,
     showInfoTip = true,
-    hasFilingChoice = [true, true],
+    hasFilingChoice,
+    currentDate,
   }: Props = $props();
+
+  /**
+   * Whether the recommended filing month has already passed.
+   *
+   * SSA lets anyone past full retirement age file up to six months
+   * retroactively, so the optimizer legitimately returns a month in the past
+   * whenever filing sooner beats waiting — always once a recipient is past
+   * 70, but also for a younger recipient at a high discount rate. Rendering
+   * such a month under a "File in" label reads as a bug, so those cases get a
+   * "File now" card naming the month to backdate to instead.
+   */
+  function isAlreadyPast(index: number, filingAge: MonthDuration): boolean {
+    const filingDate = recipients[index].birthdate.dateAtSsaAge(filingAge);
+    return !filingDate.greaterThan(currentDate);
+  }
 
   function formatAge(age: MonthDuration): string {
     return age.toFullAgeString();
@@ -60,7 +85,19 @@
 </script>
 
 {#snippet filingCard(index: number, filingAge: MonthDuration)}
-  {#if hasFilingChoice[index]}
+  {#if isAlreadyPast(index, filingAge)}
+    <div class="prefix">File</div>
+    <div class="date-big">now</div>
+    <div class="age-sub">
+      {#if !hasFilingChoice[index]}
+        Past 70, so the benefit has stopped growing.
+      {/if}
+      Ask SSA to backdate the claim to {formatFilingDateFull(
+        recipients[index],
+        filingAge
+      )}; they can pay up to six months retroactively.
+    </div>
+  {:else}
     <div class="prefix">File in</div>
     <div class="date-big">
       <span class="date-full"
@@ -71,13 +108,6 @@
       >
     </div>
     <div class="age-sub">at age {formatAge(filingAge)}</div>
-  {:else}
-    <div class="prefix">File</div>
-    <div class="date-big">now</div>
-    <div class="age-sub">
-      Past 70, so the benefit has stopped growing. SSA can backdate the claim
-      up to six months.
-    </div>
   {/if}
 {/snippet}
 

--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -15,6 +15,14 @@
     coupleResult?: CoupleFilingAgeResult;
     recipients: [Recipient, Recipient];
     showInfoTip?: boolean;
+    /**
+     * Per recipient: false once they are past 70 and filing immediately is
+     * their only remaining option. Such a recipient gets a "file now" card
+     * rather than a future filing date, because the optimizer's answer for
+     * them is a date in the past (the most retroactive month SSA allows),
+     * which reads as advice to wait when shown as a date.
+     */
+    hasFilingChoice?: [boolean, boolean];
   }
 
   let {
@@ -23,6 +31,7 @@
     coupleResult,
     recipients,
     showInfoTip = true,
+    hasFilingChoice = [true, true],
   }: Props = $props();
 
   function formatAge(age: MonthDuration): string {
@@ -50,6 +59,28 @@
   }
 </script>
 
+{#snippet filingCard(index: number, filingAge: MonthDuration)}
+  {#if hasFilingChoice[index]}
+    <div class="prefix">File in</div>
+    <div class="date-big">
+      <span class="date-full"
+        >{formatFilingDateFull(recipients[index], filingAge)}</span
+      >
+      <span class="date-short"
+        >{formatFilingDateShort(recipients[index], filingAge)}</span
+      >
+    </div>
+    <div class="age-sub">at age {formatAge(filingAge)}</div>
+  {:else}
+    <div class="prefix">File</div>
+    <div class="date-big">now</div>
+    <div class="age-sub">
+      Past 70, so the benefit has stopped growing. SSA can backdate the claim
+      up to six months.
+    </div>
+  {/if}
+{/snippet}
+
 {#if (isSingle && singleResult) || (!isSingle && coupleResult)}
   <div class="headline" class:couple={!isSingle}>
     <div class="kicker">
@@ -72,13 +103,7 @@
 
     {#if isSingle && singleResult}
       <div class="result">
-        <div class="prefix">File in</div>
-        <div class="date-big">
-          {formatFilingDateFull(recipients[0], singleResult.filingAge)}
-        </div>
-        <div class="age-sub">
-          at age {formatAge(singleResult.filingAge)}
-        </div>
+        {@render filingCard(0, singleResult.filingAge)}
       </div>
     {:else if coupleResult}
       <div class="couple-results">
@@ -86,36 +111,14 @@
           <div class="person-name">
             <RecipientName r={recipients[0]} />
           </div>
-          <div class="prefix">File in</div>
-          <div class="date-big">
-            <span class="date-full"
-              >{formatFilingDateFull(recipients[0], coupleResult.filingAges[0])}</span
-            >
-            <span class="date-short"
-              >{formatFilingDateShort(recipients[0], coupleResult.filingAges[0])}</span
-            >
-          </div>
-          <div class="age-sub">
-            at age {formatAge(coupleResult.filingAges[0])}
-          </div>
+          {@render filingCard(0, coupleResult.filingAges[0])}
         </div>
         <div class="divider" aria-hidden="true"></div>
         <div class="result">
           <div class="person-name">
             <RecipientName r={recipients[1]} />
           </div>
-          <div class="prefix">File in</div>
-          <div class="date-big">
-            <span class="date-full"
-              >{formatFilingDateFull(recipients[1], coupleResult.filingAges[1])}</span
-            >
-            <span class="date-short"
-              >{formatFilingDateShort(recipients[1], coupleResult.filingAges[1])}</span
-            >
-          </div>
-          <div class="age-sub">
-            at age {formatAge(coupleResult.filingAges[1])}
-          </div>
+          {@render filingCard(1, coupleResult.filingAges[1])}
         </div>
       </div>
     {/if}
@@ -142,7 +145,11 @@
         {/if}
       </div>
       <p class="explanation">
-        {#if isSingle}
+        {#if isSingle && !hasFilingChoice[0]}
+          Delayed retirement credits stop at 70, so the monthly amount is
+          already at its maximum. Every further month of waiting is a payment
+          forgone.
+        {:else if isSingle}
           Maximizes your expected lifetime benefits, weighted by the
           probability of surviving to each age and adjusted for the discount
           rate.

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -10,6 +10,7 @@
   } from "$lib/components/recommended-filing-card";
   import type { DeathProbability } from "$lib/life-tables";
   import type { Recipient } from "$lib/recipient";
+  import { filingAgeRange } from "$lib/strategy/calculations/strategy-calc";
 
   export let recipient: Recipient;
   export let spouse: Recipient | null = null;
@@ -122,6 +123,13 @@
   $: recipientsTuple = (
     spouse ? [recipient, spouse] : [recipient, recipient]
   ) as [Recipient, Recipient];
+
+  // Someone past 70 has no filing decision left, so the headline shows them
+  // "file now" instead of the (already past) date the optimizer returns.
+  $: hasFilingChoice = [
+    filingAgeRange(recipient, currentMonthDate()).hasChoice,
+    spouse ? filingAgeRange(spouse, currentMonthDate()).hasChoice : true,
+  ] as [boolean, boolean];
 </script>
 
 {#if result}
@@ -136,6 +144,7 @@
       coupleResult={result.couple}
       recipients={recipientsTuple}
       showInfoTip={false}
+      {hasFilingChoice}
     />
   </a>
 {/if}

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -4,13 +4,13 @@
   import {
     buildStrategyUrl,
     currentMonthDate,
+    filingChoices,
     loadDeathDistributions,
     recommendedFromDistributions,
     type RecommendedFiling,
   } from "$lib/components/recommended-filing-card";
   import type { DeathProbability } from "$lib/life-tables";
   import type { Recipient } from "$lib/recipient";
-  import { filingAgeRange } from "$lib/strategy/calculations/strategy-calc";
 
   export let recipient: Recipient;
   export let spouse: Recipient | null = null;
@@ -126,10 +126,7 @@
 
   // Someone past 70 has no filing decision left, so the headline shows them
   // "file now" instead of the (already past) date the optimizer returns.
-  $: hasFilingChoice = [
-    filingAgeRange(recipient, currentMonthDate()).hasChoice,
-    spouse ? filingAgeRange(spouse, currentMonthDate()).hasChoice : true,
-  ] as [boolean, boolean];
+  $: hasFilingChoice = filingChoices(recipient, spouse);
 </script>
 
 {#if result}
@@ -145,6 +142,7 @@
       recipients={recipientsTuple}
       showInfoTip={false}
       {hasFilingChoice}
+      currentDate={currentMonthDate()}
     />
   </a>
 {/if}

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -72,13 +72,9 @@
       // Reads the latest component-scope recipient/spouse. d1/d2 are passed in:
       // they are keyed to recipient identity via distKey and stay valid across
       // the PIA changes that trigger a recompute.
-      result = recommendedFromDistributions(
-        recipient,
-        spouse,
-        d1,
-        d2,
-        currentMonthDate()
-      );
+      const now = currentMonthDate();
+      result = recommendedFromDistributions(recipient, spouse, d1, d2, now);
+      hasFilingChoice = filingChoices(recipient, spouse, now);
     } catch (e) {
       // The optimizer returns an empty array for edge cases rather than
       // throwing, so a throw here signals a real bug, not expected input.
@@ -124,9 +120,11 @@
     spouse ? [recipient, spouse] : [recipient, recipient]
   ) as [Recipient, Recipient];
 
-  // Someone past 70 has no filing decision left, so the headline shows them
-  // "file now" instead of the (already past) date the optimizer returns.
-  $: hasFilingChoice = filingChoices(recipient, spouse);
+  // Assigned inside compute(), alongside `result`, so the flag and the
+  // figures it re-skins always come from the same inputs: deriving it
+  // reactively here would let it change during the debounce window while
+  // `result` still belongs to the previous inputs.
+  let hasFilingChoice: [boolean, boolean] = [true, true];
 </script>
 
 {#if result}

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -10,6 +10,7 @@ import {
   expectedNPVCoupleOptimized,
   expectedNPVSingle,
 } from '$lib/strategy/calculations/expected-npv';
+import { filingAgeRange } from '$lib/strategy/calculations/strategy-calc';
 import { buildStrategyHash } from '$lib/url-params';
 
 /** Default assumptions matching the strategy optimizer's initial state. */
@@ -27,6 +28,28 @@ export function currentMonthDate(now: Date = new Date()): MonthDate {
     years: now.getFullYear(),
     months: now.getMonth(),
   });
+}
+
+/**
+ * Whether each recipient still has a filing age to choose, as of `currentDate`.
+ *
+ * False once a recipient is past 70: delayed retirement credits have stopped,
+ * so filing now is their only remaining option and presenting a filing date
+ * would imply a decision they no longer have. Index 1 is always true when
+ * there is no second recipient, so single-recipient callers can ignore it.
+ *
+ * Shared so the two surfaces that render a recommendation — the strategy page
+ * and the calculator's card — cannot disagree about who still has a choice.
+ */
+export function filingChoices(
+  recipient: Recipient,
+  spouse: Recipient | null,
+  currentDate: MonthDate = currentMonthDate()
+): [boolean, boolean] {
+  return [
+    filingAgeRange(recipient, currentDate).hasChoice,
+    spouse ? filingAgeRange(spouse, currentDate).hasChoice : true,
+  ];
 }
 
 /**

--- a/src/lib/strategy/calculations/expected-npv.ts
+++ b/src/lib/strategy/calculations/expected-npv.ts
@@ -39,14 +39,17 @@
  * form is provided.
  */
 
-import { eligibleForSpousalBenefit } from '$lib/benefit-calculator';
+import {
+  eligibleForSpousalBenefit,
+  MAX_BENEFIT_AGE_MONTHS,
+} from '$lib/benefit-calculator';
 import type { DeathProbability } from '$lib/life-tables';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
 import { classifyEarnerDependent } from './earner-dependent.js';
 import {
   calculateMonthlyDiscountRate,
-  earliestFiling,
+  filingAgeRange,
   strategySumCentsCouple,
   strategySumCentsSingle,
 } from './strategy-calc.js';
@@ -79,8 +82,9 @@ export function expectedNPVSingle(
 ): FilingAgeResult[] {
   if (deathProbDist.length === 0) return [];
 
-  const startFilingMonths = earliestFiling(recipient, currentDate).asMonths();
-  const endFilingMonths = 70 * 12;
+  const range = filingAgeRange(recipient, currentDate);
+  const startFilingMonths = range.earliest.asMonths();
+  const endFilingMonths = range.latest.asMonths();
 
   const results: FilingAgeResult[] = [];
 
@@ -164,7 +168,10 @@ function benefitCentsAtAge(
       (Math.max(0, before - 36) * 5) / 1200
     );
   } else {
-    const after = ageMonths - nraMonths;
+    // Delayed credits stop accruing at age 70.
+    const creditedMonths =
+      ageMonths < MAX_BENEFIT_AGE_MONTHS ? ageMonths : MAX_BENEFIT_AGE_MONTHS;
+    const after = creditedMonths - nraMonths;
     mult = (delayedRetirementIncrease / 12) * after;
   }
   return Math.floor(Math.round(piaDollarCents * (1 + mult)) / 100) * 100;
@@ -451,24 +458,31 @@ export function expectedNPVCoupleOptimized(
   }
 
   // ── Filing ranges ──
-  const eStart = earliestFiling(earner, currentDate).asMonths();
-  const dStart = earliestFiling(dependent, currentDate).asMonths();
+  // A recipient past 70 has a single remaining option (file now), so their
+  // range collapses to one entry rather than going empty.
+  const eRange = filingAgeRange(earner, currentDate);
+  const dRange = filingAgeRange(dependent, currentDate);
+  const eStart = eRange.earliest.asMonths();
+  const dStart = dRange.earliest.asMonths();
+  const eEnd = eRange.latest.asMonths();
+  const dEnd = dRange.latest.asMonths();
 
   // dkF[kSp] is indexed up to (maxFiling + 1 - curEpoch). The pvF/dkF tables
   // are sized from maxDeath. Ensure death distribution extends past any
-  // filing epoch (normally holds: SSA life tables go to age 120, filings
-  // cap at age 70).
+  // filing epoch (normally holds: SSA life tables run to age 120, and nobody
+  // files later than today).
+  const eMaxFilingEpoch = eSsaBirth + eEnd;
+  const dMaxFilingEpoch = dSsaBirth + dEnd;
   const maxFilingEpoch =
-    eSsaBirth + 840 > dSsaBirth + 840 ? eSsaBirth + 840 : dSsaBirth + 840;
+    eMaxFilingEpoch > dMaxFilingEpoch ? eMaxFilingEpoch : dMaxFilingEpoch;
   if (maxDeath < maxFilingEpoch) {
     throw new Error(
       `death distribution max epoch (${maxDeath}) must reach at least max ` +
         `filing epoch (${maxFilingEpoch}); life table may be truncated`
     );
   }
-  const endF = 840;
-  const nEF = endF - eStart + 1;
-  const nDF = endF - dStart + 1;
+  const nEF = eEnd - eStart + 1;
+  const nDF = dEnd - dStart + 1;
 
   // ── Pre-compute benefit amounts per filing age ──
   const eFY = new Float64Array(nEF);
@@ -636,9 +650,11 @@ export function expectedNPVCoupleOptimized(
   const results: CoupleFilingAgeResult[] = [];
   const sf0 = earnerIndex === 0 ? eStart : dStart;
   const sf1 = earnerIndex === 0 ? dStart : eStart;
+  const ef0 = earnerIndex === 0 ? eEnd : dEnd;
+  const ef1 = earnerIndex === 0 ? dEnd : eEnd;
 
-  for (let f0 = sf0; f0 <= endF; f0++) {
-    for (let f1 = sf1; f1 <= endF; f1++) {
+  for (let f0 = sf0; f0 <= ef0; f0++) {
+    for (let f1 = sf1; f1 <= ef1; f1++) {
       const fe = earnerIndex === 0 ? f0 : f1;
       const fd = earnerIndex === 0 ? f1 : f0;
       const feI = fe - eStart;
@@ -857,9 +873,12 @@ export function expectedNPVCouple(
     return [];
   }
 
-  const startFiling0 = earliestFiling(recipients[0], currentDate).asMonths();
-  const startFiling1 = earliestFiling(recipients[1], currentDate).asMonths();
-  const endFiling = 70 * 12;
+  const range0 = filingAgeRange(recipients[0], currentDate);
+  const range1 = filingAgeRange(recipients[1], currentDate);
+  const startFiling0 = range0.earliest.asMonths();
+  const startFiling1 = range1.earliest.asMonths();
+  const endFiling0 = range0.latest.asMonths();
+  const endFiling1 = range1.latest.asMonths();
 
   // Pre-compute death dates for each death age to avoid repeated allocation
   const deathDates: [MonthDate[], MonthDate[]] = [[], []];
@@ -875,10 +894,10 @@ export function expectedNPVCouple(
 
   const results: CoupleFilingAgeResult[] = [];
 
-  for (let f0 = startFiling0; f0 <= endFiling; f0++) {
+  for (let f0 = startFiling0; f0 <= endFiling0; f0++) {
     const filingAge0 = new MonthDuration(f0);
 
-    for (let f1 = startFiling1; f1 <= endFiling; f1++) {
+    for (let f1 = startFiling1; f1 <= endFiling1; f1++) {
       const filingAge1 = new MonthDuration(f1);
       const strats: [MonthDuration, MonthDuration] = [filingAge0, filingAge1];
 

--- a/src/lib/strategy/calculations/expected-npv.ts
+++ b/src/lib/strategy/calculations/expected-npv.ts
@@ -200,7 +200,11 @@ function filingYearCents(
   nraEpoch: number
 ): number {
   const filingEpoch = ssaBirthEpoch + ageMonths;
-  if (filingEpoch <= nraEpoch || ageMonths >= 840 || filingEpoch % 12 === 0)
+  if (
+    filingEpoch <= nraEpoch ||
+    ageMonths >= MAX_BENEFIT_AGE_MONTHS ||
+    filingEpoch % 12 === 0
+  )
     return benefitCentsAtAge(
       piaDollarCents,
       nraMonths,
@@ -381,7 +385,7 @@ export function expectedNPVCoupleOptimized(
     .dateAtSsaAge(new MonthDuration(0))
     .monthsSinceEpoch();
   const eNraEpoch = eSsaBirth + eNra;
-  const e70Epoch = eSsaBirth + 840;
+  const e70Epoch = eSsaBirth + MAX_BENEFIT_AGE_MONTHS;
 
   const dPiaRaw = dependent.pia().primaryInsuranceAmount().cents();
   const dPiaDol = Math.floor(dPiaRaw / 100) * 100;
@@ -458,8 +462,8 @@ export function expectedNPVCoupleOptimized(
   }
 
   // ── Filing ranges ──
-  // A recipient past 70 has a single remaining option (file now), so their
-  // range collapses to one entry rather than going empty.
+  // A recipient with no filing choice left has a single remaining option, so
+  // their range collapses to one entry rather than going empty.
   const eRange = filingAgeRange(earner, currentDate);
   const dRange = filingAgeRange(dependent, currentDate);
   const eStart = eRange.earliest.asMonths();
@@ -469,8 +473,8 @@ export function expectedNPVCoupleOptimized(
 
   // dkF[kSp] is indexed up to (maxFiling + 1 - curEpoch). The pvF/dkF tables
   // are sized from maxDeath. Ensure death distribution extends past any
-  // filing epoch (normally holds: SSA life tables run to age 120, and nobody
-  // files later than today).
+  // filing epoch (normally holds: SSA life tables run to age 120, and no
+  // filing age exceeds max(70, current age)).
   const eMaxFilingEpoch = eSsaBirth + eEnd;
   const dMaxFilingEpoch = dSsaBirth + dEnd;
   const maxFilingEpoch =

--- a/src/lib/strategy/calculations/expected-npv.ts
+++ b/src/lib/strategy/calculations/expected-npv.ts
@@ -42,6 +42,7 @@
 import {
   eligibleForSpousalBenefit,
   MAX_BENEFIT_AGE_MONTHS,
+  MIN_SURVIVOR_BENEFIT_RATIO,
 } from '$lib/benefit-calculator';
 import type { DeathProbability } from '$lib/life-tables';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
@@ -323,7 +324,11 @@ function survivorCentsCalc(
 
   const m60toNRA = depSurvNra - 720;
   const m60toAge = survAge - 720;
-  const ratio = 0.715 + 0.285 * Math.max(0, m60toAge / m60toNRA);
+  // Computed exactly as survivorBenefit does: (1 - ratio), not a 0.285
+  // literal, which is a different double and rounds half-cents differently.
+  const ratio =
+    MIN_SURVIVOR_BENEFIT_RATIO +
+    (1 - MIN_SURVIVOR_BENEFIT_RATIO) * Math.max(0, m60toAge / m60toNRA);
   return Math.floor(Math.round(base * ratio) / 100) * 100;
 }
 

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -58,7 +58,8 @@ import {
 //
 // The four functions below (benefitCentsAtAge, filingYearCents,
 // spousalCentsForPair, survivorCentsCalc) are byte-for-byte copies of the
-// same-named helpers in expected-npv.ts (lines 153-317). They are
+// same-named helpers in the "Shared primitives" block of expected-npv.ts.
+// (Named rather than line-numbered: line ranges rot on the next edit.) They are
 // duplicated rather than imported to keep this hot-path module
 // self-contained for inlining. Authoritative docstrings (early-filing
 // rules, "January bump", survivor ratio, etc.) live in expected-npv.ts;
@@ -104,7 +105,11 @@ function filingYearCents(
   nraEpoch: number
 ): number {
   const filingEpoch = ssaBirthEpoch + ageMonths;
-  if (filingEpoch <= nraEpoch || ageMonths >= 840 || filingEpoch % 12 === 0)
+  if (
+    filingEpoch <= nraEpoch ||
+    ageMonths >= MAX_BENEFIT_AGE_MONTHS ||
+    filingEpoch % 12 === 0
+  )
     return benefitCentsAtAge(
       piaDollarCents,
       nraMonths,
@@ -230,7 +235,7 @@ export function optimalStrategyCoupleFast(
     .dateAtSsaAge(new MonthDuration(0))
     .monthsSinceEpoch();
   const eNraEpoch = eSsaBirth + eNra;
-  const e70Epoch = eSsaBirth + 840;
+  const e70Epoch = eSsaBirth + MAX_BENEFIT_AGE_MONTHS;
 
   const dPiaRaw = dependent.pia().primaryInsuranceAmount().cents();
   const dPiaDol = Math.floor(dPiaRaw / 100) * 100;
@@ -269,7 +274,7 @@ export function optimalStrategyCoupleFast(
   const dDeath = finalDates[dependentIndex].monthsSinceEpoch();
 
   // ── Filing ranges ──
-  // A recipient past 70 has one option left (file now), so their range
+  // A recipient with no filing choice left has one option, so their range
   // collapses to a single entry rather than going empty.
   const eRange = filingAgeRange(earner, currentDate);
   const dRange = filingAgeRange(dependent, currentDate);
@@ -510,7 +515,12 @@ export function optimalStrategyCoupleFast(
       // Cap at SSA age 70 — dep can't file past their max benefit age. This
       // matters when the earner is younger than the dep and files at 70:
       // their calendar filing month would map to a dep age above 70.
-      bestFD = Math.min(earnerFileEpoch - dSsaBirth, 840);
+      // Clamp into the dependent's own searched range: reporting an age
+      // below dStart would name a filing month they cannot file in.
+      bestFD = Math.max(
+        dStart,
+        Math.min(earnerFileEpoch - dSsaBirth, MAX_BENEFIT_AGE_MONTHS)
+      );
       if (earnerIndex === 0) bestF1 = bestFD;
       else bestF0 = bestFD;
     }

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -280,20 +280,29 @@ export function optimalStrategyCoupleFast(
   const dRange = filingAgeRange(dependent, currentDate);
   const eStart = eRange.earliest.asMonths();
   const dStart = dRange.earliest.asMonths();
-  const eEnd = Math.min(
-    eRange.latest.asMonths(),
-    earner.birthdate.ageAtSsaDate(finalDates[earnerIndex]).asMonths()
+  // Clamped to the death date, but never below the start: one recipient dying
+  // before they could file does NOT make the couple's scenario meaningless —
+  // the other still has a real filing decision, and the survivor benefit
+  // still depends on it. Collapsing the dead recipient's range to a single
+  // (immaterial) age preserves that, where inverting it would return the
+  // [0, 0, -1] sentinel and throw the surviving spouse's answer away. The
+  // slow reference reaches the same result by not clamping at all: every
+  // filing age past death yields an identical NPV, so it settles on the
+  // earliest, which is the one value kept here.
+  const eEnd = Math.max(
+    eStart,
+    Math.min(
+      eRange.latest.asMonths(),
+      earner.birthdate.ageAtSsaDate(finalDates[earnerIndex]).asMonths()
+    )
   );
-  const dEnd = Math.min(
-    dRange.latest.asMonths(),
-    dependent.birthdate.ageAtSsaDate(finalDates[dependentIndex]).asMonths()
+  const dEnd = Math.max(
+    dStart,
+    Math.min(
+      dRange.latest.asMonths(),
+      dependent.birthdate.ageAtSsaDate(finalDates[dependentIndex]).asMonths()
+    )
   );
-
-  // Sentinel: either recipient can't file (loop is empty). Matches the slow
-  // reference's behavior (returns initial [0, 0, -1]).
-  if (eStart > eEnd || dStart > dEnd) {
-    return [new MonthDuration(0), new MonthDuration(0), -1];
-  }
 
   const nEF = eEnd - eStart + 1;
   const nDF = dEnd - dStart + 1;

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -41,13 +41,16 @@
  * slow reference; see `src/test/strategy/grid-optimal-goldens.test.ts`.
  */
 
-import { eligibleForSpousalBenefit } from '$lib/benefit-calculator';
+import {
+  eligibleForSpousalBenefit,
+  MAX_BENEFIT_AGE_MONTHS,
+} from '$lib/benefit-calculator';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
 import { classifyEarnerDependent } from './earner-dependent.js';
 import {
   calculateMonthlyDiscountRate,
-  earliestFiling,
+  filingAgeRange,
 } from './strategy-calc.js';
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -82,7 +85,10 @@ function benefitCentsAtAge(
       (Math.max(0, before - 36) * 5) / 1200
     );
   } else {
-    const after = ageMonths - nraMonths;
+    // Delayed credits stop accruing at age 70.
+    const creditedMonths =
+      ageMonths < MAX_BENEFIT_AGE_MONTHS ? ageMonths : MAX_BENEFIT_AGE_MONTHS;
+    const after = creditedMonths - nraMonths;
     mult = (delayedRetirementIncrease / 12) * after;
   }
   return Math.floor(Math.round(piaDollarCents * (1 + mult)) / 100) * 100;
@@ -263,14 +269,18 @@ export function optimalStrategyCoupleFast(
   const dDeath = finalDates[dependentIndex].monthsSinceEpoch();
 
   // ── Filing ranges ──
-  const eStart = earliestFiling(earner, currentDate).asMonths();
-  const dStart = earliestFiling(dependent, currentDate).asMonths();
+  // A recipient past 70 has one option left (file now), so their range
+  // collapses to a single entry rather than going empty.
+  const eRange = filingAgeRange(earner, currentDate);
+  const dRange = filingAgeRange(dependent, currentDate);
+  const eStart = eRange.earliest.asMonths();
+  const dStart = dRange.earliest.asMonths();
   const eEnd = Math.min(
-    840,
+    eRange.latest.asMonths(),
     earner.birthdate.ageAtSsaDate(finalDates[earnerIndex]).asMonths()
   );
   const dEnd = Math.min(
-    840,
+    dRange.latest.asMonths(),
     dependent.birthdate.ageAtSsaDate(finalDates[dependentIndex]).asMonths()
   );
 

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -44,6 +44,7 @@
 import {
   eligibleForSpousalBenefit,
   MAX_BENEFIT_AGE_MONTHS,
+  MIN_SURVIVOR_BENEFIT_RATIO,
 } from '$lib/benefit-calculator';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
@@ -201,7 +202,11 @@ function survivorCentsCalc(
 
   const m60toNRA = depSurvNra - 720;
   const m60toAge = survAge - 720;
-  const ratio = 0.715 + 0.285 * Math.max(0, m60toAge / m60toNRA);
+  // Computed exactly as survivorBenefit does: (1 - ratio), not a 0.285
+  // literal, which is a different double and rounds half-cents differently.
+  const ratio =
+    MIN_SURVIVOR_BENEFIT_RATIO +
+    (1 - MIN_SURVIVOR_BENEFIT_RATIO) * Math.max(0, m60toAge / m60toNRA);
   return Math.floor(Math.round(base * ratio) / 100) * 100;
 }
 
@@ -211,10 +216,12 @@ function survivorCentsCalc(
 
 /**
  * Find the (filing0, filing1) pair that maximizes NPV of benefits for a
- * couple with known death dates. Identical result to `optimalStrategyCouple`.
+ * couple with known death dates. Matches `optimalStrategyCouple` to within a
+ * cent (the golden tests' tolerance).
  *
- * Returns `[MonthDuration(0), MonthDuration(0), -1]` sentinel if the filing
- * range is empty for either recipient (e.g. already past 70y at currentDate).
+ * Every return value is a real strategy. A recipient who dies before they
+ * could file is searched at their single earliest age, where their personal
+ * NPV is zero, rather than emptying the range — see the clamp below.
  */
 export function optimalStrategyCoupleFast(
   recipients: [Recipient, Recipient],
@@ -310,9 +317,8 @@ export function optimalStrategyCoupleFast(
   // ── Pre-tabulate discount factors dkF[k] = (1+r)^-k for k=0..maxLag+1 ──
   const maxEpoch = Math.max(eDeath, dDeath) + 2;
   const tableSize = maxEpoch - curEpoch + 1;
-  // Invariant: tableSize >= 1. Guaranteed by the sentinel above (either
-  // eDeath >= eSsaBirth + eStart >= curEpoch, since earliestFiling returns
-  // a date no earlier than currentDate; similarly for dDeath). Assert
+  // Invariant: tableSize >= 1, since each death epoch is at or after the
+  // bucket start, which is never before currentDate. Assert
   // explicitly so a cryptic Float64Array RangeError can't bury this if
   // earliestFiling's semantics change.
   if (tableSize < 1) {
@@ -441,10 +447,10 @@ export function optimalStrategyCoupleFast(
       const svStart = eDeath + 1 > dFile ? eDeath + 1 : dFile;
 
       // Survivor amount, if dep actually outlives the survivor-start date.
-      // Reference (strategy-calc.ts:91-98) compares survivor vs dep's
+      // Reference (strategySumPeriodsCouple) compares survivor vs dep's
       // post-January personal benefit (benefitOnDate at filingDate+1y,
-      // which equals benefitCentsAtAge for ages < 70). That value is
-      // already tabulated as dPJ[fdI]; for zero-PIA dep it's 0.
+      // which equals benefitCentsAtAge). That value is already tabulated
+      // as dPJ[fdI]; for zero-PIA dep it's 0.
       let survAmt = 0;
       let isSurvivorActive = false;
       if (dDeath > svStart) {

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -1,6 +1,7 @@
 import {
   benefitOnDate,
   eligibleForSpousalBenefit,
+  MAX_BENEFIT_AGE_MONTHS,
   spousalBenefitOnDate,
   survivorBenefit,
 } from '$lib/benefit-calculator';
@@ -338,6 +339,50 @@ export function earliestFiling(
   }
 
   return earliestMonth;
+}
+
+/**
+ * The oldest filing age worth considering, as a duration. Filing past the age
+ * at which delayed credits stop only forgoes payments, so the two bounds are
+ * by definition the same age.
+ */
+export const MAX_FILING_AGE: MonthDuration = new MonthDuration(
+  MAX_BENEFIT_AGE_MONTHS
+);
+
+/**
+ * The inclusive span of filing ages an optimizer should search over.
+ *
+ * `hasChoice` is false when the recipient is already past 70. There is then
+ * exactly one option left — file now, at `earliest` — so `earliest` and
+ * `latest` are equal and the "optimization" is a formality. Callers that
+ * present results to a user should say so rather than implying a decision was
+ * made on the recipient's behalf.
+ */
+export interface FilingAgeRange {
+  readonly earliest: MonthDuration;
+  readonly latest: MonthDuration;
+  readonly hasChoice: boolean;
+}
+
+/**
+ * Computes the filing ages still available to a recipient as of `currentDate`.
+ *
+ * Callers must use this rather than iterating to a hardcoded age 70: a
+ * recipient past 70 has an `earliest` filing age beyond 70, and a loop bounded
+ * by a literal 70 would run zero (or negatively many) times.
+ */
+export function filingAgeRange(
+  recipient: Recipient,
+  currentDate: MonthDate
+): FilingAgeRange {
+  const earliest = earliestFiling(recipient, currentDate);
+  const hasChoice = earliest.lessThan(MAX_FILING_AGE);
+  return {
+    earliest,
+    latest: hasChoice ? MAX_FILING_AGE : earliest,
+    hasChoice,
+  };
 }
 
 /**
@@ -698,17 +743,15 @@ export function optimalStrategyCouple(
     -1,
   ];
 
-  const startFilingDate0: number = earliestFiling(
-    recipients[0],
-    currentDate
-  ).asMonths();
-  const startFilingDate1: number = earliestFiling(
-    recipients[1],
-    currentDate
-  ).asMonths();
+  const range0 = filingAgeRange(recipients[0], currentDate);
+  const range1 = filingAgeRange(recipients[1], currentDate);
+  const startFilingDate0: number = range0.earliest.asMonths();
+  const startFilingDate1: number = range1.earliest.asMonths();
+  const endFilingAge0: number = range0.latest.asMonths();
+  const endFilingAge1: number = range1.latest.asMonths();
 
-  for (let i = startFilingDate0; i <= 70 * 12; ++i) {
-    for (let j = startFilingDate1; j <= 70 * 12; ++j) {
+  for (let i = startFilingDate0; i <= endFilingAge0; ++i) {
+    for (let j = startFilingDate1; j <= endFilingAge1; ++j) {
       const strategy: [MonthDuration, MonthDuration] = [
         new MonthDuration(i),
         new MonthDuration(j),
@@ -778,13 +821,15 @@ export function optimalStrategyCoupleOptimized(
     currentDate
   ).asMonths();
 
-  // Pre-compute final loop bounds to avoid expensive calculations in loops
+  // Pre-compute final loop bounds to avoid expensive calculations in loops.
+  // filingAgeRange, not a literal 70: a recipient past 70 has a single
+  // remaining filing age above it, and a literal bound empties the loop.
   const endFilingAge0: number = Math.min(
-    70 * 12,
+    filingAgeRange(recipients[0], currentDate).latest.asMonths(),
     recipients[0].birthdate.ageAtSsaDate(finalDates[0]).asMonths()
   );
   const endFilingAge1: number = Math.min(
-    70 * 12,
+    filingAgeRange(recipients[1], currentDate).latest.asMonths(),
     recipients[1].birthdate.ageAtSsaDate(finalDates[1]).asMonths()
   );
 
@@ -979,13 +1024,14 @@ export function optimalStrategySingle(
 ): [MonthDuration, number] {
   let bestStrategy: [MonthDuration, number] = [new MonthDuration(0), -1];
 
-  const startFilingDate: number = earliestFiling(
-    recipient,
-    currentDate
-  ).asMonths();
+  const range = filingAgeRange(recipient, currentDate);
+  const startFilingDate: number = range.earliest.asMonths();
 
+  // Filing after death is not a strategy. If the recipient dies before they
+  // could file at all the loop below is empty and the sentinel [0, -1] is
+  // returned, matching the pre-existing contract.
   const endFilingAge: number = Math.min(
-    70 * 12,
+    range.latest.asMonths(),
     recipient.birthdate.ageAtSsaDate(finalDate).asMonths()
   );
 

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -376,6 +376,51 @@ export interface FilingAgeRange {
 }
 
 /**
+ * The earliest death age worth modelling for a recipient: the later of their
+ * current age and the earliest age they could still file.
+ *
+ * Below this there is no filing strategy to find — the recipient would have
+ * died before they could claim anything — so asking the optimizer about such
+ * a scenario is a malformed question rather than one with a degenerate
+ * answer. Death-age buckets must start here.
+ *
+ * `Birthdate.currentAge()` is whole years and so cannot express this on its
+ * own: someone aged 62y1m whose earliest filing month is 62y1m would get a
+ * bucket at 62y0m, one month short of being able to file.
+ */
+export function earliestModelableDeathAge(
+  recipient: Recipient,
+  currentDate: MonthDate
+): MonthDuration {
+  const currentAge = recipient.birthdate.ageAtSsaDate(currentDate);
+  const earliest = earliestFiling(recipient, currentDate);
+  return currentAge.greaterThan(earliest) ? currentAge : earliest;
+}
+
+/**
+ * Thrown when a recipient's death date precedes every filing age available to
+ * them, so no filing strategy exists for the scenario.
+ *
+ * The optimizers used to return a `[MonthDuration(0), -1]` sentinel here — an
+ * "answer" of "file at age 0 for minus one cent" that is indistinguishable,
+ * to both the type system and the caller, from a real result. The UI wrote it
+ * straight into the results grid, and a downstream filter quietly dropped it,
+ * which is how the over-70 bug rendered an empty chart with no error. Callers
+ * should avoid asking (do not model a death age earlier than the recipient
+ * could file); reaching this means a scenario was built that cannot happen.
+ */
+export class NoFilingAgeAvailableError extends Error {
+  constructor(startFilingAge: number, endFilingAge: number) {
+    super(
+      `no filing age available: the earliest filing age is ` +
+        `${startFilingAge} months but the recipient's death allows filing ` +
+        `only through ${endFilingAge} months`
+    );
+    this.name = 'NoFilingAgeAvailableError';
+  }
+}
+
+/**
  * Computes the filing ages still available to a recipient as of `currentDate`.
  *
  * Any search that starts from `earliestFiling` must bound itself with this
@@ -847,16 +892,21 @@ export function optimalStrategyCoupleOptimized(
   // Pre-compute final loop bounds to avoid expensive calculations in loops.
   // filingAgeRange, not a literal 70: a recipient past 70 has a single
   // remaining filing age above it, and a literal bound empties the loop.
-  // Clamping to the death date can still empty the range when a recipient
-  // dies before they could file; the loops below then do not execute and the
-  // sentinel [0, 0, -1] is returned, as in optimalStrategySingle.
-  const endFilingAge0: number = Math.min(
-    filingAgeRange(recipients[0], currentDate).latest.asMonths(),
-    recipients[0].birthdate.ageAtSsaDate(finalDates[0]).asMonths()
+  // Never below the start: see optimalStrategyCoupleFast. One recipient dying
+  // before they could file must not discard the other's filing decision.
+  const endFilingAge0: number = Math.max(
+    startFilingDate0,
+    Math.min(
+      filingAgeRange(recipients[0], currentDate).latest.asMonths(),
+      recipients[0].birthdate.ageAtSsaDate(finalDates[0]).asMonths()
+    )
   );
-  const endFilingAge1: number = Math.min(
-    filingAgeRange(recipients[1], currentDate).latest.asMonths(),
-    recipients[1].birthdate.ageAtSsaDate(finalDates[1]).asMonths()
+  const endFilingAge1: number = Math.max(
+    startFilingDate1,
+    Math.min(
+      filingAgeRange(recipients[1], currentDate).latest.asMonths(),
+      recipients[1].birthdate.ageAtSsaDate(finalDates[1]).asMonths()
+    )
   );
 
   for (let i = startFilingDate0; i <= endFilingAge0; ++i) {
@@ -1048,20 +1098,24 @@ export function optimalStrategySingle(
   currentDate: MonthDate,
   discountRate: number
 ): [MonthDuration, number] {
+  // Seed only; the guard below guarantees at least one iteration replaces it.
   let bestStrategy: [MonthDuration, number] = [new MonthDuration(0), -1];
 
   const range = filingAgeRange(recipient, currentDate);
   const startFilingDate: number = range.earliest.asMonths();
 
-  // Filing after death is not a strategy. If the recipient dies before they
-  // could file at all, the loop below is empty and the [0, -1] sentinel is
-  // returned. No caller checks for -1, so such a result would surface in the
-  // UI as a filing age of 0; that is unchanged by this fix, but it is a
-  // latent gap rather than a designed contract.
+  // Filing after death is not a strategy.
   const endFilingAge: number = Math.min(
     range.latest.asMonths(),
     recipient.birthdate.ageAtSsaDate(finalDate).asMonths()
   );
+
+  // The loop below would otherwise run zero times and return its seed value
+  // as though it were an answer. Every value of this function's return type
+  // is now a real strategy.
+  if (endFilingAge < startFilingDate) {
+    throw new NoFilingAgeAvailableError(startFilingDate, endFilingAge);
+  }
 
   for (let i = startFilingDate; i <= endFilingAge; ++i) {
     const strategy = new MonthDuration(i);

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -368,6 +368,15 @@ export const MAX_FILING_AGE: MonthDuration = new MonthDuration(
  * Note that `latest` is NOT bounded by `MAX_FILING_AGE`: in exactly that case
  * it exceeds it, which is the whole point of the type. The span is always
  * non-empty (`earliest <= latest`).
+ *
+ * Model limitation: the NPV functions count payments from the month after
+ * `currentDate`, so the retroactive lump sum SSA pays for a backdated claim
+ * is worth $0 to the optimizer. Past full retirement age the winner among
+ * the backdated ages is therefore predetermined (the amount either rises
+ * with age or, past 70, is flat), and the narrow past-70y0m range is
+ * searched but cannot surprise. Valuing those months as a lump at
+ * `currentDate + 1` would let the "up to six months retroactively" the UI
+ * mentions actually influence the recommendation; it is left for follow-up.
  */
 export interface FilingAgeRange {
   readonly earliest: MonthDuration;

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -342,9 +342,9 @@ export function earliestFiling(
 }
 
 /**
- * The oldest filing age worth considering, as a duration. Filing past the age
- * at which delayed credits stop only forgoes payments, so the two bounds are
- * by definition the same age.
+ * The oldest filing age worth considering, as a duration. Filing later than
+ * the age at which delayed credits stop only forgoes payments, so the maximum
+ * useful filing age and MAX_BENEFIT_AGE_MONTHS are by definition the same age.
  */
 export const MAX_FILING_AGE: MonthDuration = new MonthDuration(
   MAX_BENEFIT_AGE_MONTHS
@@ -353,11 +353,21 @@ export const MAX_FILING_AGE: MonthDuration = new MonthDuration(
 /**
  * The inclusive span of filing ages an optimizer should search over.
  *
- * `hasChoice` is false when the recipient is already past 70. There is then
- * exactly one option left — file now, at `earliest` — so `earliest` and
- * `latest` are equal and the "optimization" is a formality. Callers that
- * present results to a user should say so rather than implying a decision was
- * made on the recipient's behalf.
+ * `hasChoice` is false once `earliest` has reached 70. Because SSA allows
+ * filing up to six months retroactively, `earliest` lags the recipient's
+ * current age by six months once they are past full retirement age, so the
+ * flip happens at age 70y6m rather than at 70y0m. A recipient aged 70y3m
+ * still has a real, if narrow, range to search.
+ *
+ * Past that point exactly one option remains: file as soon as possible,
+ * backdated to `earliest` — the most retroactive month SSA allows — so
+ * `earliest` and `latest` are equal and the "optimization" is a formality.
+ * Callers presenting results to a user should say so rather than implying a
+ * decision was made on the recipient's behalf.
+ *
+ * Note that `latest` is NOT bounded by `MAX_FILING_AGE`: in exactly that case
+ * it exceeds it, which is the whole point of the type. The span is always
+ * non-empty (`earliest <= latest`).
  */
 export interface FilingAgeRange {
   readonly earliest: MonthDuration;
@@ -368,9 +378,13 @@ export interface FilingAgeRange {
 /**
  * Computes the filing ages still available to a recipient as of `currentDate`.
  *
- * Callers must use this rather than iterating to a hardcoded age 70: a
- * recipient past 70 has an `earliest` filing age beyond 70, and a loop bounded
- * by a literal 70 would run zero (or negatively many) times.
+ * Any search that starts from `earliestFiling` must bound itself with this
+ * rather than a hardcoded age 70: that starting age can exceed 70, leaving a
+ * loop bounded by a literal 70 to run zero times, and any length derived from
+ * the range (`end - start + 1`) to go negative and throw `RangeError` from the
+ * typed-array allocations in the fast paths. (Searches that start from
+ * `earliestFilingMonth`, the age-62 month, are not affected — see
+ * alternative-strategies.ts and ai-export.ts.)
  */
 export function filingAgeRange(
   recipient: Recipient,
@@ -380,7 +394,11 @@ export function filingAgeRange(
   const hasChoice = earliest.lessThan(MAX_FILING_AGE);
   return {
     earliest,
-    latest: hasChoice ? MAX_FILING_AGE : earliest,
+    // A fresh instance rather than MAX_FILING_AGE itself: MonthDuration's
+    // increment()/decrement() mutate in place, and that idiom is used
+    // elsewhere, so handing out the shared constant by identity would let one
+    // caller corrupt it for every later call.
+    latest: hasChoice ? new MonthDuration(MAX_BENEFIT_AGE_MONTHS) : earliest,
     hasChoice,
   };
 }
@@ -703,9 +721,14 @@ function clampZeroPiaDepStrategy(
   if (!depFile.lessThan(earnerFile)) return best;
 
   // Cap at SSA age 70 — dep can't file past their max benefit age. Matters
-  // when the earner is younger than the dep and files at 70.
+  // when the earner is younger than the dep and files at 70. Floor at the age
+  // the optimizer actually searched: a dependent already past 70 has no age
+  // below that available, so the age-70 cap alone would name a filing month
+  // they cannot file in.
   const rawAge = dependent.birthdate.ageAtSsaDate(earnerFile).asMonths();
-  const newDepAge = new MonthDuration(Math.min(rawAge, 70 * 12));
+  const newDepAge = new MonthDuration(
+    Math.max(depAge.asMonths(), Math.min(rawAge, MAX_BENEFIT_AGE_MONTHS))
+  );
   const result: [MonthDuration, MonthDuration, number] = [
     best[0],
     best[1],
@@ -824,6 +847,9 @@ export function optimalStrategyCoupleOptimized(
   // Pre-compute final loop bounds to avoid expensive calculations in loops.
   // filingAgeRange, not a literal 70: a recipient past 70 has a single
   // remaining filing age above it, and a literal bound empties the loop.
+  // Clamping to the death date can still empty the range when a recipient
+  // dies before they could file; the loops below then do not execute and the
+  // sentinel [0, 0, -1] is returned, as in optimalStrategySingle.
   const endFilingAge0: number = Math.min(
     filingAgeRange(recipients[0], currentDate).latest.asMonths(),
     recipients[0].birthdate.ageAtSsaDate(finalDates[0]).asMonths()
@@ -1028,8 +1054,10 @@ export function optimalStrategySingle(
   const startFilingDate: number = range.earliest.asMonths();
 
   // Filing after death is not a strategy. If the recipient dies before they
-  // could file at all the loop below is empty and the sentinel [0, -1] is
-  // returned, matching the pre-existing contract.
+  // could file at all, the loop below is empty and the [0, -1] sentinel is
+  // returned. No caller checks for -1, so such a result would surface in the
+  // UI as a filing age of 0; that is unchanged by this fix, but it is a
+  // latent gap rather than a designed contract.
   const endFilingAge: number = Math.min(
     range.latest.asMonths(),
     recipient.birthdate.ageAtSsaDate(finalDate).asMonths()

--- a/src/lib/strategy/ui/grid-sizing.ts
+++ b/src/lib/strategy/ui/grid-sizing.ts
@@ -281,16 +281,21 @@ export function generateOneYearBuckets(
 }
 
 /**
- * Generate monthly buckets starting at startAge.
+ * Generate monthly buckets starting at `startAgeMonths`.
  * Continue while (age < 100). After that, create a final open-ended bucket.
+ *
+ * Takes months rather than years because the caller's lower bound is a filing
+ * age, which is inherently a month count: deriving it via years would lose the
+ * months and can place the first bucket's death age before the recipient could
+ * file at all, which leaves the optimizer with an empty search range.
  */
 export function generateMonthlyBuckets(
-  startAge: number,
+  startAgeMonths: number,
   probDistribution: { age: number; probability: number }[]
 ): DeathAgeBucket[] {
   const buckets: DeathAgeBucket[] = [];
 
-  let currentAgeMonths = Math.floor(startAge * 12);
+  let currentAgeMonths = Math.floor(startAgeMonths);
   const endAgeMonths = 100 * 12;
 
   const sumProbabilityRange = (from: number, to: number | null): number => {

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -128,6 +128,9 @@
 
   const MIN_FILING_AGE = 62;
   const REACTIVE_DEBOUNCE_MS = 200;
+  const STALE_RESULTS_MESSAGE =
+    "These figures are out of date — we could not recompute them for your " +
+    "latest changes.";
 
   type Stage = "mode" | "form" | "results";
   let stage: Stage = "mode";
@@ -393,9 +396,7 @@
           // The figures still on screen were computed for the previous
           // inputs. Leaving them unlabelled is worse than showing nothing:
           // they look like an answer to what the user just typed.
-          recomputeErrorMessage =
-            "These figures are out of date — we could not recompute them " +
-            "for your latest changes.";
+          recomputeErrorMessage = STALE_RESULTS_MESSAGE;
         });
     }, REACTIVE_DEBOUNCE_MS);
   }
@@ -434,11 +435,12 @@
     // not a scenario worth modelling, and asking about it is what produced
     // the "file at age 0" result. currentAge() is whole years, so the month
     // precision has to come from earliestFiling.
+    // No MIN_FILING_AGE floor needed: earliestFiling is never below 62.
     const currentDate = currentMonthDate();
-    const startAgeMonths1 = Math.max(
-      MIN_FILING_AGE * 12,
-      earliestModelableDeathAge(recipients[0], currentDate).asMonths()
-    );
+    const startAgeMonths1 = earliestModelableDeathAge(
+      recipients[0],
+      currentDate
+    ).asMonths();
 
     // Three-year buckets represent each bucket by its midpoint (start + 18
     // months), so they clear the earliest filing age without this adjustment.
@@ -459,12 +461,15 @@
       deathProbDistribution2
     );
 
-    // A run over no scenarios is a failure, not a result.
-    if (deathAgeBuckets1.length === 0 || deathAgeBuckets2.length === 0) {
+    // A run over no mortality data is a failure, not a result. (The bucket
+    // generators always emit a final open-ended bucket, so bucket count is
+    // not the thing to check; an empty distribution is.)
+    if (
+      deathProbDistribution1.length === 0 ||
+      (!isSingle && deathProbDistribution2.length === 0)
+    ) {
       throw new Error(
-        `no death-age buckets (recipient 0: ${deathAgeBuckets1.length}, ` +
-          `recipient 1: ${deathAgeBuckets2.length}); mortality data is ` +
-          "missing or unusable"
+        "empty mortality distribution; life-table data is missing or unusable"
       );
     }
   }
@@ -559,7 +564,11 @@
       next.beginRun();
 
       const currentDate = currentMonthDate();
-      hasFilingChoice = filingChoices(
+      // Computed here but assigned only once the run has fully succeeded,
+      // together with the results it describes. If a loop below throws, the
+      // store keeps the previous results, and this flag must keep describing
+      // those — not the inputs that just failed.
+      const nextFilingChoice = filingChoices(
         recipients[0],
         isSingle ? null : recipients[1],
         currentDate
@@ -626,6 +635,8 @@
       }
       next.completeRun();
 
+      let nextSingleResult: FilingAgeResult | undefined;
+      let nextCoupleResult: CoupleFilingAgeResult | undefined;
       if (isSingle) {
         const singleResults = expectedNPVSingle(
           recipients[0],
@@ -633,9 +644,8 @@
           discountRate,
           deathProbDistribution1
         );
-        optimalSingleResult =
+        nextSingleResult =
           singleResults.length > 0 ? singleResults[0] : undefined;
-        optimalCoupleResult = undefined;
       } else {
         const coupleResults = expectedNPVCoupleOptimized(
           recipients,
@@ -643,15 +653,20 @@
           discountRate,
           [deathProbDistribution1, deathProbDistribution2]
         );
-        optimalCoupleResult =
+        nextCoupleResult =
           coupleResults.length > 0 ? coupleResults[0] : undefined;
-        optimalSingleResult = undefined;
       }
 
       if (prevSelected) {
         next.setSelectedByLabels(prevSelected.rowLabel, prevSelected.colLabel);
       }
 
+      // Everything the results stage renders changes in one step, so the
+      // headline, the grids and the flag that re-skins them always describe
+      // the same run.
+      hasFilingChoice = nextFilingChoice;
+      optimalSingleResult = nextSingleResult;
+      optimalCoupleResult = nextCoupleResult;
       calculationResultsStore.set(next);
     } catch (error) {
       console.error("Calculation error:", error);
@@ -660,9 +675,14 @@
       isRunning = false;
       if (rerunPending) {
         rerunPending = false;
-        calculateStrategyMatrix().catch((err) => {
-          console.error("Queued reactive rerun failed:", err);
-        });
+        calculateStrategyMatrix()
+          .then(() => {
+            recomputeErrorMessage = null;
+          })
+          .catch((err) => {
+            console.error("Queued reactive rerun failed:", err);
+            recomputeErrorMessage = STALE_RESULTS_MESSAGE;
+          });
       }
     }
   }

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -9,11 +9,11 @@
   import { MonthDate } from "$lib/month-time";
   import { Recipient } from "$lib/recipient";
   import { optimalStrategyCoupleFast } from "$lib/strategy/calculations/optimal-strategy-fast";
+  import { optimalStrategySingle } from "$lib/strategy/calculations/strategy-calc";
   import {
-    filingAgeRange,
-    optimalStrategySingle,
-  } from "$lib/strategy/calculations/strategy-calc";
-  import { currentMonthDate } from "$lib/components/recommended-filing-card";
+    currentMonthDate,
+    filingChoices,
+  } from "$lib/components/recommended-filing-card";
   import {
     CalculationResults,
     CalculationStatus,
@@ -154,6 +154,9 @@
   let recipientInputsValid = false;
   let discountRateValid = true;
   let formErrorMessage: string | null = null;
+  // Set when a recompute triggered from the results stage fails. The form's
+  // banner is not mounted there, so the results stage needs its own.
+  let recomputeErrorMessage: string | null = null;
 
   let rerunPending = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -319,21 +322,13 @@
 
   $: formIsValid = recipientInputsValid && discountRateValid;
 
-  // A recipient past 70 has no filing decision left: delayed credits have
-  // stopped and the optimizer's only remaining option is "file now". The
-  // headline needs to know so it does not present that as a future date.
-  $: hasFilingChoice = computeFilingChoice(recipients, isSingle);
-
-  function computeFilingChoice(
-    rs: [Recipient, Recipient],
-    single: boolean
-  ): [boolean, boolean] {
-    const currentDate = currentMonthDate();
-    return [
-      filingAgeRange(rs[0], currentDate).hasChoice,
-      single ? true : filingAgeRange(rs[1], currentDate).hasChoice,
-    ];
-  }
+  // A recipient with no filing choice left has only one option: file now.
+  // The headline and the grids need to know so they do not present that as a
+  // decision. Assigned inside calculateStrategyMatrix from the same
+  // currentDate as the results it describes — deriving it reactively from
+  // live form state would let it flip a card to "File now" while the figures
+  // beside it still belong to the previous birthdate.
+  let hasFilingChoice: [boolean, boolean] = [true, true];
   $: discountRate = discountRatePercent / 100;
   $: shareUrl = buildShareUrl(recipients, isSingle, piaValues, birthdateInputs);
 
@@ -386,52 +381,74 @@
     if (debounceTimer !== null) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
       debounceTimer = null;
-      // Reactive path has no banner; log and leave prior results visible.
-      calculateStrategyMatrix().catch((err) => {
-        console.error("Reactive recompute failed:", err);
-      });
+      calculateStrategyMatrix()
+        .then(() => {
+          recomputeErrorMessage = null;
+        })
+        .catch((err) => {
+          console.error("Reactive recompute failed:", err);
+          // The figures still on screen were computed for the previous
+          // inputs. Leaving them unlabelled is worse than showing nothing:
+          // they look like an answer to what the user just typed.
+          recomputeErrorMessage =
+            "These figures are out of date — we could not recompute them " +
+            "for your latest changes.";
+        });
     }, REACTIVE_DEBOUNCE_MS);
   }
 
   let recipients: [Recipient, Recipient] = initializeRecipients();
 
   function handleRecipientUpdate() {
-    try {
-      recipients = [...recipients];
-      updateDeathProbabilityDistributions();
-    } catch (error) {
-      console.warn("Error updating form data:", error);
-    }
+    recipients = [...recipients];
+    // A speculative refresh while the user is still typing. Failures here are
+    // not worth interrupting them for: calculateStrategyMatrix awaits the
+    // same function on Continue, and surfaces the error then.
+    updateDeathProbabilityDistributions().catch((error) => {
+      console.warn("Error updating death probability distributions:", error);
+    });
   }
 
+  /**
+   * Loads mortality data and rebuilds the death-age buckets.
+   *
+   * Throws rather than swallowing. Returning quietly on failure leaves the
+   * buckets empty, and an empty bucket list still runs to "Complete" with
+   * nothing in it — which is exactly how the over-70 bug stayed invisible.
+   */
   async function updateDeathProbabilityDistributions() {
-    try {
-      const currentYear = new Date().getFullYear();
-      [deathProbDistribution1, deathProbDistribution2] = await Promise.all([
-        getDeathProbabilityDistribution(recipients[0], currentYear),
-        getDeathProbabilityDistribution(recipients[1], currentYear),
-      ]);
-      deathProbDistribution1 = [...deathProbDistribution1];
-      deathProbDistribution2 = [...deathProbDistribution2];
+    const currentYear = new Date().getFullYear();
+    [deathProbDistribution1, deathProbDistribution2] = await Promise.all([
+      getDeathProbabilityDistribution(recipients[0], currentYear),
+      getDeathProbabilityDistribution(recipients[1], currentYear),
+    ]);
+    deathProbDistribution1 = [...deathProbDistribution1];
+    deathProbDistribution2 = [...deathProbDistribution2];
 
-      const startAge1 = Math.max(
-        MIN_FILING_AGE,
-        recipients[0].birthdate.currentAge()
-      );
-      const startAge2 = Math.max(
-        MIN_FILING_AGE,
-        recipients[1].birthdate.currentAge()
-      );
+    const startAge1 = Math.max(
+      MIN_FILING_AGE,
+      recipients[0].birthdate.currentAge()
+    );
+    const startAge2 = Math.max(
+      MIN_FILING_AGE,
+      recipients[1].birthdate.currentAge()
+    );
 
-      deathAgeBuckets1 = isSingle
-        ? generateMonthlyBuckets(startAge1, deathProbDistribution1)
-        : generateThreeYearBuckets(startAge1, deathProbDistribution1);
-      deathAgeBuckets2 = generateThreeYearBuckets(
-        startAge2,
-        deathProbDistribution2
+    deathAgeBuckets1 = isSingle
+      ? generateMonthlyBuckets(startAge1, deathProbDistribution1)
+      : generateThreeYearBuckets(startAge1, deathProbDistribution1);
+    deathAgeBuckets2 = generateThreeYearBuckets(
+      startAge2,
+      deathProbDistribution2
+    );
+
+    // A run over no scenarios is a failure, not a result.
+    if (deathAgeBuckets1.length === 0 || deathAgeBuckets2.length === 0) {
+      throw new Error(
+        `no death-age buckets (recipient 0: ${deathAgeBuckets1.length}, ` +
+          `recipient 1: ${deathAgeBuckets2.length}); mortality data is ` +
+          "missing or unusable"
       );
-    } catch (error) {
-      console.warn("Error updating death probability distributions:", error);
     }
   }
 
@@ -466,6 +483,7 @@
 
   async function handleContinue() {
     formErrorMessage = null;
+    recomputeErrorMessage = null;
     try {
       await calculateStrategyMatrix();
       if (calculationResults.status() === CalculationStatus.Complete) {
@@ -492,6 +510,7 @@
 
   function handleStartOver() {
     formErrorMessage = null;
+    recomputeErrorMessage = null;
     // Preserve health tunings across Start over — they're exploration state,
     // not identity data.
     const prevHealth = snapshotHealthMultipliers();
@@ -523,6 +542,11 @@
       next.beginRun();
 
       const currentDate = currentMonthDate();
+      hasFilingChoice = filingChoices(
+        recipients[0],
+        isSingle ? null : recipients[1],
+        currentDate
+      );
 
       if (isSingle) {
         for (let i = 0; i < deathAgeBuckets1.length; i++) {
@@ -774,8 +798,13 @@
     </div>
 
     <section class="calculation-section">
-      {#if calculationResults.status() === CalculationStatus.Complete}
+      {#if recomputeErrorMessage}
         <div class="limited-width">
+          <p class="stale-banner" role="alert">{recomputeErrorMessage}</p>
+        </div>
+      {/if}
+      {#if calculationResults.status() === CalculationStatus.Complete}
+        <div class="limited-width" class:is-stale={recomputeErrorMessage}>
           <div class="hero-row">
             <OptimalStrategyHeadline
               {isSingle}
@@ -783,6 +812,7 @@
               coupleResult={optimalCoupleResult}
               {recipients}
               {hasFilingChoice}
+              currentDate={currentMonthDate()}
             />
             <AdvisorPrompt />
           </div>
@@ -862,6 +892,22 @@
     max-width: 1200px;
     margin: 0 auto;
     padding: 0.5rem;
+  }
+
+  .stale-banner {
+    margin: 0.75rem auto;
+    padding: 0.7rem 0.95rem;
+    background: #fef8ec;
+    border: 1px solid #e8cf9a;
+    color: #7a5606;
+    border-radius: 6px;
+    font-size: 0.9rem;
+  }
+
+  /* Dim figures that no longer match the inputs on screen, so they are not
+     read as the answer to what the user just changed. */
+  .limited-width.is-stale {
+    opacity: 0.55;
   }
 
   .page-hero {

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -9,7 +9,11 @@
   import { MonthDate } from "$lib/month-time";
   import { Recipient } from "$lib/recipient";
   import { optimalStrategyCoupleFast } from "$lib/strategy/calculations/optimal-strategy-fast";
-  import { optimalStrategySingle } from "$lib/strategy/calculations/strategy-calc";
+  import {
+    filingAgeRange,
+    optimalStrategySingle,
+  } from "$lib/strategy/calculations/strategy-calc";
+  import { currentMonthDate } from "$lib/components/recommended-filing-card";
   import {
     CalculationResults,
     CalculationStatus,
@@ -23,6 +27,7 @@
   import { UrlParams, buildStrategyHash } from "$lib/url-params";
   import LockedSummary from "./components/LockedSummary.svelte";
   import ModePicker from "./components/ModePicker.svelte";
+  import NoFilingDecisionPanel from "./components/NoFilingDecisionPanel.svelte";
   import RecipientInputs from "./components/RecipientInputs.svelte";
   import ScenarioDetail from "./components/ScenarioDetail.svelte";
   import ScenarioDetailSingle from "./components/ScenarioDetailSingle.svelte";
@@ -313,6 +318,22 @@
   });
 
   $: formIsValid = recipientInputsValid && discountRateValid;
+
+  // A recipient past 70 has no filing decision left: delayed credits have
+  // stopped and the optimizer's only remaining option is "file now". The
+  // headline needs to know so it does not present that as a future date.
+  $: hasFilingChoice = computeFilingChoice(recipients, isSingle);
+
+  function computeFilingChoice(
+    rs: [Recipient, Recipient],
+    single: boolean
+  ): [boolean, boolean] {
+    const currentDate = currentMonthDate();
+    return [
+      filingAgeRange(rs[0], currentDate).hasChoice,
+      single ? true : filingAgeRange(rs[1], currentDate).hasChoice,
+    ];
+  }
   $: discountRate = discountRatePercent / 100;
   $: shareUrl = buildShareUrl(recipients, isSingle, piaValues, birthdateInputs);
 
@@ -455,8 +476,13 @@
       }
     } catch (error) {
       console.error("Continue failed:", error);
+      // Every input the form accepts should produce a result, so reaching
+      // here means a bug on our side rather than bad data. Say so: telling
+      // people to "check your inputs" sends them hunting for a mistake they
+      // did not make.
       formErrorMessage =
-        "Could not compute results. Check your inputs and try again.";
+        "Something went wrong while working out your results. This looks " +
+        "like a problem on our end, not with what you entered.";
     }
   }
 
@@ -496,11 +522,7 @@
       );
       next.beginRun();
 
-      const now = new Date();
-      const currentDate = MonthDate.initFromYearsMonths({
-        years: now.getFullYear(),
-        months: now.getMonth(),
-      });
+      const currentDate = currentMonthDate();
 
       if (isSingle) {
         for (let i = 0; i < deathAgeBuckets1.length; i++) {
@@ -760,6 +782,7 @@
               singleResult={optimalSingleResult}
               coupleResult={optimalCoupleResult}
               {recipients}
+              {hasFilingChoice}
             />
             <AdvisorPrompt />
           </div>
@@ -768,7 +791,11 @@
           class="widget-anchor"
           bind:this={widgetAnchorEl}
         >
-          {#if isSingle}
+          {#if isSingle && !hasFilingChoice[0]}
+            <div class="limited-width">
+              <NoFilingDecisionPanel />
+            </div>
+          {:else if isSingle}
             <StrategyPlotSingle
               recipient={recipients[0]}
               {calculationResults}
@@ -782,6 +809,7 @@
               {calculationResults}
               {deathProbDistribution1}
               {deathProbDistribution2}
+              {hasFilingChoice}
               bind:displayAsAges
               onselectcell={handleCellSelect}
             />

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -9,7 +9,10 @@
   import { MonthDate } from "$lib/month-time";
   import { Recipient } from "$lib/recipient";
   import { optimalStrategyCoupleFast } from "$lib/strategy/calculations/optimal-strategy-fast";
-  import { optimalStrategySingle } from "$lib/strategy/calculations/strategy-calc";
+  import {
+    earliestModelableDeathAge,
+    optimalStrategySingle,
+  } from "$lib/strategy/calculations/strategy-calc";
   import {
     currentMonthDate,
     filingChoices,
@@ -425,20 +428,34 @@
     deathProbDistribution1 = [...deathProbDistribution1];
     deathProbDistribution2 = [...deathProbDistribution2];
 
-    const startAge1 = Math.max(
+    // Monthly buckets start at the first death age that admits any filing at
+    // all: the later of "now" and the earliest month the recipient could file.
+    // A death age below that leaves the optimizer nothing to search — it is
+    // not a scenario worth modelling, and asking about it is what produced
+    // the "file at age 0" result. currentAge() is whole years, so the month
+    // precision has to come from earliestFiling.
+    const currentDate = currentMonthDate();
+    const startAgeMonths1 = Math.max(
+      MIN_FILING_AGE * 12,
+      earliestModelableDeathAge(recipients[0], currentDate).asMonths()
+    );
+
+    // Three-year buckets represent each bucket by its midpoint (start + 18
+    // months), so they clear the earliest filing age without this adjustment.
+    const startAge1Years = Math.max(
       MIN_FILING_AGE,
       recipients[0].birthdate.currentAge()
     );
-    const startAge2 = Math.max(
+    const startAge2Years = Math.max(
       MIN_FILING_AGE,
       recipients[1].birthdate.currentAge()
     );
 
     deathAgeBuckets1 = isSingle
-      ? generateMonthlyBuckets(startAge1, deathProbDistribution1)
-      : generateThreeYearBuckets(startAge1, deathProbDistribution1);
+      ? generateMonthlyBuckets(startAgeMonths1, deathProbDistribution1)
+      : generateThreeYearBuckets(startAge1Years, deathProbDistribution1);
     deathAgeBuckets2 = generateThreeYearBuckets(
-      startAge2,
+      startAge2Years,
       deathProbDistribution2
     );
 

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -50,7 +50,13 @@
       years: 70,
       months: 0,
     });
-    const end = maxAge70.lessThan(deathAge) ? maxAge70 : deathAge;
+    const cap = maxAge70.lessThan(deathAge) ? maxAge70 : deathAge;
+    // A recipient already past 70 (or one who dies before reaching it) has a
+    // starting age beyond that cap. Collapse the range to that single
+    // remaining age rather than letting it invert: MonthDurationRange has no
+    // notion of an empty range, so end < start yields a negative getLength()
+    // and Array(negative) throws.
+    const end = cap.lessThan(startingAge) ? startingAge : cap;
     return new MonthDurationRange(startingAge, end);
   }
 

--- a/src/routes/strategy/components/NoFilingDecisionPanel.svelte
+++ b/src/routes/strategy/components/NoFilingDecisionPanel.svelte
@@ -1,0 +1,64 @@
+<!--
+  @component
+  @name NoFilingDecisionPanel
+  @description
+    Shown in place of the death-age chart when nobody in the scenario has a
+    filing age left to choose. Past 70 there is no lifespan trade-off left to
+    draw: delayed retirement credits have stopped, so the chart would be a
+    single repeated value.
+-->
+
+<script lang="ts">
+// True when the scenario is a couple and both are past 70.
+export let bothRecipients: boolean = false;
+</script>
+
+<div class="no-decision-note">
+  <h2>There is no filing age left to choose</h2>
+  {#if bothRecipients}
+    <p>
+      These charts normally show how the best filing ages shift with how long
+      each of you lives. You are both past 70, so that trade-off is settled:
+      delayed retirement credits stop accruing at 70, so waiting longer no
+      longer raises either monthly amount — it only skips payments you could
+      already be collecting.
+    </p>
+  {:else}
+    <p>
+      This chart normally shows how the best filing age shifts with how long
+      you live. Past 70 that trade-off is settled: delayed retirement credits
+      stop accruing at 70, so waiting longer no longer raises the monthly
+      amount — it only skips payments you could already be collecting.
+    </p>
+  {/if}
+  <p>
+    File as soon as you can, and ask SSA to backdate the claim. Once past full
+    retirement age they can pay up to six months of benefits retroactively.
+  </p>
+</div>
+
+<style>
+  .no-decision-note {
+    max-width: 720px;
+    margin: 1rem auto 2rem;
+    padding: 1.5rem 1.75rem;
+    background: #f7f8fd;
+    border-radius: 14px;
+    color: #333;
+  }
+
+  .no-decision-note h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.25rem;
+    color: #060606;
+  }
+
+  .no-decision-note p {
+    margin: 0 0 0.75rem;
+    line-height: 1.6;
+  }
+
+  .no-decision-note p:last-child {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/routes/strategy/components/NoFilingDecisionPanel.svelte
+++ b/src/routes/strategy/components/NoFilingDecisionPanel.svelte
@@ -9,13 +9,12 @@
 -->
 
 <script lang="ts">
-// True when the scenario is a couple and both are past 70.
-export let bothRecipients: boolean = false;
+export let bothPastSeventy: boolean = false;
 </script>
 
 <div class="no-decision-note">
   <h2>There is no filing age left to choose</h2>
-  {#if bothRecipients}
+  {#if bothPastSeventy}
     <p>
       These charts normally show how the best filing ages shift with how long
       each of you lives. You are both past 70, so that trade-off is settled:

--- a/src/routes/strategy/components/RecipientInputs.svelte
+++ b/src/routes/strategy/components/RecipientInputs.svelte
@@ -292,7 +292,13 @@
 </div>
 
 {#if errorMessage}
-  <div class="error-banner" role="alert">{errorMessage}</div>
+  <div class="error-banner" role="alert">
+    <p class="error-text">{errorMessage}</p>
+    <p class="error-help">
+      Reloading the page and trying again often clears it. If it keeps
+      happening, <a href="/contact">let us know</a>.
+    </p>
+  </div>
 {/if}
 
 <div class="actions">
@@ -496,6 +502,20 @@
     color: #a1241a;
     border-radius: 6px;
     font-size: 0.9rem;
+  }
+
+  .error-text {
+    margin: 0;
+  }
+
+  .error-help {
+    margin: 0.4rem 0 0;
+    font-size: 0.85rem;
+    opacity: 0.85;
+  }
+
+  .error-help a {
+    color: inherit;
   }
 
   .actions {

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import HowToReadChart from '$lib/components/HowToReadChart.svelte';
+import RecipientName from '$lib/components/RecipientName.svelte';
 import type { Recipient } from '$lib/recipient';
+import NoFilingDecisionPanel from './NoFilingDecisionPanel.svelte';
 import type {
   CalculationResults,
   CellPosition,
@@ -12,6 +14,12 @@ import StrategyMatrix from './StrategyMatrix.svelte';
 // Props
 export let recipients: [Recipient, Recipient];
 export let displayAsAges: boolean;
+/**
+ * Per recipient: false once they are past 70. A recipient with no choice left
+ * has the same filing age in every cell, so their grid carries no
+ * information and is not drawn at all.
+ */
+export let hasFilingChoice: [boolean, boolean] = [true, true];
 
 // Callback props for events
 export let onselectcell:
@@ -20,6 +28,10 @@ export let onselectcell:
 export let calculationResults: CalculationResults;
 export let deathProbDistribution1: { age: number; probability: number }[];
 export let deathProbDistribution2: { age: number; probability: number }[];
+
+// Only recipients who still have a filing decision get a grid.
+$: gridIndexes = [0, 1].filter((i) => hasFilingChoice[i]);
+$: skippedIndex = [0, 1].find((i) => !hasFilingChoice[i]);
 
 // Shared state for matrix hovering
 let hoveredCell: CellPosition | null = null;
@@ -31,103 +43,134 @@ function handleHoverCell(detail: CellPosition | null) {
 </script>
 
 <div class="result-box">
-  <div class="result-content">
-    <header class="section-header">
-      <p class="section-kicker">How death ages shape the strategies</p>
-    </header>
-    <p class="lede">
-      Every combination of lifespans has its own optimal filing strategy. The
-      <strong>Recommended Filing Ages</strong> above pick a single strategy
-      that works well across all of them; below, see what would be optimal at
-      each specific combination.
-    </p>
-    <p class="caption">
-      Each cell shows the optimal filing {displayAsAges ? 'age' : 'date'} for a
-      specific Self/Spouse death-age pair. <em>Taller rows</em> and
-      <em>wider columns</em> mark more likely death ages.
-      <strong class="hint">Click any cell</strong> to see the full filing
-      breakdown for that scenario.
-    </p>
-    <HowToReadChart>
-      <ul>
-        <li>
-          <strong>Two matrices:</strong> the left one shows Self's optimal
-          filing {displayAsAges ? 'age' : 'date'}; the right one shows Spouse's.
-          Both depend on <em>both</em> death ages because of survivor benefits.
-        </li>
-        <li>
-          <strong>Row / column position:</strong> your death age on one axis,
-          your spouse's on the other. Each cell is one specific pair.
-        </li>
-        <li>
-          <strong>Row height &amp; column width:</strong> probability of that
-          death age. Big cells are likely outcomes; tiny cells are edge cases.
-        </li>
-        <li>
-          <strong>Cell color:</strong> similar strategies share a color, so
-          large bands of one color mean the same strategy is optimal across
-          many scenarios.
-        </li>
-        <li>
-          <strong>Click a cell</strong> to see the full month-by-month benefit
-          breakdown for that death-age pair.
-        </li>
-      </ul>
-      <p>
-        <strong>Takeaway:</strong> focus on the large, dense cells. Those are
-        the most likely outcomes and they drive the Recommended Filing Ages. A
-        single strategy usually covers most of the probability mass, which is
-        why one recommendation is useful even across many possible lifespans.
+  {#if gridIndexes.length === 0}
+    <div class="result-content">
+      <NoFilingDecisionPanel bothRecipients={true} />
+    </div>
+  {:else}
+    <div class="result-content">
+      <header class="section-header">
+        <p class="section-kicker">How death ages shape the strategies</p>
+      </header>
+      <p class="lede">
+        Every combination of lifespans has its own optimal filing strategy. The
+        <strong>Recommended Filing Ages</strong> above pick a single strategy
+        that works well across all of them; below, see what would be optimal at
+        each specific combination.
       </p>
-    </HowToReadChart>
+      <p class="caption">
+        Each cell shows the optimal filing {displayAsAges ? 'age' : 'date'} for a
+        specific Self/Spouse death-age pair. <em>Taller rows</em> and
+        <em>wider columns</em> mark more likely death ages.
+        <strong class="hint">Click any cell</strong> to see the full filing
+        breakdown for that scenario.
+      </p>
+      <HowToReadChart>
+        <ul>
+          <li>
+            <strong>Two matrices:</strong> the left one shows Self's optimal
+            filing {displayAsAges ? 'age' : 'date'}; the right one shows Spouse's.
+            Both depend on <em>both</em> death ages because of survivor benefits.
+          </li>
+          <li>
+            <strong>Row / column position:</strong> your death age on one axis,
+            your spouse's on the other. Each cell is one specific pair.
+          </li>
+          <li>
+            <strong>Row height &amp; column width:</strong> probability of that
+            death age. Big cells are likely outcomes; tiny cells are edge cases.
+          </li>
+          <li>
+            <strong>Cell color:</strong> similar strategies share a color, so
+            large bands of one color mean the same strategy is optimal across
+            many scenarios.
+          </li>
+          <li>
+            <strong>Click a cell</strong> to see the full month-by-month benefit
+            breakdown for that death-age pair.
+          </li>
+        </ul>
+        <p>
+          <strong>Takeaway:</strong> focus on the large, dense cells. Those are
+          the most likely outcomes and they drive the Recommended Filing Ages. A
+          single strategy usually covers most of the probability mass, which is
+          why one recommendation is useful even across many possible lifespans.
+        </p>
+      </HowToReadChart>
+
+      {#if calculationResults.status() === CalculationStatus.Complete}
+        <div class="matrices-toolbar">
+          <span class="toolbar-label">Display filing as</span>
+          <div class="segmented" role="group" aria-label="Display filing as">
+            <button
+              type="button"
+              class="seg"
+              class:active={!displayAsAges}
+              on:click={() => (displayAsAges = false)}
+            >
+              Date
+            </button>
+            <button
+              type="button"
+              class="seg"
+              class:active={displayAsAges}
+              on:click={() => (displayAsAges = true)}
+            >
+              Age
+            </button>
+          </div>
+        </div>
+      {/if}
+    </div>
 
     {#if calculationResults.status() === CalculationStatus.Complete}
-      <div class="matrices-toolbar">
-        <span class="toolbar-label">Display filing as</span>
-        <div class="segmented" role="group" aria-label="Display filing as">
-          <button
-            type="button"
-            class="seg"
-            class:active={!displayAsAges}
-            on:click={() => (displayAsAges = false)}
-          >
-            Date
-          </button>
-          <button
-            type="button"
-            class="seg"
-            class:active={displayAsAges}
-            on:click={() => (displayAsAges = true)}
-          >
-            Age
-          </button>
+      {#if skippedIndex !== undefined}
+        <div class="result-content">
+          <p class="past-70-note">
+            <RecipientName r={recipients[skippedIndex]} /> is past 70, so there
+            is no grid for them: delayed retirement credits have stopped and
+            filing now is their only remaining option. The lifespan trade-off
+            below is <RecipientName
+              r={recipients[skippedIndex === 0 ? 1 : 0]}
+            />'s alone.
+          </p>
         </div>
+      {/if}
+      <div
+        class="matrices-container"
+        class:single-matrix={gridIndexes.length === 1}
+      >
+        {#each gridIndexes as recipientIndex (recipientIndex)}
+          <StrategyMatrix
+            {recipientIndex}
+            {recipients}
+            {calculationResults}
+            {deathProbDistribution1}
+            {deathProbDistribution2}
+            {hoveredCell}
+            {displayAsAges}
+            onhovercell={handleHoverCell}
+            {onselectcell}
+          />
+        {/each}
       </div>
     {/if}
-  </div>
-
-  {#if calculationResults.status() === CalculationStatus.Complete}
-    <div class="matrices-container">
-      {#each [0, 1] as recipientIndex}
-        <StrategyMatrix
-          {recipientIndex}
-          {recipients}
-          {calculationResults}
-          {deathProbDistribution1}
-          {deathProbDistribution2}
-          {hoveredCell}
-          {displayAsAges}
-          onhovercell={handleHoverCell}
-          {onselectcell}
-        />
-      {/each}
-    </div>
   {/if}
 </div>
 
 <style>
   .result-box {
     margin-top: 0.75rem;
+  }
+
+  .past-70-note {
+    margin: 0 0 1rem;
+    padding: 0.75rem 1rem;
+    background: #f7f8fd;
+    border-radius: 8px;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: #333;
   }
 
   /* The section heading, prose, and toolbar stay in the same 1200px column
@@ -244,6 +287,14 @@ function handleHoverCell(detail: CellPosition | null) {
     gap: 2rem;
     margin-top: 1rem;
     padding: 0 0.5rem;
+  }
+
+  /* With only one recipient still facing a decision, a half-width grid
+     stranded on the left reads as a missing second chart. */
+  .matrices-container.single-matrix {
+    grid-template-columns: minmax(0, 1fr);
+    max-width: 900px;
+    margin-inline: auto;
   }
 
   @media (max-width: 768px) {

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -44,9 +44,13 @@ function handleHoverCell(detail: CellPosition | null) {
 
 <div class="result-box">
   {#if gridIndexes.length === 0}
-    <div class="result-content">
-      <NoFilingDecisionPanel bothRecipients={true} />
-    </div>
+    <!-- Gated on Complete like the grid branch below, so the panel does not
+         flash while a calculation is still running. -->
+    {#if calculationResults.status() === CalculationStatus.Complete}
+      <div class="result-content">
+        <NoFilingDecisionPanel bothPastSeventy={true} />
+      </div>
+    {/if}
   {:else}
     <div class="result-content">
       <header class="section-header">

--- a/src/routes/strategy/components/StrategyPlotSingle.svelte
+++ b/src/routes/strategy/components/StrategyPlotSingle.svelte
@@ -60,8 +60,12 @@
     .map((_, i) => {
       const result = calculationResults.get(i, 0);
       if (!result) return null;
-      // Filter out invalid results where no filing strategy was found (e.g. death before earliest filing age)
-      if (result.filingAge1.asMonths() < earliestFilingAge) return null;
+      // No filtering on filing age here. This used to drop any point below
+      // the earliest filing age, which silently swallowed the optimizer's
+      // "file at age 0" sentinel and left the chart blank with no error.
+      // Buckets now start at the first death age that admits a filing, and
+      // the optimizer throws rather than inventing an answer, so any point
+      // reaching here is real.
       return {
         deathAge: result.bucket1.startAge,
         filingAgeMonths: result.filingAge1.asMonths(),

--- a/src/routes/strategy/components/StrategyPlotSingle.svelte
+++ b/src/routes/strategy/components/StrategyPlotSingle.svelte
@@ -40,8 +40,6 @@
   const width = 800;
   const height = 400;
   const padding = { top: 20, right: 60, bottom: 50, left: 100 };
-  // Actual earliest filing age (for filtering invalid results)
-  $: earliestFilingAge = recipient.birthdate.earliestFilingMonth().asMonths();
   // Y-axis display range with padding above and below
   const minFilingAge = 61 * 12 + 11; // 61 years 11 months
   const maxFilingAge = 70 * 12 + 1; // 70 years 1 month

--- a/src/stories/RecipientInputs.stories.ts
+++ b/src/stories/RecipientInputs.stories.ts
@@ -126,7 +126,9 @@ WithErrorBanner.args = {
   birthdateInputs: ['1965-03-15', '1967-07-22'] as [string, string],
   isSingle: false,
   continueDisabled: false,
-  errorMessage: 'Could not compute results. Check your inputs and try again.',
+  errorMessage:
+    'Something went wrong while working out your results. This looks like a ' +
+    'problem on our end, not with what you entered.',
   onUpdate: action('onUpdate'),
   onValidityChange: action('onValidityChange'),
   oncontinue: action('oncontinue'),

--- a/src/test/strategy/adversarial-couple.test.ts
+++ b/src/test/strategy/adversarial-couple.test.ts
@@ -650,36 +650,31 @@ describe('Three-way comparison: couple NPV vs sum of singles', () => {
 // 11. Filing age past 70y0m
 // ==========================================================================
 describe('Filing age past 70y0m', () => {
-  it('filing at 70y1m: strategySumCentsCouple still produces a result', () => {
-    // 70y1m = 841 months. The system should either clamp or handle gracefully.
+  it('filing at 70y1m: delayed credits are capped, so only payments are lost', () => {
+    // 70y1m = 841 months. Delayed credits stop accruing at 70, so filing a
+    // month later buys nothing and forgoes one month of benefits.
     const r1 = makeRecipientDec15(2000, 1960);
     const r2 = makeRecipientDec15(500, 1960);
     const fd1 = finalDateAtAge(r1, 85);
     const fd2 = finalDateAtAge(r2, 85);
 
-    // This might throw or might produce a result. Either is acceptable,
-    // but it should not crash with an unhandled exception.
-    let threw = false;
-    let npv = 0;
-    try {
-      npv = strategySumCentsCouple(
-        [r1, r2],
-        [fd1, fd2],
-        FAR_PAST,
-        NO_DISCOUNT,
-        [filingAge(70, 1), filingAge(67)]
-      );
-    } catch {
-      threw = true;
-    }
+    const npvAt70y1m = strategySumCentsCouple(
+      [r1, r2],
+      [fd1, fd2],
+      FAR_PAST,
+      NO_DISCOUNT,
+      [filingAge(70, 1), filingAge(67)]
+    );
+    const npvAt70 = strategySumCentsCouple(
+      [r1, r2],
+      [fd1, fd2],
+      FAR_PAST,
+      NO_DISCOUNT,
+      [filingAge(70), filingAge(67)]
+    );
 
-    // If it did not throw, NPV should still be non-negative
-    if (!threw) {
-      expect(npv).toBeGreaterThanOrEqual(0);
-    }
-    // If it threw, that's also a valid response to invalid input.
-    // The test passes either way -- we're checking for no unhandled crash.
-    expect(true).toBe(true);
+    expect(npvAt70y1m).toBeGreaterThan(0);
+    expect(npvAt70y1m).toBeLessThan(npvAt70);
   });
 
   it('filing at exactly 70y0m is valid and produces maximum delayed credits', () => {

--- a/src/test/strategy/couple-edge-cases.test.ts
+++ b/src/test/strategy/couple-edge-cases.test.ts
@@ -16,6 +16,7 @@ import {
   strategySumPeriodsCouple,
 } from '$lib/strategy/calculations';
 import {
+  earliestFiling,
   optimalStrategyCouple,
   optimalStrategyCoupleOptimized,
 } from '$lib/strategy/calculations/strategy-calc';
@@ -247,12 +248,10 @@ describe('Same birthdate, same PIA -- symmetric couple', () => {
 // 3. One spouse already past 70
 // ---------------------------------------------------------------------------
 describe('One spouse already past 70', () => {
-  it('born 1950, currentDate 2025 (age 75): optimizer returns -1 (no valid filing window)', () => {
-    // When the recipient is past 70 and currentDate is recent,
-    // earliestFiling returns an age greater than 70*12. Since the optimizer
-    // loop goes from earliestFiling to 70*12, it never iterates and returns
-    // the default -1 value. This documents that the optimizer does not
-    // support recipients who are already past 70.
+  it('born 1950, currentDate 2025 (age 75): files at the only age left', () => {
+    // Past 70 the earliest filing age exceeds 70, so there is exactly one
+    // option: file now (backdated as far as SSA allows). The spouse who is
+    // still under 70 keeps a real filing decision.
     const r1 = makeRecipient(1500, 1950, 5, 15);
     const r2 = makeRecipient(1000, 1960, 0, 15);
     const fd1 = finalDateAtAge(r1, 90);
@@ -268,14 +267,21 @@ describe('One spouse already past 70', () => {
       currentDate,
       NO_DISCOUNT
     );
-    // The optimizer returns -1 when the earliest filing age exceeds 70*12,
-    // because no valid strategy exists within the search space.
-    expect(result[2]).toBe(-1);
+
+    expect(result[2]).toBeGreaterThan(0);
+    expect(result[0].asMonths()).toBe(
+      earliestFiling(r1, currentDate).asMonths()
+    );
+    // The under-70 spouse still gets a genuine optimization.
+    expect(result[1].asMonths()).toBeGreaterThanOrEqual(
+      earliestFiling(r2, currentDate).asMonths()
+    );
+    expect(result[1].asMonths()).toBeLessThanOrEqual(70 * 12);
   });
 
-  it('both born 1950, currentDate 2025: both past 70, optimizer returns -1', () => {
-    // When both recipients are past 70 with a recent currentDate, the
-    // optimizer cannot find any valid strategy and returns its default -1.
+  it('both born 1950, currentDate 2025: both past 70, both file now', () => {
+    // With both past 70 the search space is a single pair, but it is a valid
+    // pair and must produce a real NPV rather than the empty-range sentinel.
     const r1 = makeRecipient(2000, 1950, 3, 10);
     const r2 = makeRecipient(1500, 1950, 6, 20);
     const fd1 = finalDateAtAge(r1, 90);
@@ -291,7 +297,14 @@ describe('One spouse already past 70', () => {
       currentDate,
       NO_DISCOUNT
     );
-    expect(result[2]).toBe(-1);
+
+    expect(result[2]).toBeGreaterThan(0);
+    expect(result[0].asMonths()).toBe(
+      earliestFiling(r1, currentDate).asMonths()
+    );
+    expect(result[1].asMonths()).toBe(
+      earliestFiling(r2, currentDate).asMonths()
+    );
   });
 
   it('optimized version matches non-optimized when one spouse past 70', () => {

--- a/src/test/strategy/couple-edge-cases.test.ts
+++ b/src/test/strategy/couple-edge-cases.test.ts
@@ -329,7 +329,19 @@ describe('One spouse already past 70', () => {
       currentDate,
       NO_DISCOUNT
     );
+
+    // Guard against a vacuous pass: before the past-70 fix both sides
+    // returned the -1 sentinel, so comparing them to each other proved
+    // nothing. Assert a real result first, then agreement.
+    expect(result[2]).toBeGreaterThan(0);
     expect(resultOpt[2]).toBe(result[2]);
+    expect(resultOpt[0].asMonths()).toBe(result[0].asMonths());
+    expect(resultOpt[1].asMonths()).toBe(result[1].asMonths());
+    // The past-70 spouse has one option; the under-70 spouse keeps a range.
+    expect(result[0].asMonths()).toBe(
+      earliestFiling(r1, currentDate).asMonths()
+    );
+    expect(result[1].asMonths()).toBeLessThanOrEqual(70 * 12);
   });
 });
 

--- a/src/test/strategy/edge-currentdate.test.ts
+++ b/src/test/strategy/edge-currentdate.test.ts
@@ -212,9 +212,10 @@ describe('earliestFiling - well past NRA (6-month limit)', () => {
 describe('earliestFiling - at or past 70', () => {
   // When the recipient is at or past age 70, the 6-month retroactive rule
   // still applies, so earliest = currentAge - 6 months.
-  // Past 70 that earliest age exceeds 70y0m. Optimizers must bound their
-  // search with `filingAgeRange` rather than a literal 70, which collapses
-  // the range to that single remaining choice (see over-70-filing.test.ts).
+  // That earliest age reaches 70y0m at age 70y6m and exceeds it thereafter.
+  // Optimizers must bound their search with `filingAgeRange` rather than a
+  // literal 70; `filingAgeRange` collapses the range to the single remaining
+  // choice from that point on (see over-70-filing.test.ts).
 
   it('currentDate Jan 2030 (age 70y0m): earliest = 69y6m', () => {
     const r = makeRecipient(1000, 1960, 0, 15);
@@ -236,7 +237,9 @@ describe('earliestFiling - at or past 70', () => {
     const earliest = earliestFiling(r, currentDate);
     // 6-month rule gives 72y0m - 6m = 71y6m, which exceeds 70y0m.
     expect(earliest.asMonths()).toBe(ageDuration(71, 6).asMonths());
-    // Past the age-70 cap, so this is the only filing age left:
+    // Past the age-70 cap, so this is the only filing age left. (At exactly
+    // age 70y6m the earliest age equals 70y0m, which is also a single
+    // remaining choice; it first exceeds 70y0m from 70y7m on.)
     expect(earliest.asMonths()).toBeGreaterThan(ageDuration(70, 0).asMonths());
   });
 });

--- a/src/test/strategy/edge-currentdate.test.ts
+++ b/src/test/strategy/edge-currentdate.test.ts
@@ -212,8 +212,9 @@ describe('earliestFiling - well past NRA (6-month limit)', () => {
 describe('earliestFiling - at or past 70', () => {
   // When the recipient is at or past age 70, the 6-month retroactive rule
   // still applies, so earliest = currentAge - 6 months.
-  // The optimizer loop runs for i = earliest to i <= 70*12, so if earliest
-  // exceeds 70y0m the loop has an empty range.
+  // Past 70 that earliest age exceeds 70y0m. Optimizers must bound their
+  // search with `filingAgeRange` rather than a literal 70, which collapses
+  // the range to that single remaining choice (see over-70-filing.test.ts).
 
   it('currentDate Jan 2030 (age 70y0m): earliest = 69y6m', () => {
     const r = makeRecipient(1000, 1960, 0, 15);
@@ -229,14 +230,13 @@ describe('earliestFiling - at or past 70', () => {
     expect(earliest.asMonths()).toBe(ageDuration(70, 0).asMonths());
   });
 
-  it('currentDate Jan 2032 (age 72y0m): earliest = 71y6m (past 70, empty optimizer range)', () => {
+  it('currentDate Jan 2032 (age 72y0m): earliest = 71y6m, past 70', () => {
     const r = makeRecipient(1000, 1960, 0, 15);
     const currentDate = monthDate(2032, 0); // Jan 2032
     const earliest = earliestFiling(r, currentDate);
     // 6-month rule gives 72y0m - 6m = 71y6m, which exceeds 70y0m.
-    // The optimizer loop (i = 71y6m .. i <= 70y0m) is empty.
     expect(earliest.asMonths()).toBe(ageDuration(71, 6).asMonths());
-    // Verify that the optimizer range would be empty:
+    // Past the age-70 cap, so this is the only filing age left:
     expect(earliest.asMonths()).toBeGreaterThan(ageDuration(70, 0).asMonths());
   });
 });

--- a/src/test/strategy/generate-grid-goldens.test.ts
+++ b/src/test/strategy/generate-grid-goldens.test.ts
@@ -10,11 +10,19 @@
  * Output: src/test/strategy/goldens/grid-goldens.json
  *
  * Coverage scope:
- *   - Inputs are constrained so both recipients have earliestFiling < 70y
- *     (i.e. the optimization loop is non-empty). Cases where a recipient is
- *     already past age 70+6m at currentDate are intentionally excluded —
- *     they produce a sentinel result in both slow and optimized paths and
- *     don't validate anything. The UI also never generates such cases.
+ *   - Inputs are constrained so both recipients have earliestFiling < 70y,
+ *     i.e. both still have a filing age to choose. Cases where a recipient is
+ *     already past age 70y6m at currentDate are not represented here.
+ *
+ *     They used to be excluded on the grounds that they produced a sentinel
+ *     in both paths and that the UI never generated them. Both claims were
+ *     wrong: the UI does reach them (a user simply enters a birthdate over
+ *     70), and the sentinel was the bug — the couple path actually threw
+ *     `RangeError: Invalid typed array length`. Since the optimizers now
+ *     return a real result there, these cases WOULD validate something, and
+ *     extending the generator to cover them is worthwhile. Until then, see
+ *     over-70-filing.test.ts, which pins slow-vs-fast agreement in that
+ *     regime directly.
  *   - Death ages are always >= currentAge + 1 year (mirrors UI buckets,
  *     which start past the person's current age).
  *

--- a/src/test/strategy/no-filing-age-available.test.ts
+++ b/src/test/strategy/no-filing-age-available.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for scenarios in which a recipient has no filing age at all, because
+ * they die before the earliest month they could have filed.
+ *
+ * The optimizers used to answer that malformed question with a sentinel —
+ * `[MonthDuration(0), -1]`, i.e. "file at age 0 for minus one cent". Nothing
+ * in the return type distinguished it from a real strategy, so the strategy
+ * page wrote it straight into the results grid and a filter in
+ * StrategyPlotSingle silently dropped the resulting points. That pairing (a
+ * producer emitting well-typed garbage, a consumer quietly discarding it) is
+ * how the over-70 bug rendered an empty chart with no error at all.
+ *
+ * Two changes close it, and both are pinned here:
+ *   - Death-age buckets start at `earliestModelableDeathAge`, so the UI never
+ *     asks the question.
+ *   - The optimizers throw rather than inventing an answer, so every value of
+ *     their return types is a real strategy.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
+import { MonthDate, MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+import { optimalStrategyCoupleFast } from '$lib/strategy/calculations/optimal-strategy-fast';
+import {
+  earliestFiling,
+  earliestModelableDeathAge,
+  NoFilingAgeAvailableError,
+  optimalStrategyCouple,
+  optimalStrategyCoupleOptimized,
+  optimalStrategySingle,
+} from '$lib/strategy/calculations/strategy-calc';
+import { generateMonthlyBuckets } from '$lib/strategy/ui';
+
+function makeRecipient(
+  piaDollars: number,
+  birthYear: number,
+  birthMonthIndex: number,
+  birthDay: number
+): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(birthYear, birthMonthIndex, birthDay);
+  r.setPia(Money.from(piaDollars));
+  return r;
+}
+
+const age = (years: number, months = 0): MonthDuration =>
+  MonthDuration.initFromYearsMonths({ years, months });
+
+const monthDate = (year: number, monthIndex: number): MonthDate =>
+  MonthDate.initFromYearsMonths({ years: year, months: monthIndex });
+
+function flatDeathDistribution(
+  fromAge: number
+): { age: number; probability: number }[] {
+  const dist: { age: number; probability: number }[] = [];
+  for (let a = fromAge; a <= 119; a++) {
+    dist.push({ age: a, probability: 1 / (119 - fromAge + 1) });
+  }
+  return dist;
+}
+
+describe('earliestModelableDeathAge', () => {
+  // Born on the 15th, so earliestFilingMonth is the month AFTER the 62nd
+  // birthday (62y1m). At age 62y1m exactly, a bucket derived from whole-year
+  // currentAge() would sit at 62y0m — one month before they could file.
+  it('does not fall below the earliest filing age', () => {
+    const r = makeRecipient(2000, 1964, 5, 15);
+    const currentDate = monthDate(2026, 6); // Jul 2026 -> age 62y1m
+
+    expect(r.birthdate.currentAge()).toBe(62);
+    expect(earliestFiling(r, currentDate).asMonths()).toBe(
+      age(62, 1).asMonths()
+    );
+    expect(earliestModelableDeathAge(r, currentDate).asMonths()).toBe(
+      age(62, 1).asMonths()
+    );
+  });
+
+  // Someone aged 70y11m has a whole-year currentAge() of 70, but cannot file
+  // any earlier than 70y5m, so buckets at 70y0m..70y4m are unmodelable.
+  it('does not fall below the current age past 70', () => {
+    const r = makeRecipient(2000, 1955, 9, 15);
+    const currentDate = monthDate(2026, 8); // Sep 2026 -> age 70y11m
+
+    expect(r.birthdate.currentAge()).toBe(70);
+    const modelable = earliestModelableDeathAge(r, currentDate);
+    expect(modelable.asMonths()).toBe(age(70, 11).asMonths());
+    expect(modelable.greaterThanOrEqual(earliestFiling(r, currentDate))).toBe(
+      true
+    );
+  });
+});
+
+describe('monthly buckets built from earliestModelableDeathAge', () => {
+  // The end-to-end property: every bucket the UI generates must admit at
+  // least one filing age, so the optimizer is never asked the malformed
+  // question in the first place.
+  const cases: [string, Recipient, MonthDate][] = [
+    ['age 62y1m', makeRecipient(2000, 1964, 5, 15), monthDate(2026, 6)],
+    ['age 70y11m', makeRecipient(2000, 1955, 9, 15), monthDate(2026, 8)],
+    ['age 78', makeRecipient(2000, 1948, 5, 15), monthDate(2026, 8)],
+  ];
+
+  for (const [label, recipient, currentDate] of cases) {
+    it(`every bucket admits a filing age at ${label}`, () => {
+      const startMonths = earliestModelableDeathAge(
+        recipient,
+        currentDate
+      ).asMonths();
+      const buckets = generateMonthlyBuckets(
+        startMonths,
+        flatDeathDistribution(Math.floor(startMonths / 12))
+      );
+      expect(buckets.length).toBeGreaterThan(0);
+
+      for (const bucket of buckets) {
+        const finalDate = recipient.birthdate.dateAtLayAge(bucket.expectedAge);
+        // Must not throw, and must return a filing age inside the range.
+        const [filingAge, npv] = optimalStrategySingle(
+          recipient,
+          finalDate,
+          currentDate,
+          0.03
+        );
+        expect(filingAge.asMonths()).toBeGreaterThanOrEqual(
+          earliestFiling(recipient, currentDate).asMonths()
+        );
+        expect(npv).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+/** Recipient `a` dies at 62y0m, one month before they could first file. */
+function coupleWhereFirstDiesBeforeFiling(): [Recipient, Recipient] {
+  const a = makeRecipient(2000, 1964, 5, 15);
+  const b = makeRecipient(1200, 1962, 5, 15);
+  a.markFirst();
+  b.markSecond();
+  return [a, b];
+}
+
+function deathDatesForThatCouple(
+  a: Recipient,
+  b: Recipient
+): [MonthDate, MonthDate] {
+  return [
+    a.birthdate.dateAtLayAge(age(62, 0)),
+    b.birthdate.dateAtLayAge(age(90)),
+  ];
+}
+
+describe('optimizers reject a scenario with no filing age', () => {
+  it('optimalStrategySingle throws rather than returning age 0', () => {
+    const r = makeRecipient(2000, 1964, 5, 15);
+    const currentDate = monthDate(2026, 6); // age 62y1m, earliest filing 62y1m
+    // Dies at 62y0m — one month before they could file.
+    const finalDate = r.birthdate.dateAtLayAge(age(62, 0));
+
+    expect(() =>
+      optimalStrategySingle(r, finalDate, currentDate, 0.03)
+    ).toThrow(NoFilingAgeAvailableError);
+  });
+
+  // A couple is different from a single recipient: one spouse dying before
+  // they could file does NOT make the scenario meaningless. The other still
+  // has a genuine filing decision, and the survivor benefit still depends on
+  // it. Throwing (or returning the old [0, 0, -1] sentinel) would discard
+  // that answer, so the couple optimizers collapse the dead spouse's range
+  // to a single immaterial age instead.
+  it("keeps the surviving spouse's decision when the other cannot file", () => {
+    const cur = monthDate(2026, 6);
+    const [a, b] = coupleWhereFirstDiesBeforeFiling();
+    const finalDates = deathDatesForThatCouple(a, b);
+
+    const fast = optimalStrategyCoupleFast([a, b], finalDates, cur, 0.03);
+    expect(fast[2]).toBeGreaterThan(0);
+    // The surviving spouse's age is a real filing age in their own range.
+    expect(fast[1].asMonths()).toBeGreaterThanOrEqual(
+      earliestFiling(b, cur).asMonths()
+    );
+    expect(fast[1].asMonths()).toBeLessThanOrEqual(70 * 12);
+    // The spouse who died first is reported at their earliest filing age
+    // rather than an impossible age 0.
+    expect(fast[0].asMonths()).toBe(earliestFiling(a, cur).asMonths());
+  });
+
+  it('all three couple implementations agree in that case', () => {
+    const cur = monthDate(2026, 6);
+    const [a, b] = coupleWhereFirstDiesBeforeFiling();
+    const finalDates = deathDatesForThatCouple(a, b);
+
+    const fast = optimalStrategyCoupleFast([a, b], finalDates, cur, 0.03);
+    const optimized = optimalStrategyCoupleOptimized(
+      [a, b],
+      finalDates,
+      cur,
+      0.03
+    );
+    const slow = optimalStrategyCouple([a, b], finalDates, cur, 0.03);
+
+    for (const other of [optimized, slow]) {
+      expect(other[0].asMonths()).toBe(fast[0].asMonths());
+      expect(other[1].asMonths()).toBe(fast[1].asMonths());
+      expect(Math.abs(other[2] - fast[2])).toBeLessThan(1);
+    }
+  });
+
+  it('names both bounds so the malformed scenario is identifiable', () => {
+    const r = makeRecipient(2000, 1964, 5, 15);
+    const currentDate = monthDate(2026, 6);
+    const finalDate = r.birthdate.dateAtLayAge(age(62, 0));
+
+    expect(() =>
+      optimalStrategySingle(r, finalDate, currentDate, 0.03)
+    ).toThrow(/earliest filing age is 745 months.*only through 744 months/);
+  });
+});

--- a/src/test/strategy/over-70-filing.test.ts
+++ b/src/test/strategy/over-70-filing.test.ts
@@ -11,17 +11,19 @@
  * passed 70 that range went empty or negative, which produced a nonsense
  * "file at age 0" result in the single optimizer and a
  * `RangeError: Invalid typed array length` in the couple optimizer. The couple
- * case surfaced on /strategy as "Could not compute results", which also hid the
- * still-meaningful filing decision of an under-70 spouse.
+ * case surfaced on /strategy as a generic computation-failure banner, which
+ * also hid the still-meaningful filing decision of an under-70 spouse.
  */
 
 import { describe, expect, it } from 'vitest';
 import { benefitAtAge, survivorBenefit } from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
+import { filingChoices } from '$lib/components/recommended-filing-card';
 import { Money } from '$lib/money';
 import { MonthDate, MonthDuration } from '$lib/month-time';
 import { Recipient } from '$lib/recipient';
 import {
+  expectedNPVCouple,
   expectedNPVCoupleOptimized,
   expectedNPVSingle,
 } from '$lib/strategy/calculations/expected-npv';
@@ -34,9 +36,17 @@ import {
   optimalStrategySingle,
 } from '$lib/strategy/calculations/strategy-calc';
 
-function makeRecipient(piaDollars: number, birthYear: number): Recipient {
+function makeRecipient(
+  piaDollars: number,
+  birthYear: number,
+  birthMonthIndex: number = 5
+): Recipient {
+  // Normalize so callers may pass an out-of-range month index (e.g. a month
+  // arithmetic result of -2, meaning November of the previous year).
+  const year = birthYear + Math.floor(birthMonthIndex / 12);
+  const month = ((birthMonthIndex % 12) + 12) % 12;
   const r = new Recipient();
-  r.birthdate = Birthdate.FromYMD(birthYear, 5, 15);
+  r.birthdate = Birthdate.FromYMD(year, month, 15);
   r.setPia(Money.from(piaDollars));
   return r;
 }
@@ -171,9 +181,73 @@ describe('filingAgeRange', () => {
     expect(range.latest.asMonths()).toBe(earliest.asMonths());
   });
 
+  // The flip is at 70y6m, not 70y0m: SSA's six-month retroactive window means
+  // `earliest` lags current age by six months once past full retirement age.
+  // Both sides of that boundary are pinned here, because an off-by-one in
+  // either direction reintroduces a shipped bug — `lessThanOrEqual` would show
+  // a 70y6m user a filing date six months in the past, and dropping the
+  // `hasChoice` ternary on `latest` would put the range back to negative
+  // length at 70y7m.
+  describe('the 70y6m boundary', () => {
+    // Born on the 15th, so earliestFilingMonth is the month after the 62nd
+    // birthday and `earliest` tracks currentAge - 6 months past FRA.
+    const atAge = (years: number, months: number): Recipient =>
+      makeRecipient(
+        2000,
+        CURRENT_DATE.year() - years,
+        CURRENT_DATE.monthIndex() - months
+      );
+
+    it('still has a choice at 70y5m (two ages left to search)', () => {
+      const range = filingAgeRange(atAge(70, 5), CURRENT_DATE);
+      expect(range.hasChoice).toBe(true);
+      expect(range.earliest.asMonths()).toBe(MAX_FILING_AGE.asMonths() - 1);
+      expect(range.latest.asMonths()).toBe(MAX_FILING_AGE.asMonths());
+    });
+
+    it('has no choice left at exactly 70y6m', () => {
+      const range = filingAgeRange(atAge(70, 6), CURRENT_DATE);
+      expect(range.hasChoice).toBe(false);
+      expect(range.earliest.asMonths()).toBe(MAX_FILING_AGE.asMonths());
+      expect(range.latest.asMonths()).toBe(MAX_FILING_AGE.asMonths());
+    });
+
+    it('keeps a non-empty range past the boundary at 70y7m', () => {
+      const range = filingAgeRange(atAge(70, 7), CURRENT_DATE);
+      expect(range.hasChoice).toBe(false);
+      expect(range.earliest.asMonths()).toBe(MAX_FILING_AGE.asMonths() + 1);
+      // The span must never invert: a negative (latest - earliest + 1) is
+      // what threw RangeError from the fast paths' typed arrays.
+      expect(range.latest.asMonths()).toBe(range.earliest.asMonths());
+      expect(
+        range.latest.asMonths() - range.earliest.asMonths() + 1
+      ).toBeGreaterThan(0);
+    });
+  });
+
   it('reports whether a filing decision remains', () => {
     expect(filingAgeRange(UNDER_70(), CURRENT_DATE).hasChoice).toBe(true);
     expect(filingAgeRange(OVER_70(), CURRENT_DATE).hasChoice).toBe(false);
+  });
+});
+
+describe('filingChoices', () => {
+  // Shared by the strategy page and the calculator's recommendation card so
+  // the two cannot disagree about who still has a decision to make.
+  it('reports both recipients for a couple', () => {
+    expect(filingChoices(UNDER_70(), OVER_70(), CURRENT_DATE)).toEqual([
+      true,
+      false,
+    ]);
+    expect(filingChoices(OVER_70(), UNDER_70(), CURRENT_DATE)).toEqual([
+      false,
+      true,
+    ]);
+  });
+
+  it('reports the second slot as true when there is no spouse', () => {
+    expect(filingChoices(OVER_70(), null, CURRENT_DATE)).toEqual([false, true]);
+    expect(filingChoices(UNDER_70(), null, CURRENT_DATE)).toEqual([true, true]);
   });
 });
 
@@ -296,6 +370,51 @@ describe('couple optimizer with one recipient past age 70', () => {
     // Within a cent, matching the tolerance the golden tests use: the two
     // implementations accumulate the same sum in a different order.
     expect(Math.abs(fast[2] - reference[2])).toBeLessThan(1);
+  });
+
+  it('the production NPV path agrees with its slow reference', () => {
+    // The /strategy page and the calculator card both consume
+    // expectedNPVCoupleOptimized, a different implementation from
+    // optimalStrategyCoupleFast above, with its own resized typed arrays.
+    // Unlike the golden tests (which compare an implementation against a
+    // stored snapshot of itself), this compares two independent
+    // implementations, so agreement here is the stronger claim.
+    const over = OVER_70();
+    const under = UNDER_70();
+    over.markFirst();
+    under.markSecond();
+    const recipients: [Recipient, Recipient] = [over, under];
+    const dists: [
+      { age: number; probability: number }[],
+      { age: number; probability: number }[],
+    ] = [flatDeathDistribution(78), flatDeathDistribution(64)];
+
+    const fast = expectedNPVCoupleOptimized(
+      recipients,
+      CURRENT_DATE,
+      DISCOUNT_RATE,
+      dists
+    );
+    const reference = expectedNPVCouple(
+      recipients,
+      CURRENT_DATE,
+      DISCOUNT_RATE,
+      dists
+    );
+
+    expect(fast.length).toBe(reference.length);
+    expect(fast.length).toBeGreaterThan(1);
+    for (let i = 0; i < fast.length; i++) {
+      expect(fast[i].filingAges[0].asMonths()).toBe(
+        reference[i].filingAges[0].asMonths()
+      );
+      expect(fast[i].filingAges[1].asMonths()).toBe(
+        reference[i].filingAges[1].asMonths()
+      );
+      expect(
+        Math.abs(fast[i].expectedNPVCents - reference[i].expectedNPVCents)
+      ).toBeLessThan(1);
+    }
   });
 
   it('handles both recipients being past 70', () => {

--- a/src/test/strategy/over-70-filing.test.ts
+++ b/src/test/strategy/over-70-filing.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Regression tests for recipients who are already past age 70.
+ *
+ * Delayed retirement credits stop accruing at age 70, so someone older than
+ * that has no filing decision left to make: the only thing they can do is file
+ * now (SSA allows up to six months of retroactivity), and the amount is the
+ * age-70 amount regardless of how long they waited.
+ *
+ * The optimizers used to encode the age-70 cap only as a loop bound
+ * (`for (age = earliestFiling; age <= 70*12; age++)`). Once `earliestFiling`
+ * passed 70 that range went empty or negative, which produced a nonsense
+ * "file at age 0" result in the single optimizer and a
+ * `RangeError: Invalid typed array length` in the couple optimizer. The couple
+ * case surfaced on /strategy as "Could not compute results", which also hid the
+ * still-meaningful filing decision of an under-70 spouse.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { benefitAtAge, survivorBenefit } from '$lib/benefit-calculator';
+import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
+import { MonthDate, MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+import {
+  expectedNPVCoupleOptimized,
+  expectedNPVSingle,
+} from '$lib/strategy/calculations/expected-npv';
+import { optimalStrategyCoupleFast } from '$lib/strategy/calculations/optimal-strategy-fast';
+import {
+  earliestFiling,
+  filingAgeRange,
+  MAX_FILING_AGE,
+  optimalStrategyCouple,
+  optimalStrategySingle,
+} from '$lib/strategy/calculations/strategy-calc';
+
+function makeRecipient(piaDollars: number, birthYear: number): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(birthYear, 5, 15);
+  r.setPia(Money.from(piaDollars));
+  return r;
+}
+
+function age(years: number, months: number = 0): MonthDuration {
+  return MonthDuration.initFromYearsMonths({ years, months });
+}
+
+function monthDate(year: number, monthIndex: number): MonthDate {
+  return MonthDate.initFromYearsMonths({ years: year, months: monthIndex });
+}
+
+/**
+ * A flat death distribution over the ages a recipient could still reach. The
+ * exact shape does not matter for these tests; what matters is that every
+ * recipient has some probability mass at every remaining age.
+ */
+function flatDeathDistribution(
+  fromAge: number
+): { age: number; probability: number }[] {
+  const dist: { age: number; probability: number }[] = [];
+  const toAge = 119;
+  for (let a = fromAge; a <= toAge; a++) {
+    dist.push({ age: a, probability: 1 / (toAge - fromAge + 1) });
+  }
+  return dist;
+}
+
+// Born Jun 1948, so age 78 in Jun 2026. Well past any filing decision.
+const OVER_70 = () => makeRecipient(2000, 1948);
+// Born Jun 1962, so age 64 in Jun 2026. Still has a real decision to make.
+const UNDER_70 = () => makeRecipient(1200, 1962);
+const CURRENT_DATE = monthDate(2026, 5);
+const DISCOUNT_RATE = 0.03;
+
+describe('delayed retirement credits stop at age 70', () => {
+  it('pays the same amount at 72 as at 70', () => {
+    const r = makeRecipient(2000, 1948);
+    expect(benefitAtAge(r, age(72)).cents()).toBe(
+      benefitAtAge(r, age(70)).cents()
+    );
+  });
+
+  it('pays the same amount at 70y1m as at 70y0m', () => {
+    const r = makeRecipient(2000, 1948);
+    expect(benefitAtAge(r, age(70, 1)).cents()).toBe(
+      benefitAtAge(r, age(70)).cents()
+    );
+  });
+
+  it('still credits every month up to 70', () => {
+    const r = makeRecipient(2000, 1948);
+    expect(benefitAtAge(r, age(70)).cents()).toBeGreaterThan(
+      benefitAtAge(r, age(69, 11)).cents()
+    );
+  });
+});
+
+describe('survivor benefit when the deceased filed past 70', () => {
+  // survivorBenefit reads the deceased's benefit at a date late enough for
+  // every delayed credit to have landed. That date used to be a fixed age 71,
+  // which is *before* the filing date of anyone who filed later — and
+  // benefitOnDate returns $0 for a date before filing. The Math.max then fell
+  // through to the 82.5%-of-PIA floor, understating the survivor benefit.
+  it('is based on the age-70 benefit, not the 82.5% floor', () => {
+    const deceased = makeRecipient(2000, 1948);
+    const survivor = makeRecipient(1200, 1950);
+
+    const filingDate = deceased.birthdate.dateAtSsaAge(age(77, 6));
+    const deathDate = deceased.birthdate.dateAtLayAge(age(90));
+    const survivorFilingDate = deathDate.addDuration(new MonthDuration(1));
+
+    const benefit = survivorBenefit(
+      survivor,
+      deceased,
+      filingDate,
+      deathDate,
+      survivorFilingDate
+    );
+
+    // The deceased's own benefit, with credits capped at 70, is the floor of
+    // what the survivor receives — strictly more than 82.5% of PIA.
+    const at70 = benefitAtAge(deceased, MAX_FILING_AGE);
+    expect(benefit.cents()).toBe(at70.cents());
+    expect(benefit.cents()).toBeGreaterThan(
+      deceased.pia().primaryInsuranceAmount().times(0.825).cents()
+    );
+  });
+
+  it('matches the age-70 case for a deceased who filed at exactly 70', () => {
+    const deceased = makeRecipient(2000, 1948);
+    const survivor = makeRecipient(1200, 1950);
+    const deathDate = deceased.birthdate.dateAtLayAge(age(90));
+    const survivorFilingDate = deathDate.addDuration(new MonthDuration(1));
+
+    const filedAt70 = survivorBenefit(
+      survivor,
+      deceased,
+      deceased.birthdate.dateAtSsaAge(MAX_FILING_AGE),
+      deathDate,
+      survivorFilingDate
+    );
+    const filedAt77 = survivorBenefit(
+      survivor,
+      deceased,
+      deceased.birthdate.dateAtSsaAge(age(77, 6)),
+      deathDate,
+      survivorFilingDate
+    );
+
+    expect(filedAt77.cents()).toBe(filedAt70.cents());
+  });
+});
+
+describe('filingAgeRange', () => {
+  it('runs from the earliest filing age to 70 for an under-70 recipient', () => {
+    const r = UNDER_70();
+    const range = filingAgeRange(r, CURRENT_DATE);
+    expect(range.earliest.asMonths()).toBe(
+      earliestFiling(r, CURRENT_DATE).asMonths()
+    );
+    expect(range.latest.asMonths()).toBe(MAX_FILING_AGE.asMonths());
+    expect(range.earliest.lessThan(range.latest)).toBe(true);
+  });
+
+  it('collapses to a single choice for an over-70 recipient', () => {
+    const r = OVER_70();
+    const range = filingAgeRange(r, CURRENT_DATE);
+    const earliest = earliestFiling(r, CURRENT_DATE);
+    expect(earliest.greaterThan(MAX_FILING_AGE)).toBe(true);
+    expect(range.earliest.asMonths()).toBe(earliest.asMonths());
+    expect(range.latest.asMonths()).toBe(earliest.asMonths());
+  });
+
+  it('reports whether a filing decision remains', () => {
+    expect(filingAgeRange(UNDER_70(), CURRENT_DATE).hasChoice).toBe(true);
+    expect(filingAgeRange(OVER_70(), CURRENT_DATE).hasChoice).toBe(false);
+  });
+});
+
+describe('single optimizer past age 70', () => {
+  it('recommends filing now rather than an impossible age 0', () => {
+    const r = OVER_70();
+    const finalDate = r.birthdate.dateAtLayAge(age(90));
+    const [filingAge, npvCents] = optimalStrategySingle(
+      r,
+      finalDate,
+      CURRENT_DATE,
+      DISCOUNT_RATE
+    );
+
+    expect(filingAge.asMonths()).toBe(
+      earliestFiling(r, CURRENT_DATE).asMonths()
+    );
+    expect(npvCents).toBeGreaterThan(0);
+  });
+
+  it('returns a non-empty expected-NPV ranking', () => {
+    const r = OVER_70();
+    const results = expectedNPVSingle(
+      r,
+      CURRENT_DATE,
+      DISCOUNT_RATE,
+      flatDeathDistribution(78)
+    );
+
+    expect(results.length).toBe(1);
+    expect(results[0].filingAge.asMonths()).toBe(
+      earliestFiling(r, CURRENT_DATE).asMonths()
+    );
+    expect(results[0].expectedNPVCents).toBeGreaterThan(0);
+  });
+});
+
+describe('couple optimizer with one recipient past age 70', () => {
+  it('computes a strategy instead of throwing', () => {
+    const over = OVER_70();
+    const under = UNDER_70();
+    over.markFirst();
+    under.markSecond();
+    const recipients: [Recipient, Recipient] = [over, under];
+
+    const [overFilingAge, underFilingAge, npvCents] = optimalStrategyCoupleFast(
+      recipients,
+      [
+        over.birthdate.dateAtLayAge(age(90)),
+        under.birthdate.dateAtLayAge(age(90)),
+      ],
+      CURRENT_DATE,
+      DISCOUNT_RATE
+    );
+
+    expect(overFilingAge.asMonths()).toBe(
+      earliestFiling(over, CURRENT_DATE).asMonths()
+    );
+    expect(underFilingAge.greaterThanOrEqual(age(62))).toBe(true);
+    expect(underFilingAge.lessThanOrEqual(MAX_FILING_AGE)).toBe(true);
+    expect(npvCents).toBeGreaterThan(0);
+  });
+
+  it('still optimizes the under-70 spouse across their whole range', () => {
+    const over = OVER_70();
+    const under = UNDER_70();
+    over.markFirst();
+    under.markSecond();
+    const recipients: [Recipient, Recipient] = [over, under];
+
+    const results = expectedNPVCoupleOptimized(
+      recipients,
+      CURRENT_DATE,
+      DISCOUNT_RATE,
+      [flatDeathDistribution(78), flatDeathDistribution(64)]
+    );
+
+    expect(results.length).toBeGreaterThan(0);
+    const best = results[0];
+    expect(best.expectedNPVCents).toBeGreaterThan(0);
+    expect(best.filingAges[0].asMonths()).toBe(
+      earliestFiling(over, CURRENT_DATE).asMonths()
+    );
+
+    // The under-70 spouse's filing age is the result of a real search: the
+    // ranking must contain more than one distinct choice for them.
+    const underAges = new Set(results.map((r) => r.filingAges[1].asMonths()));
+    expect(underAges.size).toBeGreaterThan(1);
+  });
+
+  it('agrees with the slow reference implementation', () => {
+    // The fast path is validated against optimalStrategyCouple by golden
+    // tests. Past 70 is the case that used to diverge: the reference's loop
+    // went empty while the fast path threw. Both must now agree.
+    const over = OVER_70();
+    const under = UNDER_70();
+    over.markFirst();
+    under.markSecond();
+    const recipients: [Recipient, Recipient] = [over, under];
+    const finalDates: [MonthDate, MonthDate] = [
+      over.birthdate.dateAtLayAge(age(90)),
+      under.birthdate.dateAtLayAge(age(88)),
+    ];
+
+    const fast = optimalStrategyCoupleFast(
+      recipients,
+      finalDates,
+      CURRENT_DATE,
+      DISCOUNT_RATE
+    );
+    const reference = optimalStrategyCouple(
+      recipients,
+      finalDates,
+      CURRENT_DATE,
+      DISCOUNT_RATE
+    );
+
+    expect(fast[0].asMonths()).toBe(reference[0].asMonths());
+    expect(fast[1].asMonths()).toBe(reference[1].asMonths());
+    // Within a cent, matching the tolerance the golden tests use: the two
+    // implementations accumulate the same sum in a different order.
+    expect(Math.abs(fast[2] - reference[2])).toBeLessThan(1);
+  });
+
+  it('handles both recipients being past 70', () => {
+    const a = makeRecipient(2000, 1948);
+    const b = makeRecipient(1200, 1950);
+    a.markFirst();
+    b.markSecond();
+    const recipients: [Recipient, Recipient] = [a, b];
+
+    const results = expectedNPVCoupleOptimized(
+      recipients,
+      CURRENT_DATE,
+      DISCOUNT_RATE,
+      [flatDeathDistribution(78), flatDeathDistribution(76)]
+    );
+
+    expect(results.length).toBe(1);
+    expect(results[0].expectedNPVCents).toBeGreaterThan(0);
+  });
+});

--- a/src/test/strategy/over-70-filing.test.ts
+++ b/src/test/strategy/over-70-filing.test.ts
@@ -34,6 +34,7 @@ import {
   MAX_FILING_AGE,
   optimalStrategyCouple,
   optimalStrategySingle,
+  strategySumCentsCouple,
 } from '$lib/strategy/calculations/strategy-calc';
 
 function makeRecipient(
@@ -285,6 +286,46 @@ describe('single optimizer past age 70', () => {
   });
 });
 
+describe('survivor rounding agrees between fast path and reference', () => {
+  // Found by fuzzing the regime this change opens: the fast copies used a
+  // literal 0.285 where the reference computes (1 - 0.715), a different
+  // double. On a half-cent base*ratio the two rounded opposite ways, giving
+  // a $1/month survivor benefit that the grid-cell NPV and the scenario
+  // detail (which re-sums periods with the reference) disagreed on by ~$200.
+  it('pins a half-cent case to within a cent', () => {
+    const earner = new Recipient();
+    earner.birthdate = Birthdate.FromYMD(1949, 10, 1);
+    earner.setPia(Money.from(1899));
+    const dependent = new Recipient();
+    dependent.birthdate = Birthdate.FromYMD(1962, 6, 28);
+    dependent.setPia(Money.from(544));
+    earner.markFirst();
+    dependent.markSecond();
+    const recipients: [Recipient, Recipient] = [earner, dependent];
+    const currentDate = monthDate(2026, 10);
+    const finalDates: [MonthDate, MonthDate] = [
+      monthDate(2029, 3),
+      monthDate(2055, 10),
+    ];
+
+    const [age0, age1, fastNpv] = optimalStrategyCoupleFast(
+      recipients,
+      finalDates,
+      currentDate,
+      0.03
+    );
+    const referenceNpv = strategySumCentsCouple(
+      recipients,
+      finalDates,
+      currentDate,
+      0.03,
+      [age0, age1]
+    );
+
+    expect(Math.abs(fastNpv - referenceNpv)).toBeLessThan(1);
+  });
+});
+
 describe('couple optimizer with one recipient past age 70', () => {
   it('computes a strategy instead of throwing', () => {
     const over = OVER_70();
@@ -311,7 +352,7 @@ describe('couple optimizer with one recipient past age 70', () => {
     expect(npvCents).toBeGreaterThan(0);
   });
 
-  it('still optimizes the under-70 spouse across their whole range', () => {
+  it('still searches the under-70 spouse across their whole range', () => {
     const over = OVER_70();
     const under = UNDER_70();
     over.markFirst();
@@ -332,8 +373,9 @@ describe('couple optimizer with one recipient past age 70', () => {
       earliestFiling(over, CURRENT_DATE).asMonths()
     );
 
-    // The under-70 spouse's filing age is the result of a real search: the
-    // ranking must contain more than one distinct choice for them.
+    // The under-70 spouse's range was actually searched: the ranking holds
+    // more than one distinct age for them. (Which age wins depends on the
+    // discount rate, so the winner itself is not pinned here.)
     const underAges = new Set(results.map((r) => r.filingAges[1].asMonths()));
     expect(underAges.size).toBeGreaterThan(1);
   });


### PR DESCRIPTION
## The bug

On `/strategy`, entering someone over 70 produced "Could not compute results. Check your inputs and try again." In a couple, that also hid the still-meaningful filing decision of an under-70 spouse.

Investigating turned up a second, quieter failure: a **single** recipient over 70 showed no error at all. The results page rendered with the recommendation block and the chart's filing-age line simply absent — a silent wrong answer rather than a visible one.

## Root cause

The age-70 cap on delayed retirement credits was never expressed in the domain model. It existed only as a loop bound in each optimizer:

```js
for (age = earliestFiling(r, now); age <= 70 * 12; age++)
```

Past 70, `earliestFiling` returns an age *above* 70 — the most backdated month SSA still allows — so that range went empty or negative:

| | Symptom |
|---|---|
| `optimalStrategySingle` | returns `[MonthDuration(0), -1]` — "file at age 0, NPV -1¢". Renders as nothing. |
| `expectedNPVCoupleOptimized` | `new Float64Array(840 - start + 1)` with a negative length → `RangeError: Invalid typed array length: -92` |

Same cause, two very different symptoms.

## The fix

Express the rule rather than implying it:

- **`benefitMultiplierAtAge` caps delayed credits at 70**, as SSA does. All three copies of the benefit formula (object model plus both fast paths) now agree, so an age past 70 pays the age-70 amount.
- **New `filingAgeRange(recipient, currentDate)`** → `{earliest, latest, hasChoice}`. Past 70 it collapses to the single remaining option instead of an empty range. All six optimizer entry points use it in place of a literal `70 * 12` — including the slow reference implementation the golden tests validate the fast paths against.

## A second bug this made reachable

`survivorBenefit` read the deceased's benefit at a fixed age-71 date. For anyone who filed *later* than 71, that date is before they filed — and `benefitOnDate` returns $0 for a date before filing. The `Math.max` then fell through to the 82.5%-of-PIA floor, understating the survivor benefit by **$84k** in one test case ($1,650/mo instead of $2,640/mo).

It now reads the amount a year after filing, which always includes every delayed credit. **The 1000-case golden suite is unchanged by this**, confirming it only ever affected filing ages past 71 — previously unreachable, because no optimizer could produce one.

## User-facing changes

- The generic **"check your inputs"** message said the wrong thing: every input the form accepts should now compute, so reaching the error means a bug on our side. It says that, and links to `/contact`.
- A recipient past 70 shows **"File now"** rather than a filing date already in the past, which read as advice to wait. The optimizer's answer for them is the maximum-backdated month, which is correct but misleading rendered as a date.
- **No death-age grid is drawn for a recipient past 70** — every cell would hold the same value. A couple with one such recipient shows the other's grid alone, centred; with both past 70 the section is replaced by an explanation.

## Testing

- New `src/test/strategy/over-70-filing.test.ts` (14 tests) covering the DRC cap, `filingAgeRange`, single and couple optimizers past 70, both-past-70, the survivor bug, and fast-vs-reference agreement in this regime.
- Two existing tests asserted the broken behaviour as intended — *"documents that the optimizer does not support recipients who are already past 70"* — and now assert the filing-now result.
- One adversarial test that accepted either a throw or a result now asserts the real guarantee: filing at 70y1m is strictly worse than at 70.
- Full suite: **2080 passing**. `npm run quality` clean, production build succeeds.
- Browser-verified: single over 70, couple with one over 70, both over 70, and an unchanged under-70 control.

## Known gap (not addressed here)

The optimizer still assumes the filing decision is entirely ahead of the user. Someone who **has already filed** has no way to say so, and gets a recommendation they cannot act on plus an NPV that ignores payments already received. `filingAgeRange` is the right seam for it — an already-filed recipient is just a range pinned to their actual filing date — but it needs a new form input and UX decisions, so it is left for a follow-up.

---

## Review round (second commit)

A multi-agent review of the first commit found that it **moved the boundary rather than removing it**, plus one regression it introduced.

**The boundary was wrong.** SSA's six-month retroactive window means `earliestFiling` lags current age by six months past FRA, so `hasChoice` flips at **70y6m**, not 70y0m. Between 70y0m and 70y6m a recipient still had a range to search — but every age in it was already in the past, so the card rendered "File in \<a month that has already passed\>". The presentation condition is not *"past 70"* but *"is this month already gone"*, which also covers a younger recipient whose optimum is retroactive at a high discount rate. Boundary tests now pin 70y5m / 70y6m / 70y7m.

**A regression this PR introduced.** Drawing the under-70 spouse's matrix made its cells clickable for a couple with an over-70 member — a path previously unreachable because the page failed first. `AlternativeStrategiesGrid` still bounded its range with a literal age 70, computing `Array(840 - 936 + 1)` for a 78-year-old and throwing `RangeError: Invalid array length` into a `catch` that logged and left the grid blank.

**The mechanism that hid the original bug was untouched.** If the life-table fetch fails, `updateDeathProbabilityDistributions` swallowed the error, buckets stayed empty, and an empty run still reached `Complete` — rendering the identical blank results page, with no age-70 involvement at all. It no longer swallows, and a run over zero scenarios is an error rather than a completion. Separately, a failed *reactive* recompute left stale figures on screen beside changed inputs, looking authoritative; the results stage now says so and dims them.

Also from review:

- `expectedNPVCoupleOptimized` — the implementation the UI actually calls — had no past-70 agreement test against its slow reference. Added, per cell.
- A zero-PIA dependent past 70 was reported filing at age 70 exactly: 18 months below the only age their range contained, and a month SSA cannot backdate to.
- `hasFilingChoice` derived reactively from live form state while the results it re-skins are a snapshot, so a birthdate edit could flip a card to "File now" beside figures for the previous birthdate.
- `filingAgeRange` handed out the shared `MAX_FILING_AGE` instance as `latest`; `MonthDuration.increment()` mutates in place, so one caller could have corrupted the constant process-wide.
- A test asserting `resultOpt[2] === result[2]` passed vacuously when both sides returned `-1`.
- The goldens generator still claimed past-70 cases "don't validate anything" and that "the UI also never generates such cases" — both of which this work disproves.

2086 tests pass. Browser-verified: 70y5m and 70y6m both render "File now" (with the past-70 clause only where true), an under-70 user still gets a future date, and clicking a matrix cell for an over-70 couple renders the alternatives grid with no `RangeError`.


---

## Sentinel removal (third commit)

The review flagged that the `[MonthDuration(0), -1]` sentinel — the mechanism behind the *silent* half of this bug — survived the first two commits. It is now gone.

**What it was.** The optimizers seeded their answer with `[new MonthDuration(0), -1]` and improved on it in a loop. If the loop ran zero times, that seed was returned as though it were a result: *file at age 0, for minus one cent*. Nothing in the return type `[MonthDuration, number]` distinguished it from a real strategy, so no caller was ever prompted to check.

**Why it mattered.** Every grid cell got the seed, the page wrote it straight into the results, and `StrategyPlotSingle` quietly dropped any point below the earliest filing age. A producer emitting well-typed garbage and a consumer silently discarding it — so the chart rendered with no line, and nothing was logged.

**It was still reachable** after the first two commits, via a death age below the earliest filing age. `Birthdate.currentAge()` is whole years, so someone aged 62y1m whose earliest filing month is *also* 62y1m got a bucket at 62y0m — one month short of being able to file.

Two changes, so the question is neither asked nor answered badly:

- **`earliestModelableDeathAge(recipient, currentDate)`** names the first death age worth modelling (the later of current age and earliest filing), and monthly buckets start there. `generateMonthlyBuckets` now takes months rather than years so the bound cannot be rounded away. Three-year buckets were never exposed — they represent each bucket by its midpoint, start + 18 months, which clears the earliest filing age on its own.
- **`optimalStrategySingle` throws `NoFilingAgeAvailableError`** instead of returning the seed. Every value of its return type is now a real strategy, which is what the type claimed all along.

**The couple optimizers deliberately do not throw.** Writing the test surfaced the slow reference returning a valid NPV where the fast paths would have thrown — and the slow reference was right. A couple's scenario is not malformed just because one spouse dies before they could file: the other still has a genuine filing decision, and the survivor benefit still depends on it. Throwing would discard a real answer exactly as the sentinel did. Their death-date clamp is now floored at the range start, collapsing the dead spouse's range to a single immaterial age. A new test pins all three couple implementations to the same result there.

With the sentinel gone at the source, `StrategyPlotSingle`'s filter is deleted; its replacement comment records why it must not come back.

2095 tests pass. Browser-verified: a normal single user's chart still draws a continuous line, and for someone just past 62 it now starts flush at 62y1m — the earliest filing month — rather than hiding a dropped point at 62y0m.

---

## Fable pass (fourth commit)

A fresh-context review over the full diff, which fuzzed 80 random couples across all three couple optimizers in the past-70 regime this change opens.

**Found: the three survivor-formula copies were not bit-identical.** `survivorBenefit` computes the age-60 reduction as `MIN + (1 - MIN) * ratio` with `MIN = 0.715`; both fast copies wrote the literal `0.285`. In IEEE arithmetic `1 - 0.715` is `0.28500000000000003` — a different double — so on a half-cent `base * ratio` they round opposite ways: **$2,488 vs $2,489/month**. The grid-cell NPV (fast path) and the scenario detail (which re-sums with the reference) then disagreed by ~$200 for the same filing pair. Both literals exist on `main`; this PR only made the regime reachable. All three now use one exported constant computed the same way. The regression test fails by 20,444 cents on the old literal.

**Also fixed:**
- The headline said *"ask SSA to backdate the claim to September 2026"* when it *is* September 2026 — a recommendation for the current month was treated as already past. Reachable for anyone under FRA at a high discount rate, since their earliest option is always this month.
- `hasFilingChoice` was assigned *before* the optimizer loops. If a loop threw, the store kept the previous run while the flag described the failed inputs — exactly the skew commit 2 set out to remove. It and the headline results now commit atomically with the store. The calculator card had the same reactive derivation and gets the same fix.
- The deferred-rerun failure path only logged; it now raises the stale banner.
- The "no death-age buckets" guard could never fire (both generators always emit a final open-ended bucket); it now checks the mortality distribution, which can actually be empty.
- Stale sentinel docs, a dead `earliestFilingAge`, a redundant `MIN_FILING_AGE` floor, and one over-claiming test name.

**Documented, not changed:** the NPV functions count payments from the month after `currentDate`, so the retroactive lump sum SSA pays for a backdated claim is worth **$0 to the optimizer**. Past FRA the winner among backdated ages is therefore predetermined, and the 70y0m–70y6m range is searched but cannot surprise. The over-70 advice is unaffected (the amount is flat). Noted on `filingAgeRange` as a follow-up — valuing those months as a lump at `currentDate + 1` would let the "up to six months retroactively" the UI mentions actually influence the recommendation.

The review confirmed the rest empirically: the 77y6m payment stream is the age-70 amount from the backdated month with no January bump; the couple clamp yields identical results across all three implementations including a zero-PIA dependent aged 76; nothing downstream of the death buckets assumed whole-year starts; and every new test was reasoned through against `main` and would fail there.

2096 tests pass.
