### PR TITLE
fix(strategy): label a death-month filing as "does not file"

### DIFF
--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -454,6 +454,30 @@ export function allBenefitsOnDateNominal(
 }
 
 /**
+ * Whether a filing month means the recipient actually filed before dying.
+ *
+ * SSA pays no retirement benefit for the month of death, so a claim effective
+ * in that month or later is no claim at all. The survivor rules below treat
+ * such a worker as never having filed, and the UI labels the strategy "does
+ * not file" rather than naming a filing month.
+ *
+ * The optimizers do not model a separate "never file" choice. They cap the
+ * search at the death month (or, for a recipient who dies before they could
+ * file, at the one age left), so a filing age in or past the death month is
+ * how that strategy is represented.
+ *
+ * Model limitation: the benefit-period generators still count the death
+ * month inclusive, so a death-month filing earns one month of personal
+ * benefit in the NPV even though SSA would not pay it.
+ */
+export function filedBeforeDeath(
+  filingDate: MonthDate,
+  deathDate: MonthDate
+): boolean {
+  return filingDate.lessThan(deathDate);
+}
+
+/**
  * Determines the survivor benefit for a recipient.
  * @param survivor The surviving recipient.
  * @param deceased The deceased recipient.
@@ -464,22 +488,6 @@ export function allBenefitsOnDateNominal(
  * @param survivorFilingDate The date the survivor recipient filed for
  * survivor benefits.
  */
-/**
- * Whether a filing month means the recipient actually filed before dying.
- *
- * SSA pays no retirement benefit for the month of death, so a claim effective
- * in that month (or later) is, for every purpose here, no claim at all: the
- * survivor rules below treat the worker as never having filed, and the UI
- * labels such a strategy "does not file" rather than naming a filing month.
- * The optimizers search filing ages up to and including the death month, so
- * this is the only way a "never file" strategy is represented.
- */
-export function filedBeforeDeath(
-  filingDate: MonthDate,
-  deathDate: MonthDate
-): boolean {
-  return filingDate.lessThan(deathDate);
-}
 
 export function survivorBenefit(
   survivor: Recipient,

--- a/src/lib/benefit-calculator.ts
+++ b/src/lib/benefit-calculator.ts
@@ -464,6 +464,23 @@ export function allBenefitsOnDateNominal(
  * @param survivorFilingDate The date the survivor recipient filed for
  * survivor benefits.
  */
+/**
+ * Whether a filing month means the recipient actually filed before dying.
+ *
+ * SSA pays no retirement benefit for the month of death, so a claim effective
+ * in that month (or later) is, for every purpose here, no claim at all: the
+ * survivor rules below treat the worker as never having filed, and the UI
+ * labels such a strategy "does not file" rather than naming a filing month.
+ * The optimizers search filing ages up to and including the death month, so
+ * this is the only way a "never file" strategy is represented.
+ */
+export function filedBeforeDeath(
+  filingDate: MonthDate,
+  deathDate: MonthDate
+): boolean {
+  return filingDate.lessThan(deathDate);
+}
+
 export function survivorBenefit(
   survivor: Recipient,
   deceased: Recipient,
@@ -489,7 +506,7 @@ export function survivorBenefit(
   const afterAllCredits = (filingDate: MonthDate): MonthDate =>
     filingDate.addDuration(MonthDuration.OneYear());
 
-  if (deceasedFilingDate.greaterThanOrEqual(deceasedDeathDate)) {
+  if (!filedBeforeDeath(deceasedFilingDate, deceasedDeathDate)) {
     // If the deceased recipient did not file for benefits before death:
     if (deceasedDeathDate.lessThan(deceased.normalRetirementDate())) {
       // If the deceased died before Normal Retirement Age, the survivor

--- a/src/lib/strategy/ui/formatting.ts
+++ b/src/lib/strategy/ui/formatting.ts
@@ -153,21 +153,6 @@ export const NEVER_FILES_LABEL = 'Does not file';
 export const NEVER_FILES_DETAIL = 'Dies before filing';
 
 /**
- * Get the "never files" label sized to a matrix cell, mirroring the width
- * breakpoints of getFilingDate so the two read consistently side by side.
- * @param cellWidth The computed width of the cell in pixels
- */
-export function getNeverFilesLabel(cellWidth: number = 0): string {
-  if (cellWidth < 50) {
-    return '—';
-  } else if (cellWidth < 80) {
-    return 'None';
-  } else {
-    return NEVER_FILES_LABEL;
-  }
-}
-
-/**
  * Factory function to create border removal functions
  * @param valueExtractor Function that extracts the value to compare
  * @returns Object with functions for each border direction

--- a/src/lib/strategy/ui/formatting.ts
+++ b/src/lib/strategy/ui/formatting.ts
@@ -147,6 +147,12 @@ export function getFilingAge(
 export const NEVER_FILES_LABEL = 'Does not file';
 
 /**
+ * Secondary line shown under NEVER_FILES_LABEL where a filing date would
+ * otherwise appear.
+ */
+export const NEVER_FILES_DETAIL = 'Dies before filing';
+
+/**
  * Get the "never files" label sized to a matrix cell, mirroring the width
  * breakpoints of getFilingDate so the two read consistently side by side.
  * @param cellWidth The computed width of the cell in pixels

--- a/src/lib/strategy/ui/formatting.ts
+++ b/src/lib/strategy/ui/formatting.ts
@@ -141,6 +141,27 @@ export function getFilingAge(
 }
 
 /**
+ * Label for a strategy in which the recipient dies before their filing month,
+ * so they never file. See `filedBeforeDeath` in benefit-calculator.ts.
+ */
+export const NEVER_FILES_LABEL = 'Does not file';
+
+/**
+ * Get the "never files" label sized to a matrix cell, mirroring the width
+ * breakpoints of getFilingDate so the two read consistently side by side.
+ * @param cellWidth The computed width of the cell in pixels
+ */
+export function getNeverFilesLabel(cellWidth: number = 0): string {
+  if (cellWidth < 50) {
+    return '—';
+  } else if (cellWidth < 80) {
+    return 'None';
+  } else {
+    return NEVER_FILES_LABEL;
+  }
+}
+
+/**
  * Factory function to create border removal functions
  * @param valueExtractor Function that extracts the value to compare
  * @returns Object with functions for each border direction

--- a/src/lib/strategy/ui/index.ts
+++ b/src/lib/strategy/ui/index.ts
@@ -16,7 +16,6 @@ export {
   formatBirthdate,
   getFilingAge,
   getFilingDate,
-  getNeverFilesLabel,
   NEVER_FILES_DETAIL,
   NEVER_FILES_LABEL,
   parseBirthdate,

--- a/src/lib/strategy/ui/index.ts
+++ b/src/lib/strategy/ui/index.ts
@@ -16,6 +16,8 @@ export {
   formatBirthdate,
   getFilingAge,
   getFilingDate,
+  getNeverFilesLabel,
+  NEVER_FILES_LABEL,
   parseBirthdate,
 } from './formatting.js';
 export type { CellPosition, DeathAgeBucket } from './grid-sizing.js';

--- a/src/lib/strategy/ui/index.ts
+++ b/src/lib/strategy/ui/index.ts
@@ -17,6 +17,7 @@ export {
   getFilingAge,
   getFilingDate,
   getNeverFilesLabel,
+  NEVER_FILES_DETAIL,
   NEVER_FILES_LABEL,
   parseBirthdate,
 } from './formatting.js';

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -52,7 +52,14 @@
       years: 70,
       months: 0,
     });
-    const cap = maxAge70.lessThan(deathAge) ? maxAge70 : deathAge;
+    // Cap by the SSA age at the death date, as the optimizers do, rather than
+    // by the death age itself: for a recipient born on the 1st the two differ
+    // by a month, and the last column must be the death month so that the
+    // "never files" strategy (see filedBeforeDeath) has a cell.
+    const deathAgeSsa = recipient.birthdate.ageAtSsaDate(
+      recipient.birthdate.dateAtLayAge(deathAge)
+    );
+    const cap = maxAge70.lessThan(deathAgeSsa) ? maxAge70 : deathAgeSsa;
     // A recipient already past 70 (or one who dies before reaching it) has a
     // starting age beyond that cap. Collapse the range to that single
     // remaining age rather than letting it invert: MonthDurationRange has no
@@ -279,10 +286,11 @@
     // The last row/column is the death month itself. Filing then is the
     // "never files" strategy, not a filing month: say so.
     const recipient = recipients[recipientIndex];
+    const filingDate = recipient.birthdate.dateAtSsaAge(duration);
     const deathDate = recipient.birthdate.dateAtLayAge(
       recipientIndex === 0 ? deathAge1 : deathAge2
     );
-    if (!filedBeforeDeath(recipient.birthdate.dateAtSsaAge(duration), deathDate)) {
+    if (!filedBeforeDeath(filingDate, deathDate)) {
       return NEVER_FILES_LABEL;
     }
     if (displayAsAges) {
@@ -292,8 +300,6 @@
       if (months === 1) return `Age ${years} and 1 month`;
       return `Age ${years} and ${months} months`;
     }
-    const filingDate =
-      recipients[recipientIndex].birthdate.dateAtSsaAge(duration);
     return `${filingDate.monthName()} ${filingDate.year()}`;
   }
 </script>

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import { filedBeforeDeath } from "$lib/benefit-calculator";
   import RecipientName from "$lib/components/RecipientName.svelte";
   import { Money } from "$lib/money";
   import { MonthDurationRange } from "$lib/month-duration-range";
   import { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import { strategySumCentsCouple } from "$lib/strategy/calculations/strategy-calc";
+  import { NEVER_FILES_LABEL } from "$lib/strategy/ui";
 
   export let recipients: [Recipient, Recipient];
   export let deathAge1: MonthDuration;
@@ -274,6 +276,15 @@
     duration: MonthDuration,
     recipientIndex: number = 0
   ): string {
+    // The last row/column is the death month itself. Filing then is the
+    // "never files" strategy, not a filing month: say so.
+    const recipient = recipients[recipientIndex];
+    const deathDate = recipient.birthdate.dateAtLayAge(
+      recipientIndex === 0 ? deathAge1 : deathAge2
+    );
+    if (!filedBeforeDeath(recipient.birthdate.dateAtSsaAge(duration), deathDate)) {
+      return NEVER_FILES_LABEL;
+    }
     if (displayAsAges) {
       const years = duration.years();
       const months = duration.modMonths();

--- a/src/routes/strategy/components/AlternativeStrategiesRow.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesRow.svelte
@@ -9,7 +9,7 @@
     getStrategyColor,
     type YearGroup,
   } from "$lib/strategy/calculations/alternative-strategies";
-  import { NEVER_FILES_LABEL } from "$lib/strategy/ui";
+  import { NEVER_FILES_DETAIL, NEVER_FILES_LABEL } from "$lib/strategy/ui";
 
   export let recipient: Recipient;
   export let deathAge: MonthDuration;
@@ -34,11 +34,15 @@
     return getStrategyColor(percentOfOptimal, isOptimal);
   }
 
-  function formatFilingAge(filingAge: MonthDuration): string {
-    // The last box is the death month itself: the "never files" strategy.
+  // The last box is the death month itself: the "never files" strategy.
+  function neverFiles(filingAge: MonthDuration): boolean {
     const filingDate = recipient.birthdate.dateAtSsaAge(filingAge);
     const deathDate = recipient.birthdate.dateAtLayAge(deathAge);
-    if (!filedBeforeDeath(filingDate, deathDate)) {
+    return !filedBeforeDeath(filingDate, deathDate);
+  }
+
+  function formatFilingAge(filingAge: MonthDuration): string {
+    if (neverFiles(filingAge)) {
       return NEVER_FILES_LABEL;
     }
     return formatFilingAgeDisplay(
@@ -75,16 +79,20 @@
                 <div class="placeholder-text">N/A</div>
               </div>
             {:else}
+              {@const npvText = result.isOptimal
+                ? `Optimal · ${result.npv.wholeDollars()}`
+                : `${formatDelta(result.npv)} vs optimal · ${result.npv.wholeDollars()} (${result.percentOfOptimal.toFixed(1)}%)`}
               <div
                 class="strategy-box"
                 class:optimal={result.isOptimal}
+                class:never-files={neverFiles(result.filingAge)}
                 style="background-color: {getColor(
                   result.percentOfOptimal,
                   result.isOptimal
                 )};"
-                title={result.isOptimal
-                  ? `Optimal · ${result.npv.wholeDollars()}`
-                  : `${formatDelta(result.npv)} vs optimal · ${result.npv.wholeDollars()} (${result.percentOfOptimal.toFixed(1)}%)`}
+                title={neverFiles(result.filingAge)
+                  ? `${NEVER_FILES_DETAIL} · ${npvText}`
+                  : npvText}
               >
                 <div class="filing-label">
                   {formatFilingAge(result.filingAge)}
@@ -219,6 +227,17 @@
     font-weight: bold;
     font-size: 0.72rem;
     margin-bottom: 0.15rem;
+  }
+
+  /* The label is wider than a date; let this one box grow to fit rather
+     than wrap the label onto two lines. */
+  .strategy-box.never-files {
+    width: auto;
+    min-width: 70px;
+  }
+
+  .strategy-box.never-files .filing-label {
+    white-space: nowrap;
   }
 
   .delta-value {

--- a/src/routes/strategy/components/AlternativeStrategiesRow.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { filedBeforeDeath } from "$lib/benefit-calculator";
   import { Money } from "$lib/money";
   import { MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
@@ -8,6 +9,7 @@
     getStrategyColor,
     type YearGroup,
   } from "$lib/strategy/calculations/alternative-strategies";
+  import { NEVER_FILES_LABEL } from "$lib/strategy/ui";
 
   export let recipient: Recipient;
   export let deathAge: MonthDuration;
@@ -33,6 +35,12 @@
   }
 
   function formatFilingAge(filingAge: MonthDuration): string {
+    // The last box is the death month itself: the "never files" strategy.
+    const filingDate = recipient.birthdate.dateAtSsaAge(filingAge);
+    const deathDate = recipient.birthdate.dateAtLayAge(deathAge);
+    if (!filedBeforeDeath(filingDate, deathDate)) {
+      return NEVER_FILES_LABEL;
+    }
     return formatFilingAgeDisplay(
       filingAge,
       displayAsAges,

--- a/src/routes/strategy/components/ScenarioDetail.svelte
+++ b/src/routes/strategy/components/ScenarioDetail.svelte
@@ -3,9 +3,10 @@
   import RecipientName from "$lib/components/RecipientName.svelte";
   import type { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
+  import { filedBeforeDeath } from "$lib/benefit-calculator";
   import { BenefitType } from "$lib/strategy/calculations/benefit-period";
   import { strategySumPeriodsCouple } from "$lib/strategy/calculations/strategy-calc";
-  import type { StrategyResult } from "$lib/strategy/ui";
+  import { NEVER_FILES_LABEL, type StrategyResult } from "$lib/strategy/ui";
   import AlternativeStrategiesGrid from "./AlternativeStrategiesGrid.svelte";
 
   export let recipients: [Recipient, Recipient];
@@ -38,6 +39,10 @@
   $: expectedAge2 = result.bucket2.expectedAge;
   $: deathDate1 = recipients[0].birthdate.dateAtLayAge(expectedAge1);
   $: deathDate2 = recipients[1].birthdate.dateAtLayAge(expectedAge2);
+  // A filing month at or after death is the "never files" strategy, not a
+  // filing; name it as such rather than showing the death month as a date.
+  $: files1 = filedBeforeDeath(filingDate1, deathDate1);
+  $: files2 = filedBeforeDeath(filingDate2, deathDate2);
 
   // Use expectedAge (probability-weighted) so the timeline matches the death
   // dates the optimizer used to compute totalBenefit and choose filingAge1/2.
@@ -127,13 +132,23 @@
       <div class="filing-summary">
         <div class="filing-person">
           <p class="person-name"><RecipientName r={recipients[0]} /></p>
-          <p class="filing-age">{result.filingAge1.toFullAgeString()}</p>
-          <p class="filing-date">{filingDate1.toString()}</p>
+          {#if files1}
+            <p class="filing-age">{result.filingAge1.toFullAgeString()}</p>
+            <p class="filing-date">{filingDate1.toString()}</p>
+          {:else}
+            <p class="filing-age">{NEVER_FILES_LABEL}</p>
+            <p class="filing-date">Dies before filing</p>
+          {/if}
         </div>
         <div class="filing-person">
           <p class="person-name"><RecipientName r={recipients[1]} /></p>
-          <p class="filing-age">{result.filingAge2.toFullAgeString()}</p>
-          <p class="filing-date">{filingDate2.toString()}</p>
+          {#if files2}
+            <p class="filing-age">{result.filingAge2.toFullAgeString()}</p>
+            <p class="filing-date">{filingDate2.toString()}</p>
+          {:else}
+            <p class="filing-age">{NEVER_FILES_LABEL}</p>
+            <p class="filing-date">Dies before filing</p>
+          {/if}
         </div>
       </div>
       <div class="npv-card">

--- a/src/routes/strategy/components/ScenarioDetail.svelte
+++ b/src/routes/strategy/components/ScenarioDetail.svelte
@@ -6,7 +6,11 @@
   import { filedBeforeDeath } from "$lib/benefit-calculator";
   import { BenefitType } from "$lib/strategy/calculations/benefit-period";
   import { strategySumPeriodsCouple } from "$lib/strategy/calculations/strategy-calc";
-  import { NEVER_FILES_LABEL, type StrategyResult } from "$lib/strategy/ui";
+  import {
+    NEVER_FILES_DETAIL,
+    NEVER_FILES_LABEL,
+    type StrategyResult,
+  } from "$lib/strategy/ui";
   import AlternativeStrategiesGrid from "./AlternativeStrategiesGrid.svelte";
 
   export let recipients: [Recipient, Recipient];
@@ -137,7 +141,7 @@
             <p class="filing-date">{filingDate1.toString()}</p>
           {:else}
             <p class="filing-age">{NEVER_FILES_LABEL}</p>
-            <p class="filing-date">Dies before filing</p>
+            <p class="filing-date">{NEVER_FILES_DETAIL}</p>
           {/if}
         </div>
         <div class="filing-person">
@@ -147,7 +151,7 @@
             <p class="filing-date">{filingDate2.toString()}</p>
           {:else}
             <p class="filing-age">{NEVER_FILES_LABEL}</p>
-            <p class="filing-date">Dies before filing</p>
+            <p class="filing-date">{NEVER_FILES_DETAIL}</p>
           {/if}
         </div>
       </div>

--- a/src/routes/strategy/components/ScenarioDetailSingle.svelte
+++ b/src/routes/strategy/components/ScenarioDetailSingle.svelte
@@ -4,7 +4,11 @@
   import { filedBeforeDeath } from "$lib/benefit-calculator";
   import type { Recipient } from "$lib/recipient";
   import { strategySumPeriodsSingle } from "$lib/strategy/calculations/strategy-calc";
-  import { NEVER_FILES_LABEL, type StrategyResult } from "$lib/strategy/ui";
+  import {
+    NEVER_FILES_DETAIL,
+    NEVER_FILES_LABEL,
+    type StrategyResult,
+  } from "$lib/strategy/ui";
   import AlternativeStrategiesRow from "./AlternativeStrategiesRow.svelte";
 
   export let recipient: Recipient;
@@ -86,7 +90,7 @@
           <p class="filing-date">{filingDate.toString()}</p>
         {:else}
           <p class="filing-age">{NEVER_FILES_LABEL}</p>
-          <p class="filing-date">Dies before filing</p>
+          <p class="filing-date">{NEVER_FILES_DETAIL}</p>
         {/if}
       </div>
       <div class="npv-card">

--- a/src/routes/strategy/components/ScenarioDetailSingle.svelte
+++ b/src/routes/strategy/components/ScenarioDetailSingle.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
+  import { filedBeforeDeath } from "$lib/benefit-calculator";
   import type { Recipient } from "$lib/recipient";
   import { strategySumPeriodsSingle } from "$lib/strategy/calculations/strategy-calc";
-  import type { StrategyResult } from "$lib/strategy/ui";
+  import { NEVER_FILES_LABEL, type StrategyResult } from "$lib/strategy/ui";
   import AlternativeStrategiesRow from "./AlternativeStrategiesRow.svelte";
 
   export let recipient: Recipient;
@@ -20,6 +21,9 @@
   $: filingDate = recipient.birthdate.dateAtSsaAge(result.filingAge1);
   $: expectedAge = result.bucket1.expectedAge;
   $: deathDate = recipient.birthdate.dateAtLayAge(expectedAge);
+  // A filing month at or after death is the "never files" strategy, not a
+  // filing; name it as such rather than showing the death month as a date.
+  $: files = filedBeforeDeath(filingDate, deathDate);
 
   // Use expectedAge (probability-weighted) so the timeline matches the death
   // date the optimizer used to compute totalBenefit and choose filingAge1.
@@ -77,8 +81,13 @@
     <h3 class="section-title">Optimal filing in this scenario</h3>
     <div class="filing-grid">
       <div class="filing-summary">
-        <p class="filing-age">{result.filingAge1.toFullAgeString()}</p>
-        <p class="filing-date">{filingDate.toString()}</p>
+        {#if files}
+          <p class="filing-age">{result.filingAge1.toFullAgeString()}</p>
+          <p class="filing-date">{filingDate.toString()}</p>
+        {:else}
+          <p class="filing-age">{NEVER_FILES_LABEL}</p>
+          <p class="filing-date">Dies before filing</p>
+        {/if}
       </div>
       <div class="npv-card">
         <span class="npv-label">

--- a/src/routes/strategy/components/StrategyCell.svelte
+++ b/src/routes/strategy/components/StrategyCell.svelte
@@ -3,11 +3,12 @@ import { filedBeforeDeath } from '$lib/benefit-calculator';
 import RecipientName from '$lib/components/RecipientName.svelte';
 import type { MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
-import type { CellPosition } from '$lib/strategy/ui';
+import type { CellPosition, StrategyResult } from '$lib/strategy/ui';
 import {
   getFilingAge,
   getFilingDate,
   getNeverFilesLabel,
+  NEVER_FILES_DETAIL,
   NEVER_FILES_LABEL,
 } from '$lib/strategy/ui';
 
@@ -40,20 +41,43 @@ let cellHoverInfo: {
 } | null = null;
 
 /**
+ * The per-recipient half of a couple result. StrategyResult declares the
+ * second recipient's fields optional because the same shape serves single
+ * results; this cell is couple-only, and reading the fields through here
+ * makes a missing half a visible error rather than a property read on
+ * undefined.
+ */
+interface RecipientStrategy {
+  readonly filingAge: MonthDuration;
+  readonly deathAge: MonthDuration;
+}
+
+function recipientStrategy(
+  result: StrategyResult,
+  recipientIndex: number
+): RecipientStrategy {
+  if (recipientIndex === 0) {
+    return { filingAge: result.filingAge1, deathAge: result.bucket1.expectedAge };
+  }
+  if (result.filingAge2 === undefined || result.bucket2 === undefined) {
+    throw new Error('StrategyCell requires a couple result');
+  }
+  return { filingAge: result.filingAge2, deathAge: result.bucket2.expectedAge };
+}
+
+/**
  * Whether this cell's strategy has the recipient filing before their death
- * month. The optimizer's search includes the death month itself, and a
- * filing then is the "never files" strategy rather than a filing.
+ * month. The optimizer's search runs up to the death month (or, for a
+ * recipient who dies before they could file, the one age past death that is
+ * left), and a filing then is the "never files" strategy rather than a filing.
  */
 function filesInCell(
-  calculationResult: any,
+  result: StrategyResult,
   recipients: [Recipient, Recipient],
   recipientIndex: number
 ): boolean {
   const recipient = recipients[recipientIndex];
-  const filingAge: MonthDuration =
-    calculationResult[`filingAge${recipientIndex + 1}`];
-  const deathAge: MonthDuration =
-    calculationResult[`bucket${recipientIndex + 1}`].expectedAge;
+  const { filingAge, deathAge } = recipientStrategy(result, recipientIndex);
   return filedBeforeDeath(
     recipient.birthdate.dateAtSsaAge(filingAge),
     recipient.birthdate.dateAtLayAge(deathAge)
@@ -61,21 +85,18 @@ function filesInCell(
 }
 
 function describeFiling(
-  calculationResult: any,
+  result: StrategyResult,
   recipients: [Recipient, Recipient],
   recipientIndex: number
 ): string {
-  if (!filesInCell(calculationResult, recipients, recipientIndex)) {
-    return `${NEVER_FILES_LABEL} (dies first)`;
+  if (!filesInCell(result, recipients, recipientIndex)) {
+    return `${NEVER_FILES_LABEL} (${NEVER_FILES_DETAIL.toLowerCase()})`;
   }
-  const years = calculationResult[`filingAge${recipientIndex + 1}Years`];
-  const months = calculationResult[`filingAge${recipientIndex + 1}Months`];
-  const filingAge: MonthDuration =
-    calculationResult[`filingAge${recipientIndex + 1}`];
+  const { filingAge } = recipientStrategy(result, recipientIndex);
   const filingDate = recipients[recipientIndex].birthdate.dateAtSsaAge(
     filingAge
   );
-  return `${years}y ${months}m (${filingDate.toString()})`;
+  return `${filingAge.years()}y ${filingAge.modMonths()}m (${filingDate.toString()})`;
 }
 
 // Calculate conditional CSS classes

--- a/src/routes/strategy/components/StrategyCell.svelte
+++ b/src/routes/strategy/components/StrategyCell.svelte
@@ -7,7 +7,6 @@ import type { CellPosition, StrategyResult } from '$lib/strategy/ui';
 import {
   getFilingAge,
   getFilingDate,
-  getNeverFilesLabel,
   NEVER_FILES_DETAIL,
   NEVER_FILES_LABEL,
 } from '$lib/strategy/ui';
@@ -184,8 +183,12 @@ function getCellContentReactive(
   // Default to a larger size to show full format until actual dimensions are available
   const effectiveCellWidth = cellWidth || 100;
 
+  // One label at every width. Unlike a date, which can be abbreviated
+  // without changing meaning, a different word here would read as a
+  // different outcome. The cell truncates with an ellipsis; the hover
+  // overlay spells it out.
   if (!filesInCell(calculationResult, recipients, recipientIndex)) {
-    return getNeverFilesLabel(effectiveCellWidth);
+    return NEVER_FILES_LABEL;
   }
 
   if (displayAsAges) {

--- a/src/routes/strategy/components/StrategyCell.svelte
+++ b/src/routes/strategy/components/StrategyCell.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+import { filedBeforeDeath } from '$lib/benefit-calculator';
 import RecipientName from '$lib/components/RecipientName.svelte';
+import type { MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
 import type { CellPosition } from '$lib/strategy/ui';
-import { getFilingAge, getFilingDate } from '$lib/strategy/ui';
+import {
+  getFilingAge,
+  getFilingDate,
+  getNeverFilesLabel,
+  NEVER_FILES_LABEL,
+} from '$lib/strategy/ui';
 
 // Props
 export let rowIndex: number;
@@ -28,11 +35,48 @@ export let onselect: ((position: CellPosition) => void) | undefined =
 let cellHoverInfo: {
   x: number;
   y: number;
-  filingDate1: string;
-  filingDate2: string;
-  filingAge1: string;
-  filingAge2: string;
+  filing1: string;
+  filing2: string;
 } | null = null;
+
+/**
+ * Whether this cell's strategy has the recipient filing before their death
+ * month. The optimizer's search includes the death month itself, and a
+ * filing then is the "never files" strategy rather than a filing.
+ */
+function filesInCell(
+  calculationResult: any,
+  recipients: [Recipient, Recipient],
+  recipientIndex: number
+): boolean {
+  const recipient = recipients[recipientIndex];
+  const filingAge: MonthDuration =
+    calculationResult[`filingAge${recipientIndex + 1}`];
+  const deathAge: MonthDuration =
+    calculationResult[`bucket${recipientIndex + 1}`].expectedAge;
+  return filedBeforeDeath(
+    recipient.birthdate.dateAtSsaAge(filingAge),
+    recipient.birthdate.dateAtLayAge(deathAge)
+  );
+}
+
+function describeFiling(
+  calculationResult: any,
+  recipients: [Recipient, Recipient],
+  recipientIndex: number
+): string {
+  if (!filesInCell(calculationResult, recipients, recipientIndex)) {
+    return `${NEVER_FILES_LABEL} (dies first)`;
+  }
+  const years = calculationResult[`filingAge${recipientIndex + 1}Years`];
+  const months = calculationResult[`filingAge${recipientIndex + 1}Months`];
+  const filingAge: MonthDuration =
+    calculationResult[`filingAge${recipientIndex + 1}`];
+  const filingDate = recipients[recipientIndex].birthdate.dateAtSsaAge(
+    filingAge
+  );
+  return `${years}y ${months}m (${filingDate.toString()})`;
+}
 
 // Calculate conditional CSS classes
 $: isHighlightedCell =
@@ -55,26 +99,11 @@ function handleMouseOver(event: MouseEvent) {
   onhover?.({ rowIndex, colIndex });
 
   if (calculationResult) {
-    // Calculate filing dates for both recipients
-    const {
-      filingAge1Years,
-      filingAge1Months,
-      filingAge2Years,
-      filingAge2Months,
-      filingAge1,
-      filingAge2,
-    } = calculationResult;
-
-    const filingDate1 = recipients[0].birthdate.dateAtSsaAge(filingAge1);
-    const filingDate2 = recipients[1].birthdate.dateAtSsaAge(filingAge2);
-
     cellHoverInfo = {
       x: event.clientX,
       y: event.clientY,
-      filingDate1: filingDate1.toString(),
-      filingDate2: filingDate2.toString(),
-      filingAge1: `${filingAge1Years}y ${filingAge1Months}m`,
-      filingAge2: `${filingAge2Years}y ${filingAge2Months}m`,
+      filing1: describeFiling(calculationResult, recipients, 0),
+      filing2: describeFiling(calculationResult, recipients, 1),
     };
   }
 }
@@ -134,6 +163,10 @@ function getCellContentReactive(
   // Default to a larger size to show full format until actual dimensions are available
   const effectiveCellWidth = cellWidth || 100;
 
+  if (!filesInCell(calculationResult, recipients, recipientIndex)) {
+    return getNeverFilesLabel(effectiveCellWidth);
+  }
+
   if (displayAsAges) {
     return getFilingAge(
       filingAgeYears,
@@ -186,11 +219,11 @@ function getCellContentReactive(
     <div class="overlay-content">
       <div class="overlay-section">
         <strong><RecipientName r={recipients[0]} />:</strong>
-        {cellHoverInfo.filingAge1} ({cellHoverInfo.filingDate1})
+        {cellHoverInfo.filing1}
       </div>
       <div class="overlay-section">
         <strong><RecipientName r={recipients[1]} />:</strong>
-        {cellHoverInfo.filingAge2} ({cellHoverInfo.filingDate2})
+        {cellHoverInfo.filing2}
       </div>
       <div class="overlay-footer">Click for full details</div>
     </div>

--- a/src/routes/strategy/components/StrategyOverview.svelte
+++ b/src/routes/strategy/components/StrategyOverview.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+  import { filedBeforeDeath } from "$lib/benefit-calculator";
   import RecipientName from "$lib/components/RecipientName.svelte";
   import { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
   import { BenefitType } from "$lib/strategy/calculations/benefit-period";
   import { strategySumPeriodsCouple } from "$lib/strategy/calculations/strategy-calc";
-  import type { StrategyResult } from "$lib/strategy/ui";
+  import {
+    NEVER_FILES_DETAIL,
+    NEVER_FILES_LABEL,
+    type StrategyResult,
+  } from "$lib/strategy/ui";
 
   // Props
   export let recipients: [Recipient, Recipient];
@@ -35,6 +40,12 @@
     result && expectedAge2
       ? recipients[1].birthdate.dateAtLayAge(expectedAge2)
       : null;
+  // A filing month in or after the death month is the "never files"
+  // strategy, not a filing; name it as such rather than showing a date.
+  $: files1 =
+    filingDate1 && deathDate1 ? filedBeforeDeath(filingDate1, deathDate1) : true;
+  $: files2 =
+    filingDate2 && deathDate2 ? filedBeforeDeath(filingDate2, deathDate2) : true;
 
   // Calculate the benefit periods for the selected strategy
   // Use expectedAge (probability-weighted) so the timeline matches the death
@@ -124,13 +135,37 @@
         <tbody>
           <tr>
             <td class="row-label">Filing Age</td>
-            <td>{result.filingAge1Years}y {result.filingAge1Months}m</td>
-            <td>{result.filingAge2Years}y {result.filingAge2Months}m</td>
+            <td>
+              {#if files1}
+                {result.filingAge1Years}y {result.filingAge1Months}m
+              {:else}
+                {NEVER_FILES_LABEL}
+              {/if}
+            </td>
+            <td>
+              {#if files2}
+                {result.filingAge2Years}y {result.filingAge2Months}m
+              {:else}
+                {NEVER_FILES_LABEL}
+              {/if}
+            </td>
           </tr>
           <tr>
             <td class="row-label">Filing Date</td>
-            <td>{filingDate1?.toString() || "N/A"}</td>
-            <td>{filingDate2?.toString() || "N/A"}</td>
+            <td>
+              {#if files1}
+                {filingDate1?.toString() || "N/A"}
+              {:else}
+                {NEVER_FILES_DETAIL}
+              {/if}
+            </td>
+            <td>
+              {#if files2}
+                {filingDate2?.toString() || "N/A"}
+              {:else}
+                {NEVER_FILES_DETAIL}
+              {/if}
+            </td>
           </tr>
           <tr>
             <td class="row-label">Death Age</td>

--- a/src/routes/strategy/components/StrategyPlotSingle.svelte
+++ b/src/routes/strategy/components/StrategyPlotSingle.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import { filedBeforeDeath } from "$lib/benefit-calculator";
   import HowToReadChart from "$lib/components/HowToReadChart.svelte";
   import { MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
-  import type { CalculationResults } from "$lib/strategy/ui";
+  import {
+    type CalculationResults,
+    NEVER_FILES_LABEL,
+    type StrategyResult,
+  } from "$lib/strategy/ui";
   import { onMount } from "svelte";
 
   /** The recipient for whom the strategy is calculated. */
@@ -197,6 +202,28 @@
     const date = recipient.birthdate.dateAtSsaAge(new MonthDuration(months));
     const d = new Date(date.year(), date.monthIndex());
     return d.toLocaleString("default", { month: "short", year: "numeric" });
+  }
+
+  /**
+   * Axis label for a point's filing age. A filing month in or after the
+   * death month is the "never files" strategy, not a filing month.
+   */
+  function formatFiling(point: {
+    filingAgeMonths: number;
+    result: StrategyResult;
+  }): string {
+    const filingDate = recipient.birthdate.dateAtSsaAge(
+      new MonthDuration(point.filingAgeMonths)
+    );
+    const deathDate = recipient.birthdate.dateAtLayAge(
+      point.result.bucket1.expectedAge
+    );
+    if (!filedBeforeDeath(filingDate, deathDate)) {
+      return NEVER_FILES_LABEL;
+    }
+    return displayAsAges
+      ? formatAge(point.filingAgeMonths)
+      : formatDate(point.filingAgeMonths);
   }
 
   // Draw Loop
@@ -525,9 +552,7 @@
       ctx.fillText(label, x, height - padding.bottom + 20);
 
       // Y Axis Label Highlight
-      const yLabel = displayAsAges
-        ? formatAge(hoveredPoint.filingAgeMonths)
-        : formatDate(hoveredPoint.filingAgeMonths);
+      const yLabel = formatFiling(hoveredPoint);
 
       ctx.textAlign = "right";
       const textWidth = ctx.measureText(yLabel).width;

--- a/src/test/strategy/never-files-boundary.test.ts
+++ b/src/test/strategy/never-files-boundary.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { filedBeforeDeath, survivorBenefit } from '$lib/benefit-calculator';
+import {
+  benefitAtAge,
+  filedBeforeDeath,
+  survivorBenefit,
+} from '$lib/benefit-calculator';
 import { Birthdate } from '$lib/birthday';
 import { Money } from '$lib/money';
 import { MonthDate, MonthDuration } from '$lib/month-time';
 import { Recipient } from '$lib/recipient';
+import { optimalStrategyCoupleOptimized } from '$lib/strategy/calculations/strategy-calc';
 
 /**
  * A filing month at or after the death month is not a filing at all. The
@@ -82,5 +87,146 @@ describe('survivor base at the filing-month boundary', () => {
       survivorFilingDate
     );
     expect(result.cents()).toBe(Money.from(2547).cents());
+  });
+});
+
+describe('survivor base at the filing-month boundary after FRA', () => {
+  // Earner born July 2, 1960 (FRA 67). Survivor claims at their own FRA so
+  // the base amount is observable directly.
+  const deceased = makeRecipient(2000, 1960, 6, 2);
+  const survivor = makeRecipient(300, 1962, 3, 2);
+  const survivorFilingDate = survivor.birthdate.dateAtSsaAge(
+    survivor.survivorNormalRetirementAge()
+  );
+
+  it('dying at 68y6m: previous-month filing vs death-month filing differ by one month of credits', () => {
+    const deathDate = deceased.birthdate.dateAtLayAge(age(68, 6));
+    const previousMonth = deathDate.subtractDuration(new MonthDuration(1));
+
+    const filed = survivorBenefit(
+      survivor,
+      deceased,
+      previousMonth,
+      deathDate,
+      survivorFilingDate
+    );
+    const neverFiled = survivorBenefit(
+      survivor,
+      deceased,
+      deathDate,
+      deathDate,
+      survivorFilingDate
+    );
+
+    // Both exceed the 82.5% floor, so the filed branch reads the deceased's
+    // actual benefit and the never-filed branch reads it as if filed at death.
+    expect(filed.cents()).toBe(benefitAtAge(deceased, age(68, 5)).cents());
+    expect(neverFiled.cents()).toBe(benefitAtAge(deceased, age(68, 6)).cents());
+    expect(neverFiled.cents()).toBeGreaterThan(filed.cents());
+  });
+
+  it('dying past 70: both branches agree on the age-70 benefit', () => {
+    const deathDate = deceased.birthdate.dateAtLayAge(age(72, 0));
+    const previousMonth = deathDate.subtractDuration(new MonthDuration(1));
+    // The survivor is past their own FRA by then, so claiming the month after
+    // death carries no age reduction.
+    const claimAfterDeath = deathDate.addDuration(new MonthDuration(1));
+
+    const filed = survivorBenefit(
+      survivor,
+      deceased,
+      previousMonth,
+      deathDate,
+      claimAfterDeath
+    );
+    const neverFiled = survivorBenefit(
+      survivor,
+      deceased,
+      deathDate,
+      deathDate,
+      claimAfterDeath
+    );
+
+    const atAge70 = benefitAtAge(deceased, age(70, 0));
+    expect(filed.cents()).toBe(atAge70.cents());
+    expect(neverFiled.cents()).toBe(atAge70.cents());
+  });
+});
+
+describe('the optimizer represents "never files" as a death-month filing', () => {
+  // The display components derive the "does not file" label from the
+  // optimizer's output through filedBeforeDeath. These pin that contract.
+  const currentDate = MonthDate.initFromYearsMonths({ years: 2026, months: 8 });
+
+  it('a high earner dying early before FRA never files, so the survivor keeps full PIA', () => {
+    const earner = makeRecipient(2500, 1965, 6, 2);
+    const dependent = makeRecipient(300, 1966, 3, 2);
+    const recipients: [Recipient, Recipient] = [earner, dependent];
+    const finalDates: [MonthDate, MonthDate] = [
+      earner.birthdate.dateAtLayAge(age(64, 0)),
+      dependent.birthdate.dateAtLayAge(age(90, 0)),
+    ];
+
+    const [earnerAge] = optimalStrategyCoupleOptimized(
+      recipients,
+      finalDates,
+      currentDate,
+      0.03
+    );
+    expect(
+      filedBeforeDeath(earner.birthdate.dateAtSsaAge(earnerAge), finalDates[0])
+    ).toBe(false);
+  });
+
+  it('a recipient dying before the earliest filing age is clamped to an age past death', () => {
+    const earner = makeRecipient(2500, 1966, 6, 2);
+    const dependent = makeRecipient(300, 1966, 3, 2);
+    const recipients: [Recipient, Recipient] = [earner, dependent];
+    const finalDates: [MonthDate, MonthDate] = [
+      earner.birthdate.dateAtLayAge(age(61, 0)),
+      dependent.birthdate.dateAtLayAge(age(90, 0)),
+    ];
+
+    const [earnerAge] = optimalStrategyCoupleOptimized(
+      recipients,
+      finalDates,
+      currentDate,
+      0.03
+    );
+    expect(
+      filedBeforeDeath(earner.birthdate.dateAtSsaAge(earnerAge), finalDates[0])
+    ).toBe(false);
+  });
+});
+
+describe('first-of-month birthdays', () => {
+  // SSA treats a person as attaining an age the day before their birthday,
+  // so for someone born on the 1st the SSA age is a month ahead of the lay
+  // age. Display sites derive filing dates from SSA ages and death dates from
+  // lay ages; the round trip through ageAtSsaDate must land on the death
+  // month exactly.
+  const recipient = makeRecipient(1000, 1960, 0, 1);
+  const deathDate = recipient.birthdate.dateAtLayAge(age(70, 6));
+
+  it('the SSA age at the death date maps back to the death month', () => {
+    const deathAgeSsa = recipient.birthdate.ageAtSsaDate(deathDate);
+    expect(recipient.birthdate.dateAtSsaAge(deathAgeSsa).toString()).toBe(
+      deathDate.toString()
+    );
+    expect(
+      filedBeforeDeath(recipient.birthdate.dateAtSsaAge(deathAgeSsa), deathDate)
+    ).toBe(false);
+  });
+
+  it('one SSA month earlier is a real filing', () => {
+    const oneMonthEarlier = recipient.birthdate
+      .ageAtSsaDate(deathDate)
+      .subtract(new MonthDuration(1));
+    expect(
+      filedBeforeDeath(
+        recipient.birthdate.dateAtSsaAge(oneMonthEarlier),
+        deathDate
+      )
+    ).toBe(true);
   });
 });

--- a/src/test/strategy/never-files-boundary.test.ts
+++ b/src/test/strategy/never-files-boundary.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { filedBeforeDeath, survivorBenefit } from '$lib/benefit-calculator';
+import { Birthdate } from '$lib/birthday';
+import { Money } from '$lib/money';
+import { MonthDate, MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+
+/**
+ * A filing month at or after the death month is not a filing at all. The
+ * survivor rules already treat it that way; these tests pin that boundary and
+ * the predicate the UI uses to label such a strategy "does not file".
+ */
+
+function makeRecipient(
+  piaDollars: number,
+  year: number,
+  monthIndex: number,
+  day: number
+): Recipient {
+  const r = new Recipient();
+  r.birthdate = Birthdate.FromYMD(year, monthIndex, day);
+  r.setPia(Money.from(piaDollars));
+  return r;
+}
+
+const age = (years: number, months: number) =>
+  MonthDuration.initFromYearsMonths({ years, months });
+
+describe('filedBeforeDeath', () => {
+  const death = MonthDate.initFromYearsMonths({ years: 2029, months: 0 });
+
+  it('is true for a filing month before the death month', () => {
+    const filing = death.subtractDuration(new MonthDuration(1));
+    expect(filedBeforeDeath(filing, death)).toBe(true);
+  });
+
+  it('is false for a filing month equal to the death month', () => {
+    expect(filedBeforeDeath(death, death)).toBe(false);
+  });
+
+  it('is false for a filing month after the death month', () => {
+    const filing = death.addDuration(new MonthDuration(1));
+    expect(filedBeforeDeath(filing, death)).toBe(false);
+  });
+});
+
+describe('survivor base at the filing-month boundary', () => {
+  // Earner born July 2, 1965 (FRA 67), dies Jan 2029 at 63y6m, before FRA.
+  // Survivor born April 2, 1966 with a small PIA.
+  const deceased = makeRecipient(2547, 1965, 6, 2);
+  const survivor = makeRecipient(599, 1966, 3, 2);
+  const deathDate = deceased.birthdate.dateAtLayAge(age(63, 6));
+  // Survivor claims at their own full retirement age so no age reduction
+  // applies and the base amount is observable directly.
+  const survivorFilingDate = survivor.birthdate.dateAtSsaAge(
+    survivor.survivorNormalRetirementAge()
+  );
+
+  it('filing one month before death caps the survivor at 82.5% of PIA', () => {
+    const filingDate = deathDate.subtractDuration(new MonthDuration(1));
+    expect(filedBeforeDeath(filingDate, deathDate)).toBe(true);
+
+    const result = survivorBenefit(
+      survivor,
+      deceased,
+      filingDate,
+      deathDate,
+      survivorFilingDate
+    );
+    const ribLim = Money.from(2547).times(0.825).floorToDollar();
+    expect(result.cents()).toBe(ribLim.cents());
+  });
+
+  it('filing in the death month is no filing: survivor gets full PIA', () => {
+    expect(filedBeforeDeath(deathDate, deathDate)).toBe(false);
+
+    const result = survivorBenefit(
+      survivor,
+      deceased,
+      deathDate,
+      deathDate,
+      survivorFilingDate
+    );
+    expect(result.cents()).toBe(Money.from(2547).cents());
+  });
+});

--- a/src/test/strategy/ui/formatting.test.ts
+++ b/src/test/strategy/ui/formatting.test.ts
@@ -6,7 +6,6 @@ import {
   createBorderRemovalFunctions,
   getFilingAge,
   getFilingDate,
-  getNeverFilesLabel,
 } from '$lib/strategy/ui/formatting';
 
 /**
@@ -229,23 +228,6 @@ describe('formatting', () => {
         expect(funcs.left(0, 0)).toBe(false);
         expect(funcs.top(0, 0)).toBe(false);
       });
-    });
-  });
-
-  describe('getNeverFilesLabel', () => {
-    it('uses a dash where a date would not fit', () => {
-      expect(getNeverFilesLabel(30)).toBe('—');
-      expect(getNeverFilesLabel(49)).toBe('—');
-    });
-
-    it('uses a short word in medium cells', () => {
-      expect(getNeverFilesLabel(50)).toBe('None');
-      expect(getNeverFilesLabel(79)).toBe('None');
-    });
-
-    it('spells it out in large cells', () => {
-      expect(getNeverFilesLabel(80)).toBe('Does not file');
-      expect(getNeverFilesLabel(200)).toBe('Does not file');
     });
   });
 });

--- a/src/test/strategy/ui/formatting.test.ts
+++ b/src/test/strategy/ui/formatting.test.ts
@@ -6,6 +6,7 @@ import {
   createBorderRemovalFunctions,
   getFilingAge,
   getFilingDate,
+  getNeverFilesLabel,
 } from '$lib/strategy/ui/formatting';
 
 /**
@@ -228,6 +229,23 @@ describe('formatting', () => {
         expect(funcs.left(0, 0)).toBe(false);
         expect(funcs.top(0, 0)).toBe(false);
       });
+    });
+  });
+
+  describe('getNeverFilesLabel', () => {
+    it('uses a dash where a date would not fit', () => {
+      expect(getNeverFilesLabel(30)).toBe('—');
+      expect(getNeverFilesLabel(49)).toBe('—');
+    });
+
+    it('uses a short word in medium cells', () => {
+      expect(getNeverFilesLabel(50)).toBe('None');
+      expect(getNeverFilesLabel(79)).toBe('None');
+    });
+
+    it('spells it out in large cells', () => {
+      expect(getNeverFilesLabel(80)).toBe('Does not file');
+      expect(getNeverFilesLabel(200)).toBe('Does not file');
     });
   });
 });


### PR DESCRIPTION
## Summary

The strategy optimizers search filing ages up to and including the death month. The survivor rules treat a filing at or after death as no filing at all, so the survivor's base is the full PIA rather than the 82.5% RIB-LIM floor. That row is the "never files" strategy and is frequently the scenario optimum when the higher earner dies early, but every surface named it as a filing month (e.g. "63 years 6 months / Jan 2029"), which made the jump from the row above look like a discontinuity bug.

Repro: `/strategy#pia1=2547&dob1=1965-07-02&name1=Alex&pia2=599&dob2=1966-04-02&name2=Chris`, click the cell for Alex dies at 63 / Chris dies at 72.

## Changes

- `filedBeforeDeath(filingDate, deathDate)` added to `benefit-calculator.ts` and used inside `survivorBenefit`, so the label and the calculation share one definition.
- Death-age matrix cell and hover overlay, couple and single scenario detail cards, and the alternative-strategies hover panel now say "Does not file" for such a row.
- `getNeverFilesLabel(cellWidth)` mirrors `getFilingDate`'s width breakpoints for the matrix cell.

## Tests

- New `never-files-boundary.test.ts`: predicate truth table, plus survivor base at the boundary (one month before death caps at 82.5% of PIA; the death month itself yields full PIA).
- `formatting.test.ts`: width breakpoints for the new label.
- Full suite: 83 files, 2185 tests pass. `npm run quality` clean.
- Verified in the running app: matrix hover reads "Alex: Does not file (dies first)", scenario card reads "Does not file / Dies before filing", alt-grid panel reads "Does not file".

## Known gap (follow-up)

Benefit periods still include the death month, so the payment timeline shows one check in a month SSA does not pay for. Unrelated to the label and left out of this PR.
