### PR TITLE
feat(calculator): use the live 20-year Treasury rate in the filing card

### DIFF
--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
+  import {
+    DEFAULT_DISCOUNT_RATE_ASSUMPTION,
+    type DiscountRateAssumption,
+  } from "$lib/components/recommended-filing-card";
   import { Money } from "$lib/money";
   import type { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
@@ -15,6 +19,12 @@
     coupleResult?: CoupleFilingAgeResult;
     recipients: [Recipient, Recipient];
     showInfoTip?: boolean;
+    /**
+     * The discount rate the result was computed with. Only shown when the
+     * info tip is hidden (the calculator card), where the surrounding page
+     * has no rate input to point at.
+     */
+    discountRateAssumption?: DiscountRateAssumption;
     /**
      * Per recipient: false once filing immediately is their only remaining
      * option. Such a recipient gets a "file now" card rather than a filing
@@ -40,6 +50,7 @@
     coupleResult,
     recipients,
     showInfoTip = true,
+    discountRateAssumption = DEFAULT_DISCOUNT_RATE_ASSUMPTION,
     hasFilingChoice,
     currentDate,
   }: Props = $props();
@@ -83,6 +94,11 @@
 
   function formatMoney(cents: number): string {
     return Money.fromCents(Math.round(cents)).wholeDollars();
+  }
+
+  /** 0.0312 -> "3.12%"; trailing zeros dropped so 0.025 -> "2.5%". */
+  function formatPercent(rate: number): string {
+    return `${parseFloat((rate * 100).toFixed(2))}%`;
   }
 </script>
 
@@ -191,8 +207,17 @@
           the discount rate.
         {/if}
         {#if !showInfoTip}
-          Based on default assumptions — a 2.5% discount rate and blended life
-          expectancy. Open the optimizer to adjust.
+          {#if discountRateAssumption.source === "treasury"}
+            Based on the current 20-year Treasury rate ({formatPercent(
+              discountRateAssumption.rate
+            )}) as the discount rate and blended life expectancy. Open the
+            optimizer to adjust.
+          {:else}
+            Based on default assumptions — a {formatPercent(
+              discountRateAssumption.rate
+            )} discount rate and blended life expectancy. Open the optimizer
+            to adjust.
+          {/if}
         {/if}
       </p>
     </div>

--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -4,6 +4,7 @@
   import {
     DEFAULT_DISCOUNT_RATE_ASSUMPTION,
     type DiscountRateAssumption,
+    formatDiscountRatePercent,
   } from "$lib/components/recommended-filing-card";
   import { Money } from "$lib/money";
   import type { MonthDate, MonthDuration } from "$lib/month-time";
@@ -94,11 +95,6 @@
 
   function formatMoney(cents: number): string {
     return Money.fromCents(Math.round(cents)).wholeDollars();
-  }
-
-  /** 0.0312 -> "3.12%"; trailing zeros dropped so 0.025 -> "2.5%". */
-  function formatPercent(rate: number): string {
-    return `${parseFloat((rate * 100).toFixed(2))}%`;
   }
 </script>
 
@@ -208,12 +204,12 @@
         {/if}
         {#if !showInfoTip}
           {#if discountRateAssumption.source === "treasury"}
-            Based on the current 20-year Treasury rate ({formatPercent(
+            Based on the current 20-year Treasury rate ({formatDiscountRatePercent(
               discountRateAssumption.rate
             )}) as the discount rate and blended life expectancy. Open the
             optimizer to adjust.
           {:else}
-            Based on default assumptions — a {formatPercent(
+            Based on default assumptions — a {formatDiscountRatePercent(
               discountRateAssumption.rate
             )} discount rate and blended life expectancy. Open the optimizer
             to adjust.

--- a/src/lib/components/RecommendedFilingCard.svelte
+++ b/src/lib/components/RecommendedFilingCard.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import OptimalStrategyHeadline from "$lib/components/OptimalStrategyHeadline.svelte";
   import {
     buildStrategyUrl,
     currentMonthDate,
+    DEFAULT_DISCOUNT_RATE_ASSUMPTION,
+    type DiscountRateAssumption,
     filingChoices,
     loadDeathDistributions,
+    loadDiscountRateAssumption,
     recommendedFromDistributions,
     type RecommendedFiling,
   } from "$lib/components/recommended-filing-card";
@@ -20,6 +23,10 @@
   let dist1: DeathProbability[] | null = null;
   let dist2: DeathProbability[] | null = null;
   let result: RecommendedFiling | null = null;
+  // Starts at the default so the card can render as soon as mortality data
+  // loads; swapped for the live 20-year Treasury rate once that arrives, the
+  // same way the strategy page's rate input behaves.
+  let discountRate: DiscountRateAssumption = DEFAULT_DISCOUNT_RATE_ASSUMPTION;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   // Key the loaded distributions to the inputs that actually affect mortality
   // (gender, birth year, health multiplier) so that PIA changes (earnings
@@ -35,8 +42,12 @@
   // them on each store update, which invalidates these reactive blocks (e.g. on
   // a PIA, gender, or health change).
   $: void maybeLoadDistributions(recipient, spouse);
-  $: scheduleRecompute(recipient, spouse, dist1, dist2);
+  $: scheduleRecompute(recipient, spouse, dist1, dist2, discountRate);
   $: strategyUrl = buildStrategyUrl(recipient, spouse);
+
+  onMount(async () => {
+    discountRate = await loadDiscountRateAssumption();
+  });
 
   async function maybeLoadDistributions(
     r: Recipient,
@@ -73,8 +84,16 @@
       // they are keyed to recipient identity via distKey and stay valid across
       // the PIA changes that trigger a recompute.
       const now = currentMonthDate();
-      result = recommendedFromDistributions(recipient, spouse, d1, d2, now);
+      result = recommendedFromDistributions(
+        recipient,
+        spouse,
+        d1,
+        d2,
+        now,
+        discountRate.rate
+      );
       hasFilingChoice = filingChoices(recipient, spouse, now);
+      computedDiscountRate = discountRate;
     } catch (e) {
       // The optimizer returns an empty array for edge cases rather than
       // throwing, so a throw here signals a real bug, not expected input.
@@ -87,10 +106,12 @@
     _r: Recipient,
     _s: Recipient | null,
     d1: DeathProbability[] | null,
-    d2: DeathProbability[] | null
+    d2: DeathProbability[] | null,
+    _rate: DiscountRateAssumption
   ): void {
-    // _r/_s are unused by name: they only register recipient/spouse as reactive
-    // dependencies so this block re-runs on store updates (e.g. PIA changes).
+    // _r/_s/_rate are unused by name: they only register recipient, spouse,
+    // and the discount rate as reactive dependencies so this block re-runs on
+    // store updates (e.g. PIA changes) and when the Treasury rate arrives.
     if (!d1) return;
     if (debounceTimer) {
       clearTimeout(debounceTimer);
@@ -125,6 +146,11 @@
   // reactively here would let it change during the debounce window while
   // `result` still belongs to the previous inputs.
   let hasFilingChoice: [boolean, boolean] = [true, true];
+  // Likewise: the rate the displayed `result` was actually computed with, so
+  // the card's copy never names the Treasury rate while the figures above it
+  // still reflect the default from before that rate arrived.
+  let computedDiscountRate: DiscountRateAssumption =
+    DEFAULT_DISCOUNT_RATE_ASSUMPTION;
 </script>
 
 {#if result}
@@ -139,6 +165,7 @@
       coupleResult={result.couple}
       recipients={recipientsTuple}
       showInfoTip={false}
+      discountRateAssumption={computedDiscountRate}
       {hasFilingChoice}
       currentDate={currentMonthDate()}
     />

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -16,7 +16,9 @@ import { buildStrategyHash } from '$lib/url-params';
 
 /**
  * Discount rate used until the live 20-year Treasury rate arrives, and when
- * it cannot be fetched at all. Matches the strategy optimizer's fallback.
+ * it cannot be fetched at all. Matches the strategy optimizer's fallback,
+ * which is spelled out as literals in treasury-yields.ts and
+ * DiscountRateInput.svelte; changing this constant alone will not change it.
  */
 export const DEFAULT_DISCOUNT_RATE = 0.025;
 
@@ -30,23 +32,63 @@ export interface DiscountRateAssumption {
   readonly source: 'treasury' | 'default';
 }
 
+/** The assumption used before the Treasury fetch resolves and whenever it fails. */
 export const DEFAULT_DISCOUNT_RATE_ASSUMPTION: DiscountRateAssumption = {
   rate: DEFAULT_DISCOUNT_RATE,
   source: 'default',
 };
 
 /**
+ * The range of annual discount rates the strategy page's input accepts
+ * (0% to 50%). Kept in step with DiscountRateInput.svelte so a rate the card
+ * shows is always one the optimizer will run with when the user clicks
+ * through. The 20-year real yield was negative for stretches of 2020-2022.
+ */
+const MIN_DISCOUNT_RATE = 0;
+const MAX_DISCOUNT_RATE = 0.5;
+
+/**
+ * Rounds an annual rate to two decimal places of a percent (0.031249 to
+ * 0.0312), which is what the strategy page's input does to the fetched rate
+ * before running the optimizer. Rounding here too keeps both surfaces
+ * computing with the identical number.
+ */
+function roundToOptimizerPrecision(rate: number): number {
+  return Number((rate * 100).toFixed(2)) / 100;
+}
+
+/** 0.0312 -> "3.12%"; trailing zeros dropped so 0.025 -> "2.5%". */
+export function formatDiscountRatePercent(rate: number): string {
+  return `${Number((rate * 100).toFixed(2))}%`;
+}
+
+/**
  * Loads the current 20-year Treasury real yield, the same rate the strategy
- * optimizer preselects. Never throws: on any failure it returns the default
- * assumption so the card can still render.
+ * optimizer preselects. Never throws: on any failure, or a rate outside the
+ * range the optimizer accepts, it returns the default assumption so the card
+ * can still render.
  */
 export async function loadDiscountRateAssumption(): Promise<DiscountRateAssumption> {
   try {
     const data = await fetchRecommendedDiscountRate();
     if (!data.success) return DEFAULT_DISCOUNT_RATE_ASSUMPTION;
-    return { rate: data.rate, source: 'treasury' };
+    const rate = roundToOptimizerPrecision(data.rate);
+    if (
+      !Number.isFinite(rate) ||
+      rate < MIN_DISCOUNT_RATE ||
+      rate > MAX_DISCOUNT_RATE
+    ) {
+      console.warn(
+        'RecommendedFilingCard: fetched discount rate outside optimizer range, using default',
+        data.rate
+      );
+      return DEFAULT_DISCOUNT_RATE_ASSUMPTION;
+    }
+    return { rate, source: 'treasury' };
   } catch (e) {
-    console.warn('RecommendedFilingCard: failed to load discount rate', e);
+    // fetchRecommendedDiscountRate is documented never to throw, so reaching
+    // here is a bug rather than a routine network fallback.
+    console.error('RecommendedFilingCard: unexpected discount rate failure', e);
     return DEFAULT_DISCOUNT_RATE_ASSUMPTION;
   }
 }

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -11,10 +11,45 @@ import {
   expectedNPVSingle,
 } from '$lib/strategy/calculations/expected-npv';
 import { filingAgeRange } from '$lib/strategy/calculations/strategy-calc';
+import { fetchRecommendedDiscountRate } from '$lib/strategy/data';
 import { buildStrategyHash } from '$lib/url-params';
 
-/** Default assumptions matching the strategy optimizer's initial state. */
+/**
+ * Discount rate used until the live 20-year Treasury rate arrives, and when
+ * it cannot be fetched at all. Matches the strategy optimizer's fallback.
+ */
 export const DEFAULT_DISCOUNT_RATE = 0.025;
+
+/**
+ * The discount rate the card computed with, and where it came from, so the
+ * card's copy can say "the current 20-year Treasury rate" only when that is
+ * actually true.
+ */
+export interface DiscountRateAssumption {
+  readonly rate: number;
+  readonly source: 'treasury' | 'default';
+}
+
+export const DEFAULT_DISCOUNT_RATE_ASSUMPTION: DiscountRateAssumption = {
+  rate: DEFAULT_DISCOUNT_RATE,
+  source: 'default',
+};
+
+/**
+ * Loads the current 20-year Treasury real yield, the same rate the strategy
+ * optimizer preselects. Never throws: on any failure it returns the default
+ * assumption so the card can still render.
+ */
+export async function loadDiscountRateAssumption(): Promise<DiscountRateAssumption> {
+  try {
+    const data = await fetchRecommendedDiscountRate();
+    if (!data.success) return DEFAULT_DISCOUNT_RATE_ASSUMPTION;
+    return { rate: data.rate, source: 'treasury' };
+  } catch (e) {
+    console.warn('RecommendedFilingCard: failed to load discount rate', e);
+    return DEFAULT_DISCOUNT_RATE_ASSUMPTION;
+  }
+}
 
 export interface RecommendedFiling {
   readonly isSingle: boolean;

--- a/src/lib/strategy/data/index.ts
+++ b/src/lib/strategy/data/index.ts
@@ -2,5 +2,7 @@
 export {
   fetchFredDFII20Yield,
   fetchLatest20YearTreasuryYield,
+  fetchRecommendedDiscountRate,
   getRecommendedDiscountRate,
+  type TreasuryYieldData,
 } from './treasury-yields.js';

--- a/src/lib/strategy/data/treasury-yields.ts
+++ b/src/lib/strategy/data/treasury-yields.ts
@@ -1,7 +1,7 @@
 /**
  * Interface for Treasury yield data
  */
-interface TreasuryYieldData {
+export interface TreasuryYieldData {
   date: string;
   rate: number;
   success: boolean;
@@ -170,35 +170,40 @@ export async function fetchFredDFII20Yield(): Promise<TreasuryYieldData> {
 }
 
 /**
+ * Fetches the current 20-year inflation-adjusted Treasury yield, trying the
+ * Treasury Department feed first and FRED second. Never throws: when both
+ * sources fail, `success` is false and `rate` is the 2.5% default.
+ * @returns Promise resolving to the yield data, with `success` reporting
+ *   whether a live rate was obtained.
+ */
+export async function fetchRecommendedDiscountRate(): Promise<TreasuryYieldData> {
+  const treasuryData = await fetchLatest20YearTreasuryYield();
+  if (treasuryData.success) {
+    return treasuryData;
+  }
+  console.warn(
+    'Using fallback due to Treasury data error:',
+    treasuryData.error
+  );
+
+  const fredData = await fetchFredDFII20Yield();
+  if (!fredData.success) {
+    console.warn(
+      'Using default discount rate due to FRED data error:',
+      fredData.error
+    );
+  }
+  return fredData;
+}
+
+/**
  * Gets the current recommended discount rate based on Treasury yields
  * Falls back to FRED data, then to a default value of 2.5% if unable to fetch the data.
  * @returns Promise resolving to the recommended discount rate as a decimal
  */
 export async function getRecommendedDiscountRate(): Promise<number> {
   try {
-    // First try to fetch the latest data from Treasury
-    const treasuryData = await fetchLatest20YearTreasuryYield();
-
-    if (treasuryData.success) {
-      return treasuryData.rate;
-    } else {
-      console.warn(
-        'Using fallback due to Treasury data error:',
-        treasuryData.error
-      );
-
-      // If Treasury data fails, try FRED data
-      const fredData = await fetchFredDFII20Yield();
-      if (fredData.success) {
-        return fredData.rate;
-      } else {
-        console.warn(
-          'Using default discount rate due to FRED data error:',
-          fredData.error
-        );
-        return 0.025; // Default to 2.5% if all attempts fail
-      }
-    }
+    return (await fetchRecommendedDiscountRate()).rate;
   } catch (error) {
     console.error('Error getting recommended discount rate:', error);
     return 0.025; // Default to 2.5% if there's an error

--- a/src/lib/strategy/data/treasury-yields.ts
+++ b/src/lib/strategy/data/treasury-yields.ts
@@ -1,10 +1,14 @@
 /**
- * Interface for Treasury yield data
+ * Result of a 20-year Treasury real-yield lookup.
  */
 export interface TreasuryYieldData {
+  /** Observation date (YYYY-MM-DD), or today's date when the fetch failed. */
   date: string;
+  /** Annual rate as a decimal (0.025 = 2.5%); the 2.5% default on failure. */
   rate: number;
+  /** True only when `rate` came from a live feed. */
   success: boolean;
+  /** Set only on failure. */
   error?: string;
 }
 
@@ -39,7 +43,7 @@ async function fetchTreasuryMonth(
 
 /**
  * Fetches the latest 20-year Treasury yield from the Treasury Department API
- * @returns Promise resolving to the yield rate as a decimal (e.g., 0.025 for 2.5%)
+ * @returns Promise resolving to the yield data; `success` is false on failure
  */
 export async function fetchLatest20YearTreasuryYield(): Promise<TreasuryYieldData> {
   try {
@@ -124,7 +128,7 @@ export async function fetchLatest20YearTreasuryYield(): Promise<TreasuryYieldDat
 
 /**
  * Fetches the latest 20-year inflation-adjusted Treasury yield from FRED (Federal Reserve Economic Data).
- * @returns Promise resolving to the yield rate as a decimal (e.g., 0.025 for 2.5%)
+ * @returns Promise resolving to the yield data; `success` is false on failure
  */
 export async function fetchFredDFII20Yield(): Promise<TreasuryYieldData> {
   try {

--- a/src/test/components/recommended-filing-card.test.ts
+++ b/src/test/components/recommended-filing-card.test.ts
@@ -5,6 +5,8 @@ import {
   buildStrategyUrl,
   currentMonthDate,
   DEFAULT_DISCOUNT_RATE,
+  DEFAULT_DISCOUNT_RATE_ASSUMPTION,
+  formatDiscountRatePercent,
   loadDeathDistributions,
   loadDiscountRateAssumption,
   recommendedFromDistributions,
@@ -23,9 +25,10 @@ vi.mock('$lib/life-tables', async (importOriginal) => {
   return { ...actual, getDeathProbabilityDistribution: vi.fn() };
 });
 
-vi.mock('$lib/strategy/data', () => ({
-  fetchRecommendedDiscountRate: vi.fn(),
-}));
+vi.mock('$lib/strategy/data', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/strategy/data')>();
+  return { ...actual, fetchRecommendedDiscountRate: vi.fn() };
+});
 
 import { getDeathProbabilityDistribution } from '$lib/life-tables';
 import { fetchRecommendedDiscountRate } from '$lib/strategy/data';
@@ -83,6 +86,35 @@ describe('loadDiscountRateAssumption', () => {
     expect(got).toEqual({ rate: 0.031, source: 'treasury' });
   });
 
+  it('rounds to two decimal places of a percent, as the optimizer does', async () => {
+    vi.mocked(fetchRecommendedDiscountRate).mockResolvedValue({
+      date: '2026-09-10',
+      rate: 0.031249,
+      success: true,
+    });
+
+    const got = await loadDiscountRateAssumption();
+
+    // Written as the strategy page computes it (rounded percent / 100) so the
+    // two surfaces are asserted to use the bit-identical number.
+    expect(got).toEqual({ rate: 3.12 / 100, source: 'treasury' });
+  });
+
+  it.each([-0.0075, 0.51, Number.NaN])(
+    'falls back to the default when the fetched rate (%s) is outside the optimizer range',
+    async (rate) => {
+      vi.mocked(fetchRecommendedDiscountRate).mockResolvedValue({
+        date: '2026-09-10',
+        rate,
+        success: true,
+      });
+
+      const got = await loadDiscountRateAssumption();
+
+      expect(got).toEqual(DEFAULT_DISCOUNT_RATE_ASSUMPTION);
+    }
+  );
+
   it('falls back to the default rate when every source fails', async () => {
     vi.mocked(fetchRecommendedDiscountRate).mockResolvedValue({
       date: '2026-09-10',
@@ -104,6 +136,18 @@ describe('loadDiscountRateAssumption', () => {
     const got = await loadDiscountRateAssumption();
 
     expect(got).toEqual({ rate: DEFAULT_DISCOUNT_RATE, source: 'default' });
+  });
+});
+
+describe('formatDiscountRatePercent', () => {
+  it.each([
+    [0.025, '2.5%'],
+    [0.0312, '3.12%'],
+    [0.03, '3%'],
+    [0, '0%'],
+    [0.031249, '3.12%'],
+  ])('formats %s as %s', (rate, expected) => {
+    expect(formatDiscountRatePercent(rate)).toBe(expected);
   });
 });
 
@@ -201,6 +245,35 @@ describe('recommendedFromDistributions', () => {
     const r = makeRecipient(1500, 1960);
     const got = recommendedFromDistributions(r, null, [], null, FAR_PAST, 0);
     expect(got).toBeNull();
+  });
+
+  it('passes the discount rate through: a higher rate lowers the NPV', () => {
+    const r = makeRecipient(1500, 1960);
+    const dist: DeathProbability[] = [
+      { age: 80, probability: 0.5 },
+      { age: 90, probability: 0.5 },
+    ];
+
+    const low = recommendedFromDistributions(
+      r,
+      null,
+      dist,
+      null,
+      FAR_PAST,
+      0.01
+    );
+    const high = recommendedFromDistributions(
+      r,
+      null,
+      dist,
+      null,
+      FAR_PAST,
+      0.06
+    );
+
+    expect(high!.single!.expectedNPVCents).toBeLessThan(
+      low!.single!.expectedNPVCents
+    );
   });
 
   it('defaults the discount rate to DEFAULT_DISCOUNT_RATE when omitted', () => {

--- a/src/test/components/recommended-filing-card.test.ts
+++ b/src/test/components/recommended-filing-card.test.ts
@@ -6,6 +6,7 @@ import {
   currentMonthDate,
   DEFAULT_DISCOUNT_RATE,
   loadDeathDistributions,
+  loadDiscountRateAssumption,
   recommendedFromDistributions,
 } from '$lib/components/recommended-filing-card';
 import type { DeathProbability } from '$lib/life-tables';
@@ -22,7 +23,12 @@ vi.mock('$lib/life-tables', async (importOriginal) => {
   return { ...actual, getDeathProbabilityDistribution: vi.fn() };
 });
 
+vi.mock('$lib/strategy/data', () => ({
+  fetchRecommendedDiscountRate: vi.fn(),
+}));
+
 import { getDeathProbabilityDistribution } from '$lib/life-tables';
+import { fetchRecommendedDiscountRate } from '$lib/strategy/data';
 
 // Filing window is fixed at 62-70 when "now" is before the birthdate, matching
 // the existing expected-npv tests (FAR_PAST removes the "filing in the past"
@@ -59,6 +65,45 @@ describe('currentMonthDate', () => {
     const md = currentMonthDate(new Date(2025, 11, 1));
     expect(md.year()).toBe(2025);
     expect(md.monthName()).toBe('Dec');
+  });
+});
+
+describe('loadDiscountRateAssumption', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('uses the fetched 20-year Treasury rate when the fetch succeeds', async () => {
+    vi.mocked(fetchRecommendedDiscountRate).mockResolvedValue({
+      date: '2026-09-10',
+      rate: 0.031,
+      success: true,
+    });
+
+    const got = await loadDiscountRateAssumption();
+
+    expect(got).toEqual({ rate: 0.031, source: 'treasury' });
+  });
+
+  it('falls back to the default rate when every source fails', async () => {
+    vi.mocked(fetchRecommendedDiscountRate).mockResolvedValue({
+      date: '2026-09-10',
+      rate: 0.025,
+      success: false,
+      error: 'network down',
+    });
+
+    const got = await loadDiscountRateAssumption();
+
+    expect(got).toEqual({ rate: DEFAULT_DISCOUNT_RATE, source: 'default' });
+  });
+
+  it('falls back to the default rate when the fetch throws', async () => {
+    vi.mocked(fetchRecommendedDiscountRate).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const got = await loadDiscountRateAssumption();
+
+    expect(got).toEqual({ rate: DEFAULT_DISCOUNT_RATE, source: 'default' });
   });
 });
 

--- a/src/test/strategy/treasury-yields.test.ts
+++ b/src/test/strategy/treasury-yields.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   fetchFredDFII20Yield,
   fetchLatest20YearTreasuryYield,
+  fetchRecommendedDiscountRate,
   getRecommendedDiscountRate,
 } from '$lib/strategy/data';
 
@@ -173,6 +174,46 @@ describe('Treasury Yields Library', () => {
         'FRED DFII20 data not found or is invalid in the response'
       );
       expect(result.rate).toBe(0.025); // Default to 2.5%
+    });
+  });
+
+  describe('fetchRecommendedDiscountRate', () => {
+    it('reports success with the treasury rate when the treasury fetch works', async () => {
+      const result = await fetchRecommendedDiscountRate();
+
+      expect(result.success).toBe(true);
+      expect(result.rate).toBe(0.035);
+    });
+
+    it('reports success with the FRED rate when treasury fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('DATE,DFII20\n2024-06-27,2.1'),
+      });
+
+      const result = await fetchRecommendedDiscountRate();
+
+      expect(result.success).toBe(true);
+      expect(result.rate).toBe(0.021);
+    });
+
+    it('reports failure with the default rate when both sources fail', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      mockFetch.mockRejectedValueOnce(new Error('FRED network error'));
+
+      const result = await fetchRecommendedDiscountRate();
+
+      expect(result.success).toBe(false);
+      expect(result.rate).toBe(0.025);
     });
   });
 


### PR DESCRIPTION
## Summary

The calculator's inline recommended-filing card computed with a hard-coded 2.5% discount rate, while the `/strategy` page it links to fetches the current 20-year Treasury real yield on mount. Clicking through could show a different rate and sometimes a different recommended filing age.

This makes the card fetch the same rate the optimizer uses.

## Changes

- `treasury-yields.ts`: new `fetchRecommendedDiscountRate()` returning `TreasuryYieldData` (with `success`) so callers can distinguish a live rate from the fallback. `getRecommendedDiscountRate()` now delegates to it; behavior unchanged.
- `recommended-filing-card.ts`: new `DiscountRateAssumption` type and `loadDiscountRateAssumption()`, which never throws and falls back to the 2.5% default.
- `RecommendedFilingCard.svelte`: loads the rate on mount alongside the life tables, renders immediately with the default, and recomputes when the rate arrives. Tracks the rate the visible result was actually computed with so the copy and the numbers never disagree during the debounce window.
- `OptimalStrategyHeadline.svelte`: new optional `discountRateAssumption` prop. The calculator copy now reads "Based on the current 20-year Treasury rate (3.1%)..." when live, or keeps the old default wording otherwise.

## Notes

- This adds one outbound request to treasury.gov (or FRED as fallback) on calculator visits. No user data is sent.
- Storybook already stubs both endpoints in `.storybook/preview.ts`, so the Full Report Chromatic snapshots stay deterministic.

## Testing

- `npm test`: 82 files, 2167 tests pass (6 new).
- `npm run quality` and `npm run build` clean.
