### PR TITLE
feat(strategy): let a couple record that one spouse already receives benefits

### DIFF
--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -39,6 +39,10 @@
      * month SSA allows — a month that has already passed, which under a
      * "File in" label reads as a bug rather than as advice.
      *
+     * Also false for a recipient who has already filed. They get the
+     * "Started benefits" card instead, because `alreadyFiled` takes
+     * precedence in the snippet.
+     *
      * Required rather than defaulted: defaulting it to [true, true] would
      * silently reinstate that already-passed date for any caller that forgot
      * to pass it.
@@ -57,7 +61,7 @@
     /**
      * Called when the viewer clicks "Already receiving benefits?" on the
      * card of an eligible recipient who was not marked as filed. When
-     * omitted (the calculator card), no hint is shown.
+     * omitted (the calculator card, and single mode), no hint is shown.
      */
     onAlreadyFiledHint?: () => void;
   }
@@ -118,9 +122,10 @@
 
   /**
    * The filed recipient's own monthly benefit at their actual filing age, in
-   * today's dollars, so it matches every other amount on the page. Null for
-   * a zero-PIA recipient: what they receive is a spousal benefit that this
-   * card does not compute, and "about $0 per month" would read as a bug.
+   * today's dollars, so it matches every other amount on the page. Any
+   * spousal top-up is not included. Null for a zero-PIA recipient: what
+   * they receive is a spousal benefit that this card does not compute, and
+   * "about $0 per month" would read as a bug.
    */
   function filedAmount(index: number, filedAt: MonthDate): string | null {
     const age = recipients[index].birthdate.ageAtSsaDate(filedAt);
@@ -152,7 +157,7 @@
     {@const amount = filedAmount(index, filedAt)}
     <div class="age-sub">
       at age {filedAge(index, filedAt)}{#if amount !== null}, about {amount} per
-        month in today's dollars{/if}
+        month from your own record, in today's dollars{/if}
     </div>
   {:else if isAlreadyPast(index, filingAge)}
     <div class="prefix">File</div>

--- a/src/lib/components/OptimalStrategyHeadline.svelte
+++ b/src/lib/components/OptimalStrategyHeadline.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { benefitAtAge } from "$lib/benefit-calculator";
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
   import {
@@ -9,6 +10,11 @@
   import { Money } from "$lib/money";
   import type { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
+  import {
+    type AlreadyFiled,
+    isEligibleToHaveFiled,
+    NOT_FILED,
+  } from "$lib/strategy/calculations/already-filed";
   import type {
     FilingAgeResult,
     CoupleFilingAgeResult,
@@ -43,6 +49,17 @@
      * date that is still ahead from one that has already passed.
      */
     currentDate: MonthDate;
+    /**
+     * Per recipient, the month benefits actually started, or null. A filed
+     * recipient's card states that as a fact instead of a recommendation.
+     */
+    alreadyFiled?: AlreadyFiled;
+    /**
+     * Called when the viewer clicks "Already receiving benefits?" on the
+     * card of an eligible recipient who was not marked as filed. When
+     * omitted (the calculator card), no hint is shown.
+     */
+    onAlreadyFiledHint?: () => void;
   }
 
   let {
@@ -54,6 +71,8 @@
     discountRateAssumption = DEFAULT_DISCOUNT_RATE_ASSUMPTION,
     hasFilingChoice,
     currentDate,
+    alreadyFiled = NOT_FILED,
+    onAlreadyFiledHint,
   }: Props = $props();
 
   /**
@@ -96,10 +115,46 @@
   function formatMoney(cents: number): string {
     return Money.fromCents(Math.round(cents)).wholeDollars();
   }
+
+  /**
+   * The filed recipient's own monthly benefit at their actual filing age, in
+   * today's dollars, so it matches every other amount on the page. Null for
+   * a zero-PIA recipient: what they receive is a spousal benefit that this
+   * card does not compute, and "about $0 per month" would read as a bug.
+   */
+  function filedAmount(index: number, filedAt: MonthDate): string | null {
+    const age = recipients[index].birthdate.ageAtSsaDate(filedAt);
+    const amount = benefitAtAge(recipients[index], age);
+    return amount.cents() > 0 ? amount.wholeDollars() : null;
+  }
+
+  function filedAge(index: number, filedAt: MonthDate): string {
+    return recipients[index].birthdate.ageAtSsaDate(filedAt).toFullAgeString();
+  }
+
+  function showFiledHint(index: number): boolean {
+    return (
+      onAlreadyFiledHint !== undefined &&
+      alreadyFiled[index] === null &&
+      isEligibleToHaveFiled(recipients[index].birthdate, currentDate)
+    );
+  }
 </script>
 
 {#snippet filingCard(index: number, filingAge: MonthDuration)}
-  {#if isAlreadyPast(index, filingAge)}
+  {@const filedAt = alreadyFiled[index]}
+  {#if filedAt !== null}
+    <div class="prefix">Started benefits</div>
+    <div class="date-big">
+      <span class="date-full">{filedAt.monthFullName()} {filedAt.year()}</span>
+      <span class="date-short">{filedAt.monthName()} {filedAt.year()}</span>
+    </div>
+    {@const amount = filedAmount(index, filedAt)}
+    <div class="age-sub">
+      at age {filedAge(index, filedAt)}{#if amount !== null}, about {amount} per
+        month in today's dollars{/if}
+    </div>
+  {:else if isAlreadyPast(index, filingAge)}
     <div class="prefix">File</div>
     <div class="date-big">now</div>
     <div class="age-sub">
@@ -122,6 +177,11 @@
       >
     </div>
     <div class="age-sub">at age {formatAge(filingAge)}</div>
+  {/if}
+  {#if showFiledHint(index)}
+    <button type="button" class="filed-hint" onclick={onAlreadyFiledHint}>
+      Already receiving benefits? Update your details
+    </button>
   {/if}
 {/snippet}
 
@@ -197,6 +257,15 @@
           Maximizes your expected lifetime benefits, weighted by the
           probability of surviving to each age and adjusted for the discount
           rate.
+        {:else if alreadyFiled[0] !== null && alreadyFiled[1] !== null}
+          You are both already receiving benefits, so there is no filing
+          decision left here. The figure is the expected value of what is
+          still to come.
+        {:else if alreadyFiled[0] !== null || alreadyFiled[1] !== null}
+          Maximizes your expected combined lifetime benefits, taking
+          <RecipientName r={recipients[alreadyFiled[0] !== null ? 0 : 1]} />'s
+          filing date as given and weighting by each person's probability of
+          surviving to each age, adjusted for the discount rate.
         {:else}
           Maximizes your expected combined lifetime benefits, weighted by
           each person's probability of surviving to each age and adjusted for
@@ -281,6 +350,18 @@
     font-size: 1rem;
     color: #4b5563;
     font-weight: 500;
+  }
+
+  .filed-hint {
+    margin-top: 0.5rem;
+    padding: 0;
+    border: none;
+    background: none;
+    color: #3b4a9f;
+    font: inherit;
+    font-size: 0.85rem;
+    text-decoration: underline;
+    cursor: pointer;
   }
 
   .couple-results {

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -2,6 +2,10 @@ import type { DeathProbability } from '$lib/life-tables';
 import { getDeathProbabilityDistribution } from '$lib/life-tables';
 import { MonthDate } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
+import {
+  type AlreadyFiled,
+  NOT_FILED,
+} from '$lib/strategy/calculations/already-filed';
 import type {
   CoupleFilingAgeResult,
   FilingAgeResult,
@@ -110,10 +114,11 @@ export function currentMonthDate(now: Date = new Date()): MonthDate {
 /**
  * Whether each recipient still has a filing age to choose, as of `currentDate`.
  *
- * False once a recipient is past 70: delayed retirement credits have stopped,
- * so filing now is their only remaining option and presenting a filing date
- * would imply a decision they no longer have. Index 1 is always true when
- * there is no second recipient, so single-recipient callers can ignore it.
+ * False once a recipient is past 70 (delayed retirement credits have stopped,
+ * so filing now is their only remaining option) or once they have already
+ * filed (`alreadyFiled`), since presenting a filing date to either would
+ * imply a decision they no longer have. Index 1 is always true when there is
+ * no second recipient, so single-recipient callers can ignore it.
  *
  * Shared so the two surfaces that render a recommendation — the strategy page
  * and the calculator's card — cannot disagree about who still has a choice.
@@ -121,11 +126,14 @@ export function currentMonthDate(now: Date = new Date()): MonthDate {
 export function filingChoices(
   recipient: Recipient,
   spouse: Recipient | null,
-  currentDate: MonthDate = currentMonthDate()
+  currentDate: MonthDate = currentMonthDate(),
+  alreadyFiled: AlreadyFiled = NOT_FILED
 ): [boolean, boolean] {
   return [
-    filingAgeRange(recipient, currentDate).hasChoice,
-    spouse ? filingAgeRange(spouse, currentDate).hasChoice : true,
+    filingAgeRange(recipient, currentDate, alreadyFiled[0]).hasChoice,
+    spouse
+      ? filingAgeRange(spouse, currentDate, alreadyFiled[1]).hasChoice
+      : true,
   ];
 }
 

--- a/src/lib/components/recommended-filing-card.ts
+++ b/src/lib/components/recommended-filing-card.ts
@@ -120,8 +120,8 @@ export function currentMonthDate(now: Date = new Date()): MonthDate {
  * imply a decision they no longer have. Index 1 is always true when there is
  * no second recipient, so single-recipient callers can ignore it.
  *
- * Shared so the two surfaces that render a recommendation — the strategy page
- * and the calculator's card — cannot disagree about who still has a choice.
+ * Shared so the two surfaces that render a recommendation, the strategy page
+ * and the calculator's card, cannot disagree about who still has a choice.
  */
 export function filingChoices(
   recipient: Recipient,

--- a/src/lib/strategy/calculations/already-filed.ts
+++ b/src/lib/strategy/calculations/already-filed.ts
@@ -1,0 +1,68 @@
+/**
+ * The "already receiving benefits" input to the strategy optimizer.
+ *
+ * A recipient who has filed has no filing decision left to make: their
+ * filing month is a fact. The optimizer treats it as a filing-age range of
+ * exactly one entry (see `filingAgeRange`), and searches only the other
+ * spouse's ages. This module owns the type and the rules for when the input
+ * may be shown and what values it accepts; it deliberately depends on
+ * nothing but `Birthdate` and `MonthDate` so the form can use it without a
+ * `Recipient`.
+ */
+
+import type { Birthdate } from '$lib/birthday';
+import type { MonthDate } from '$lib/month-time';
+
+/**
+ * Per recipient, the month benefits actually started, or null if the
+ * recipient has not filed. Index order matches the `recipients` tuple used
+ * throughout the strategy code.
+ */
+export type AlreadyFiled = readonly [MonthDate | null, MonthDate | null];
+
+/** Nobody has filed. The default for every optimizer entry point. */
+export const NOT_FILED: AlreadyFiled = [null, null];
+
+/** The first calendar month in which this person could have filed. */
+export function earliestFilingDate(birthdate: Birthdate): MonthDate {
+  return birthdate.dateAtSsaAge(birthdate.earliestFilingMonth());
+}
+
+/**
+ * Whether the person is old enough to have filed as of `currentDate`: their
+ * earliest filing month (age 62, adjusted for the 1st/2nd-of-month rule) is
+ * this month or earlier. The form shows the "already receiving benefits"
+ * control only when this is true, so nobody under 62 ever sees it.
+ */
+export function isEligibleToHaveFiled(
+  birthdate: Birthdate,
+  currentDate: MonthDate
+): boolean {
+  return earliestFilingDate(birthdate).lessThanOrEqual(currentDate);
+}
+
+/**
+ * Validates a claimed filing month. Returns null when acceptable, otherwise
+ * a message suitable for showing under the input.
+ *
+ * The month must be no earlier than the person's earliest filing month and
+ * no later than `currentDate`: this feature records what has happened, not
+ * a plan.
+ */
+export function validateFiledMonth(
+  birthdate: Birthdate,
+  filedAt: MonthDate,
+  currentDate: MonthDate
+): string | null {
+  const earliest = earliestFilingDate(birthdate);
+  if (filedAt.lessThan(earliest)) {
+    return (
+      `Benefits cannot start before the first full month at age 62, ` +
+      `which is ${earliest.monthFullName()} ${earliest.year()} for this birthdate.`
+    );
+  }
+  if (filedAt.greaterThan(currentDate)) {
+    return 'The start month cannot be in the future.';
+  }
+  return null;
+}

--- a/src/lib/strategy/calculations/already-filed.ts
+++ b/src/lib/strategy/calculations/already-filed.ts
@@ -20,6 +20,13 @@ import type { MonthDate } from '$lib/month-time';
  */
 export type AlreadyFiled = readonly [MonthDate | null, MonthDate | null];
 
+/**
+ * The mutable form-state shape the strategy page binds into its inputs.
+ * Snapshot it into an `AlreadyFiled` before handing it to a calculation, so
+ * results describe one set of inputs even if the form changes mid-run.
+ */
+export type AlreadyFiledInput = [MonthDate | null, MonthDate | null];
+
 /** Nobody has filed. The default for every optimizer entry point. */
 export const NOT_FILED: AlreadyFiled = [null, null];
 

--- a/src/lib/strategy/calculations/expected-npv.ts
+++ b/src/lib/strategy/calculations/expected-npv.ts
@@ -369,9 +369,10 @@ function survivorCentsCalc(
  * is for `recipients[0]`. Validated against the exact version by 1,000
  * golden test cases in `expected-npv-couple-goldens.test.ts`.
  *
- * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
- *                       or null; a filed recipient contributes exactly one
- *                       filing age.
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits
+ *                                      actually started, or null; a filed
+ *                                      recipient contributes exactly one
+ *                                      filing age.
  */
 export function expectedNPVCoupleOptimized(
   recipients: [Recipient, Recipient],
@@ -879,9 +880,10 @@ export function expectedNPVCoupleOptimized(
  *
  * Deaths are assumed independent (standard actuarial assumption).
  *
- * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
- *                       or null; a filed recipient contributes exactly one
- *                       filing age.
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits
+ *                                      actually started, or null; a filed
+ *                                      recipient contributes exactly one
+ *                                      filing age.
  * @returns Array of {filingAges, expectedNPVCents} sorted descending by
  *          expectedNPVCents. The first element is the optimal filing pair.
  */

--- a/src/lib/strategy/calculations/expected-npv.ts
+++ b/src/lib/strategy/calculations/expected-npv.ts
@@ -47,6 +47,7 @@ import {
 import type { DeathProbability } from '$lib/life-tables';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
+import { type AlreadyFiled, NOT_FILED } from './already-filed';
 import { classifyEarnerDependent } from './earner-dependent.js';
 import {
   calculateMonthlyDiscountRate,
@@ -367,12 +368,17 @@ function survivorCentsCalc(
  * original recipient order (not earner/dependent order) — `filingAges[0]`
  * is for `recipients[0]`. Validated against the exact version by 1,000
  * golden test cases in `expected-npv-couple-goldens.test.ts`.
+ *
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
+ *                       or null; a filed recipient contributes exactly one
+ *                       filing age.
  */
 export function expectedNPVCoupleOptimized(
   recipients: [Recipient, Recipient],
   currentDate: MonthDate,
   discountRate: number,
-  deathProbDists: [DeathProbability[], DeathProbability[]]
+  deathProbDists: [DeathProbability[], DeathProbability[]],
+  alreadyFiled: AlreadyFiled = NOT_FILED
 ): CoupleFilingAgeResult[] {
   if (deathProbDists[0].length === 0 || deathProbDists[1].length === 0)
     return [];
@@ -469,8 +475,12 @@ export function expectedNPVCoupleOptimized(
   // ── Filing ranges ──
   // A recipient with no filing choice left has a single remaining option, so
   // their range collapses to one entry rather than going empty.
-  const eRange = filingAgeRange(earner, currentDate);
-  const dRange = filingAgeRange(dependent, currentDate);
+  const eRange = filingAgeRange(earner, currentDate, alreadyFiled[earnerIndex]);
+  const dRange = filingAgeRange(
+    dependent,
+    currentDate,
+    alreadyFiled[dependentIndex]
+  );
   const eStart = eRange.earliest.asMonths();
   const dStart = dRange.earliest.asMonths();
   const eEnd = eRange.latest.asMonths();
@@ -869,6 +879,9 @@ export function expectedNPVCoupleOptimized(
  *
  * Deaths are assumed independent (standard actuarial assumption).
  *
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
+ *                       or null; a filed recipient contributes exactly one
+ *                       filing age.
  * @returns Array of {filingAges, expectedNPVCents} sorted descending by
  *          expectedNPVCents. The first element is the optimal filing pair.
  */
@@ -876,14 +889,15 @@ export function expectedNPVCouple(
   recipients: [Recipient, Recipient],
   currentDate: MonthDate,
   discountRate: number,
-  deathProbDists: [DeathProbability[], DeathProbability[]]
+  deathProbDists: [DeathProbability[], DeathProbability[]],
+  alreadyFiled: AlreadyFiled = NOT_FILED
 ): CoupleFilingAgeResult[] {
   if (deathProbDists[0].length === 0 || deathProbDists[1].length === 0) {
     return [];
   }
 
-  const range0 = filingAgeRange(recipients[0], currentDate);
-  const range1 = filingAgeRange(recipients[1], currentDate);
+  const range0 = filingAgeRange(recipients[0], currentDate, alreadyFiled[0]);
+  const range1 = filingAgeRange(recipients[1], currentDate, alreadyFiled[1]);
   const startFiling0 = range0.earliest.asMonths();
   const startFiling1 = range1.earliest.asMonths();
   const endFiling0 = range0.latest.asMonths();

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -530,7 +530,11 @@ export function optimalStrategyCoupleFast(
   // dependent filing ages below earner's produce identical NPV. The loop's
   // tie-break picks the earliest, which displays a misleading "62y1m". Bump
   // the reported dep age to match the earner's filing whenever needed.
-  if (depZeroPia) {
+  //
+  // Not when the dependent is recorded in `alreadyFiled`: that month is a
+  // fact the user entered, not a tie-break, and expectedNPVCoupleOptimized
+  // reports it unchanged. Bumping it here would make the surfaces disagree.
+  if (depZeroPia && alreadyFiled[dependentIndex] === null) {
     const bestFE = earnerIndex === 0 ? bestF0 : bestF1;
     const earnerFileEpoch = eSsaBirth + bestFE;
     let bestFD = earnerIndex === 0 ? bestF1 : bestF0;

--- a/src/lib/strategy/calculations/optimal-strategy-fast.ts
+++ b/src/lib/strategy/calculations/optimal-strategy-fast.ts
@@ -48,6 +48,7 @@ import {
 } from '$lib/benefit-calculator';
 import { type MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
+import { type AlreadyFiled, NOT_FILED } from './already-filed';
 import { classifyEarnerDependent } from './earner-dependent.js';
 import {
   calculateMonthlyDiscountRate,
@@ -222,12 +223,16 @@ function survivorCentsCalc(
  * Every return value is a real strategy. A recipient who dies before they
  * could file is searched at their single earliest age, where their personal
  * NPV is zero, rather than emptying the range — see the clamp below.
+ *
+ * A recipient recorded in `alreadyFiled` is searched at their actual filing
+ * age only.
  */
 export function optimalStrategyCoupleFast(
   recipients: [Recipient, Recipient],
   finalDates: [MonthDate, MonthDate],
   currentDate: MonthDate,
-  discountRate: number
+  discountRate: number,
+  alreadyFiled: AlreadyFiled = NOT_FILED
 ): [MonthDuration, MonthDuration, number] {
   // ── Classify earner/dependent ──
   const { earner, dependent, earnerIndex, dependentIndex } =
@@ -283,8 +288,12 @@ export function optimalStrategyCoupleFast(
   // ── Filing ranges ──
   // A recipient with no filing choice left has one option, so their range
   // collapses to a single entry rather than going empty.
-  const eRange = filingAgeRange(earner, currentDate);
-  const dRange = filingAgeRange(dependent, currentDate);
+  const eRange = filingAgeRange(earner, currentDate, alreadyFiled[earnerIndex]);
+  const dRange = filingAgeRange(
+    dependent,
+    currentDate,
+    alreadyFiled[dependentIndex]
+  );
   const eStart = eRange.earliest.asMonths();
   const dStart = dRange.earliest.asMonths();
   // Clamped to the death date, but never below the start: one recipient dying

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -358,11 +358,12 @@ export const MAX_FILING_AGE: MonthDuration = new MonthDuration(
 /**
  * The inclusive span of filing ages an optimizer should search over.
  *
- * `hasChoice` is false once `earliest` has reached 70. Because SSA allows
+ * `hasChoice` is false once `earliest` has reached 70, or when the recipient
+ * has already filed (see `filingAgeRange`'s `filedAt`). Because SSA allows
  * filing up to six months retroactively, `earliest` lags the recipient's
  * current age by six months once they are past full retirement age, so the
- * flip happens at age 70y6m rather than at 70y0m. A recipient aged 70y3m
- * still has a real, if narrow, range to search.
+ * age-based flip happens at age 70y6m rather than at 70y0m. A recipient aged
+ * 70y3m still has a real, if narrow, range to search.
  *
  * Past that point exactly one option remains: file as soon as possible,
  * backdated to `earliest` — the most retroactive month SSA allows — so
@@ -370,9 +371,9 @@ export const MAX_FILING_AGE: MonthDuration = new MonthDuration(
  * Callers presenting results to a user should say so rather than implying a
  * decision was made on the recipient's behalf.
  *
- * Note that `latest` is NOT bounded by `MAX_FILING_AGE`: in exactly that case
- * it exceeds it, which is the whole point of the type. The span is always
- * non-empty (`earliest <= latest`).
+ * Note that `latest` is NOT bounded by `MAX_FILING_AGE`: past 70 it exceeds
+ * it, and for a filed recipient both bounds are the actual filing age,
+ * whatever that is. The span is always non-empty (`earliest <= latest`).
  *
  * Model limitation: the NPV functions count payments from the month after
  * `currentDate`, so the retroactive lump sum SSA pays for a backdated claim
@@ -788,12 +789,19 @@ export function strategySumPeriodsOptimized(
  * If the brute-force optimizer recorded a dependent filing age earlier than
  * the earner's, every such pair produces the same NPV as the (matching-earner)
  * pair, so the reported dependent age would be misleading. Bump it forward.
+ *
+ * A dependent recorded in `alreadyFiled` is left alone: their filing month is
+ * a fact the user entered, not a tie-break the optimizer chose, and the
+ * expected-NPV path reports it unchanged. Bumping it here would make the two
+ * surfaces disagree about when that person filed.
  */
 function clampZeroPiaDepStrategy(
   recipients: [Recipient, Recipient],
-  best: [MonthDuration, MonthDuration, number]
+  best: [MonthDuration, MonthDuration, number],
+  alreadyFiled: AlreadyFiled
 ): [MonthDuration, MonthDuration, number] {
   const { earnerIndex, dependentIndex } = classifyEarnerDependent(recipients);
+  if (alreadyFiled[dependentIndex] !== null) return best;
   const dependent = recipients[dependentIndex];
   if (dependent.pia().primaryInsuranceAmount().cents() !== 0) return best;
 
@@ -835,9 +843,10 @@ function clampZeroPiaDepStrategy(
  * @param {MonthDate} currentDate - Today's date.
  * @param {number} discountRate - Rate used for present value calculation. 0
  *                                means no discount.
- * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
- *                       or null. A filed recipient is searched at that single
- *                       age.
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits
+ *                                      actually started, or null. A filed
+ *                                      recipient is searched at that single
+ *                                      age.
  * @returns {[MonthDuration, MonthDuration]} An array containing the optimal
  *                                           filing ages for each recipient.
  */
@@ -881,7 +890,7 @@ export function optimalStrategyCouple(
     }
   }
 
-  return clampZeroPiaDepStrategy(recipients, bestStrategy);
+  return clampZeroPiaDepStrategy(recipients, bestStrategy, alreadyFiled);
 }
 
 /**
@@ -897,9 +906,10 @@ export function optimalStrategyCouple(
  * @param {MonthDate} currentDate - Today's date.
  * @param {number} discountRate - Rate used for present value calculation. 0
  *                                means no discount.
- * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
- *                       or null. A filed recipient is searched at that single
- *                       age.
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits
+ *                                      actually started, or null. A filed
+ *                                      recipient is searched at that single
+ *                                      age.
  * @returns {[MonthDuration, MonthDuration]} An array containing the optimal
  *                                           filing ages for each recipient.
  */
@@ -973,7 +983,7 @@ export function optimalStrategyCoupleOptimized(
     }
   }
 
-  return clampZeroPiaDepStrategy(recipients, bestStrategy);
+  return clampZeroPiaDepStrategy(recipients, bestStrategy, alreadyFiled);
 }
 
 /**

--- a/src/lib/strategy/calculations/strategy-calc.ts
+++ b/src/lib/strategy/calculations/strategy-calc.ts
@@ -8,6 +8,11 @@ import {
 import { Money } from '$lib/money';
 import { MonthDate, MonthDuration } from '$lib/month-time';
 import type { Recipient } from '$lib/recipient';
+import {
+  type AlreadyFiled,
+  NOT_FILED,
+  validateFiledMonth,
+} from './already-filed';
 import { BenefitPeriod, BenefitType } from './benefit-period.js';
 import { classifyEarnerDependent } from './earner-dependent.js';
 import { PersonalBenefitPeriods } from './recipient-personal-benefits.js';
@@ -439,11 +444,36 @@ export class NoFilingAgeAvailableError extends Error {
  * typed-array allocations in the fast paths. (Searches that start from
  * `earliestFilingMonth`, the age-62 month, are not affected — see
  * alternative-strategies.ts and ai-export.ts.)
+ *
+ * `filedAt`, when given, is the month the recipient actually started
+ * benefits. The range is then that single filing age with `hasChoice`
+ * false: there is nothing to search. The month must pass
+ * `validateFiledMonth`; the form enforces that, so a failure here is a
+ * programming error and throws rather than silently searching a nonsense
+ * age.
  */
 export function filingAgeRange(
   recipient: Recipient,
-  currentDate: MonthDate
+  currentDate: MonthDate,
+  filedAt: MonthDate | null = null
 ): FilingAgeRange {
+  if (filedAt !== null) {
+    const problem = validateFiledMonth(
+      recipient.birthdate,
+      filedAt,
+      currentDate
+    );
+    if (problem !== null) {
+      throw new Error(`invalid filed month: ${problem}`);
+    }
+    const filedAge = recipient.birthdate.ageAtSsaDate(filedAt);
+    return {
+      earliest: filedAge,
+      latest: new MonthDuration(filedAge.asMonths()),
+      hasChoice: false,
+    };
+  }
+
   const earliest = earliestFiling(recipient, currentDate);
   const hasChoice = earliest.lessThan(MAX_FILING_AGE);
   return {
@@ -805,6 +835,9 @@ function clampZeroPiaDepStrategy(
  * @param {MonthDate} currentDate - Today's date.
  * @param {number} discountRate - Rate used for present value calculation. 0
  *                                means no discount.
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
+ *                       or null. A filed recipient is searched at that single
+ *                       age.
  * @returns {[MonthDuration, MonthDuration]} An array containing the optimal
  *                                           filing ages for each recipient.
  */
@@ -812,7 +845,8 @@ export function optimalStrategyCouple(
   recipients: [Recipient, Recipient],
   finalDates: [MonthDate, MonthDate],
   currentDate: MonthDate,
-  discountRate: number
+  discountRate: number,
+  alreadyFiled: AlreadyFiled = NOT_FILED
 ): [MonthDuration, MonthDuration, number] {
   let bestStrategy: [MonthDuration, MonthDuration, number] = [
     new MonthDuration(0),
@@ -820,8 +854,8 @@ export function optimalStrategyCouple(
     -1,
   ];
 
-  const range0 = filingAgeRange(recipients[0], currentDate);
-  const range1 = filingAgeRange(recipients[1], currentDate);
+  const range0 = filingAgeRange(recipients[0], currentDate, alreadyFiled[0]);
+  const range1 = filingAgeRange(recipients[1], currentDate, alreadyFiled[1]);
   const startFilingDate0: number = range0.earliest.asMonths();
   const startFilingDate1: number = range1.earliest.asMonths();
   const endFilingAge0: number = range0.latest.asMonths();
@@ -863,6 +897,9 @@ export function optimalStrategyCouple(
  * @param {MonthDate} currentDate - Today's date.
  * @param {number} discountRate - Rate used for present value calculation. 0
  *                                means no discount.
+ * @param {AlreadyFiled} alreadyFiled - Per recipient, the month benefits actually started,
+ *                       or null. A filed recipient is searched at that single
+ *                       age.
  * @returns {[MonthDuration, MonthDuration]} An array containing the optimal
  *                                           filing ages for each recipient.
  */
@@ -870,7 +907,8 @@ export function optimalStrategyCoupleOptimized(
   recipients: [Recipient, Recipient],
   finalDates: [MonthDate, MonthDate],
   currentDate: MonthDate,
-  discountRate: number
+  discountRate: number,
+  alreadyFiled: AlreadyFiled = NOT_FILED
 ): [MonthDuration, MonthDuration, number] {
   let bestStrategy: [MonthDuration, MonthDuration, number] = [
     new MonthDuration(0),
@@ -889,14 +927,10 @@ export function optimalStrategyCoupleOptimized(
     monthlyDiscountRate
   );
 
-  const startFilingDate0: number = earliestFiling(
-    recipients[0],
-    currentDate
-  ).asMonths();
-  const startFilingDate1: number = earliestFiling(
-    recipients[1],
-    currentDate
-  ).asMonths();
+  const range0 = filingAgeRange(recipients[0], currentDate, alreadyFiled[0]);
+  const range1 = filingAgeRange(recipients[1], currentDate, alreadyFiled[1]);
+  const startFilingDate0: number = range0.earliest.asMonths();
+  const startFilingDate1: number = range1.earliest.asMonths();
 
   // Pre-compute final loop bounds to avoid expensive calculations in loops.
   // filingAgeRange, not a literal 70: a recipient past 70 has a single
@@ -906,14 +940,14 @@ export function optimalStrategyCoupleOptimized(
   const endFilingAge0: number = Math.max(
     startFilingDate0,
     Math.min(
-      filingAgeRange(recipients[0], currentDate).latest.asMonths(),
+      range0.latest.asMonths(),
       recipients[0].birthdate.ageAtSsaDate(finalDates[0]).asMonths()
     )
   );
   const endFilingAge1: number = Math.max(
     startFilingDate1,
     Math.min(
-      filingAgeRange(recipients[1], currentDate).latest.asMonths(),
+      range1.latest.asMonths(),
       recipients[1].birthdate.ageAtSsaDate(finalDates[1]).asMonths()
     )
   );

--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -56,8 +56,8 @@ export class UrlParams {
   }
 
   /**
-   * Parses a `YYYY-MM` month. The format is fixed-width and regular, so a
-   * pattern is an exact parser for it. Anything else yields null.
+   * Parses a `YYYY-MM` month. The pattern captures the fixed-width shape;
+   * the month range is checked separately. Anything else yields null.
    */
   private static parseMonthOrNull(value: string | null): MonthDate | null {
     if (!value) return null;

--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -12,6 +12,8 @@
  * server-side processing and maintain client-side privacy.
  */
 
+import { MonthDate } from '$lib/month-time';
+
 export type Gender = 'male' | 'female' | 'blended';
 
 /**
@@ -51,6 +53,20 @@ export class UrlParams {
     if (!value) return null;
     const parsed = parseInt(value, 10);
     return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  /**
+   * Parses a `YYYY-MM` month. The format is fixed-width and regular, so a
+   * pattern is an exact parser for it. Anything else yields null.
+   */
+  private static parseMonthOrNull(value: string | null): MonthDate | null {
+    if (!value) return null;
+    const match = value.match(/^(\d{4})-(\d{2})$/);
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    if (month < 1 || month > 12) return null;
+    return MonthDate.initFromYearsMonths({ years: year, months: month - 1 });
   }
 
   /**
@@ -276,6 +292,19 @@ export class UrlParams {
     return UrlParams.parseGender(this.params.get('gender2'));
   }
 
+  /**
+   * Month recipient (person 1) started benefits, or null when absent or
+   * malformed. Format: YYYY-MM. Example: #filed1=2024-03
+   */
+  getRecipientFiledMonth(): MonthDate | null {
+    return UrlParams.parseMonthOrNull(this.params.get('filed1'));
+  }
+
+  /** Month spouse (person 2) started benefits, or null. Example: #filed2=2025-11 */
+  getSpouseFiledMonth(): MonthDate | null {
+    return UrlParams.parseMonthOrNull(this.params.get('filed2'));
+  }
+
   private static parseGender(value: string | null): Gender {
     if (value === 'male' || value === 'female' || value === 'blended') {
       return value;
@@ -292,29 +321,39 @@ export class UrlParams {
   }
 }
 
+/** Formats a month as `YYYY-MM` for the share URL. */
+export function formatFiledMonth(date: MonthDate): string {
+  return `${date.year()}-${String(date.monthIndex() + 1).padStart(2, '0')}`;
+}
+
 export interface StrategyHashParams {
   isSingle: boolean;
   pia1: number;
   dob1: string;
   name1?: string;
   gender1?: Gender;
+  filed1?: MonthDate | null;
   pia2?: number;
   dob2?: string;
   name2?: string;
   gender2?: Gender;
+  filed2?: MonthDate | null;
 }
 
-// Omits gender params when blended (the default) to keep URLs short.
+// Omits gender params when blended (the default) to keep URLs short. Filed
+// months are couple-only: single mode never offers the input.
 export function buildStrategyHash(p: StrategyHashParams): string {
   const parts: string[] = [`pia1=${Math.round(p.pia1)}`, `dob1=${p.dob1}`];
   if (p.name1) parts.push(`name1=${encodeURIComponent(p.name1)}`);
   if (p.gender1 && p.gender1 !== 'blended') parts.push(`gender1=${p.gender1}`);
 
   if (!p.isSingle && p.pia2 !== undefined && p.dob2) {
+    if (p.filed1) parts.push(`filed1=${formatFiledMonth(p.filed1)}`);
     parts.push(`pia2=${Math.round(p.pia2)}`, `dob2=${p.dob2}`);
     if (p.name2) parts.push(`name2=${encodeURIComponent(p.name2)}`);
     if (p.gender2 && p.gender2 !== 'blended')
       parts.push(`gender2=${p.gender2}`);
+    if (p.filed2) parts.push(`filed2=${formatFiledMonth(p.filed2)}`);
   }
 
   return `#${parts.join('&')}`;

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -8,6 +8,11 @@
   import { Money } from "$lib/money";
   import { MonthDate } from "$lib/month-time";
   import { Recipient } from "$lib/recipient";
+  import {
+    type AlreadyFiled,
+    isEligibleToHaveFiled,
+    NOT_FILED,
+  } from "$lib/strategy/calculations/already-filed";
   import { optimalStrategyCoupleFast } from "$lib/strategy/calculations/optimal-strategy-fast";
   import {
     earliestModelableDeathAge,
@@ -155,6 +160,10 @@
   let isSingle: boolean = false;
   let birthdateInputs: [string, string] = ["", ""];
   let piaValues: [number | null, number | null] = [null, null];
+  // Per recipient, the month benefits actually started, or null. Couple mode
+  // only. Kept with the other form inputs rather than on Recipient: the
+  // calculator's filing-date stores mean "what if", this means "what happened".
+  let alreadyFiled: [MonthDate | null, MonthDate | null] = [null, null];
   let discountRatePercent: number = 2.5;
 
   let recipientInputsValid = false;
@@ -305,6 +314,19 @@
           recipients[1].birthdate = bd2;
           if (params.getSpouseName()) recipients[1].name = params.getSpouseName()!;
           recipients[1].gender = params.getSpouseGender();
+          // The form re-validates a restored month only for someone old
+          // enough to show the control. A hand-edited link can mark an
+          // under-62 person as filed; drop that here so it never reaches the
+          // optimizer, which refuses it.
+          const restoredNow = currentMonthDate();
+          const restored = [
+            params.getRecipientFiledMonth(),
+            params.getSpouseFiledMonth(),
+          ];
+          alreadyFiled = [
+            isEligibleToHaveFiled(bd1, restoredNow) ? restored[0] : null,
+            isEligibleToHaveFiled(bd2, restoredNow) ? restored[1] : null,
+          ];
         }
       }
 
@@ -335,14 +357,24 @@
   // live form state would let it flip a card to "File now" while the figures
   // beside it still belong to the previous birthdate.
   let hasFilingChoice: [boolean, boolean] = [true, true];
+  // The filed months the current results were computed with; see
+  // hasFilingChoice for why this is not derived reactively from the form.
+  let resultsAlreadyFiled: AlreadyFiled = NOT_FILED;
   $: discountRate = discountRatePercent / 100;
-  $: shareUrl = buildShareUrl(recipients, isSingle, piaValues, birthdateInputs);
+  $: shareUrl = buildShareUrl(
+    recipients,
+    isSingle,
+    piaValues,
+    birthdateInputs,
+    alreadyFiled
+  );
 
   function buildShareUrl(
     rs: [typeof recipients[0], typeof recipients[1]],
     single: boolean,
     pias: [number | null, number | null],
-    dobs: [string, string]
+    dobs: [string, string],
+    filed: [MonthDate | null, MonthDate | null]
   ): string {
     if (!dobs[0] || pias[0] === null) return "";
     const hash = buildStrategyHash({
@@ -351,6 +383,7 @@
       dob1: dobs[0],
       name1: rs[0].name && rs[0].name !== "Self" ? rs[0].name : undefined,
       gender1: rs[0].gender,
+      filed1: filed[0],
       ...(
         !single && pias[1] !== null && dobs[1]
           ? {
@@ -358,6 +391,7 @@
               dob2: dobs[1],
               name2: rs[1].name && rs[1].name !== "Spouse" ? rs[1].name : undefined,
               gender2: rs[1].gender,
+              filed2: filed[1],
             }
           : {}
       ),
@@ -538,6 +572,7 @@
     const prevHealth = snapshotHealthMultipliers();
     birthdateInputs = ["", ""];
     piaValues = [null, null];
+    alreadyFiled = [null, null];
     recipients = initializeRecipients();
     recipients[0].healthMultiplier = prevHealth[0];
     recipients[1].healthMultiplier = prevHealth[1];
@@ -564,6 +599,11 @@
       next.beginRun();
 
       const currentDate = currentMonthDate();
+      // Snapshot: single mode never has a filed spouse, and the results must
+      // describe one set of inputs even if the form changes mid-run.
+      const filedSnapshot: AlreadyFiled = isSingle
+        ? NOT_FILED
+        : [alreadyFiled[0], alreadyFiled[1]];
       // Computed here but assigned only once the run has fully succeeded,
       // together with the results it describes. If a loop below throws, the
       // store keeps the previous results, and this flag must keep describing
@@ -571,7 +611,8 @@
       const nextFilingChoice = filingChoices(
         recipients[0],
         isSingle ? null : recipients[1],
-        currentDate
+        currentDate,
+        filedSnapshot
       );
 
       if (isSingle) {
@@ -614,7 +655,8 @@
                 recipients,
                 finalDates,
                 currentDate,
-                discountRate
+                discountRate,
+                filedSnapshot
               );
 
             next.set(i, j, {
@@ -651,7 +693,8 @@
           recipients,
           currentDate,
           discountRate,
-          [deathProbDistribution1, deathProbDistribution2]
+          [deathProbDistribution1, deathProbDistribution2],
+          filedSnapshot
         );
         nextCoupleResult =
           coupleResults.length > 0 ? coupleResults[0] : undefined;
@@ -665,6 +708,7 @@
       // headline, the grids and the flag that re-skins them always describe
       // the same run.
       hasFilingChoice = nextFilingChoice;
+      resultsAlreadyFiled = filedSnapshot;
       optimalSingleResult = nextSingleResult;
       optimalCoupleResult = nextCoupleResult;
       calculationResultsStore.set(next);
@@ -786,6 +830,7 @@
           {isSingle}
           bind:piaValues
           bind:birthdateInputs
+          bind:alreadyFiled
           continueDisabled={!formIsValid}
           errorMessage={formErrorMessage}
           onUpdate={handleRecipientUpdate}
@@ -850,6 +895,8 @@
               {recipients}
               {hasFilingChoice}
               currentDate={currentMonthDate()}
+              alreadyFiled={resultsAlreadyFiled}
+              onAlreadyFiledHint={isSingle ? undefined : handleEdit}
             />
             <AdvisorPrompt />
           </div>
@@ -877,6 +924,7 @@
               {deathProbDistribution1}
               {deathProbDistribution2}
               {hasFilingChoice}
+              alreadyFiled={resultsAlreadyFiled}
               bind:displayAsAges
               onselectcell={handleCellSelect}
             />
@@ -898,6 +946,7 @@
             {recipients}
             result={calculationResults.getSelectedCellData()}
             {discountRate}
+            alreadyFiled={resultsAlreadyFiled}
             bind:displayAsAges
             onBack={handleBackToMatrix}
           />

--- a/src/routes/strategy/+page.svelte
+++ b/src/routes/strategy/+page.svelte
@@ -10,6 +10,7 @@
   import { Recipient } from "$lib/recipient";
   import {
     type AlreadyFiled,
+    type AlreadyFiledInput,
     isEligibleToHaveFiled,
     NOT_FILED,
   } from "$lib/strategy/calculations/already-filed";
@@ -163,7 +164,7 @@
   // Per recipient, the month benefits actually started, or null. Couple mode
   // only. Kept with the other form inputs rather than on Recipient: the
   // calculator's filing-date stores mean "what if", this means "what happened".
-  let alreadyFiled: [MonthDate | null, MonthDate | null] = [null, null];
+  let alreadyFiled: AlreadyFiledInput = [null, null];
   let discountRatePercent: number = 2.5;
 
   let recipientInputsValid = false;
@@ -317,7 +318,9 @@
           // The form re-validates a restored month only for someone old
           // enough to show the control. A hand-edited link can mark an
           // under-62 person as filed; drop that here so it never reaches the
-          // optimizer, which refuses it.
+          // optimizer, which refuses it. Restore always lands on the form
+          // stage, where FiledMonthInput re-validates the month on mount;
+          // that is what completes validation before any calculation runs.
           const restoredNow = currentMonthDate();
           const restored = [
             params.getRecipientFiledMonth(),
@@ -350,7 +353,8 @@
 
   $: formIsValid = recipientInputsValid && discountRateValid;
 
-  // A recipient with no filing choice left has only one option: file now.
+  // A recipient with no filing choice left, because they are past 70 or have
+  // already filed, has nothing to decide.
   // The headline and the grids need to know so they do not present that as a
   // decision. Assigned inside calculateStrategyMatrix from the same
   // currentDate as the results it describes — deriving it reactively from

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -38,16 +38,21 @@
   const currentDate: MonthDate = MonthDate.initFromNow();
 
   // One axis collapses to a single filing age when that recipient has already
-  // filed. At the normal cell size a lone row or column is illegible, and the
-  // axis labels, which span the cell tracks, have nowhere to go. That case
-  // gets larger cells, drops the in-grid axis labels (their tracks go to
-  // zero), and says in a note above the grid which axis varies. The two-axis
-  // layout is untouched.
+  // filed, or is past 70 or dies before 70 (see createFilingAgeRange); this
+  // keys on the range length, not on the reason for it. At the normal cell
+  // size a lone row or column is illegible, and the axis labels, which span
+  // the cell tracks, have nowhere to go. That case gets larger cells, drops
+  // the in-grid axis labels (their tracks go to zero), and says in a note
+  // above the grid which axis varies. The two-axis layout is untouched.
   const CELL_PX = 8;
   const COLLAPSED_CELL_PX = 16;
   const AXIS_LABEL_PX = 20;
 
-  /** Index of the recipient whose axis is a single row or column, if any. */
+  /**
+   * Index of the recipient whose axis is a single row or column, if any.
+   * Only called when at least one axis has more than one entry: no grid is
+   * drawn when neither person has a choice.
+   */
   function collapsedAxisOf(
     range1Length: number,
     range2Length: number
@@ -428,8 +433,6 @@
             ? "Age"
             : "Date"}
         </div>
-      {/if}
-      {#if collapsedAxis === null}
         <div
           class="recipient-header recipient-header-row"
           style:grid-column="1"

--- a/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
+++ b/src/routes/strategy/components/AlternativeStrategiesGrid.svelte
@@ -4,6 +4,10 @@
   import { MonthDurationRange } from "$lib/month-duration-range";
   import { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
+  import {
+    type AlreadyFiled,
+    NOT_FILED,
+  } from "$lib/strategy/calculations/already-filed";
   import { strategySumCentsCouple } from "$lib/strategy/calculations/strategy-calc";
 
   export let recipients: [Recipient, Recipient];
@@ -13,6 +17,11 @@
   export let optimalNPV: Money;
   export let optimalFilingAges: [MonthDuration, MonthDuration];
   export let displayAsAges: boolean = false;
+  /**
+   * Per recipient, the month benefits started, or null. A filed recipient's
+   * axis collapses to their actual filing age.
+   */
+  export let alreadyFiled: AlreadyFiled = NOT_FILED;
 
   interface AlternativeResult {
     filingAge1: MonthDuration;
@@ -28,6 +37,26 @@
   let isCalculating: boolean = false;
   const currentDate: MonthDate = MonthDate.initFromNow();
 
+  // One axis collapses to a single filing age when that recipient has already
+  // filed. At the normal cell size a lone row or column is illegible, and the
+  // axis labels, which span the cell tracks, have nowhere to go. That case
+  // gets larger cells, drops the in-grid axis labels (their tracks go to
+  // zero), and says in a note above the grid which axis varies. The two-axis
+  // layout is untouched.
+  const CELL_PX = 8;
+  const COLLAPSED_CELL_PX = 16;
+  const AXIS_LABEL_PX = 20;
+
+  /** Index of the recipient whose axis is a single row or column, if any. */
+  function collapsedAxisOf(
+    range1Length: number,
+    range2Length: number
+  ): 0 | 1 | null {
+    if (range1Length === 1) return 0;
+    if (range2Length === 1) return 1;
+    return null;
+  }
+
   let hoveredRowIndex: number = -1;
   let hoveredColIndex: number = -1;
   let hoveredResult: AlternativeResult | null = null;
@@ -39,8 +68,15 @@
 
   function createFilingAgeRange(
     recipient: Recipient,
-    deathAge: MonthDuration
+    deathAge: MonthDuration,
+    filedAt: MonthDate | null
   ): MonthDurationRange {
+    // Already filed: the only "alternative" is what happened. One instance
+    // serves as both bounds; MonthDurationRange only reads them.
+    if (filedAt !== null) {
+      const filedAge = recipient.birthdate.ageAtSsaDate(filedAt);
+      return new MonthDurationRange(filedAge, filedAge);
+    }
     const currentAge = recipient.birthdate.ageAtSsaDate(currentDate);
     const earliestFiling = recipient.birthdate.earliestFilingMonth();
     const startingAge = currentAge.greaterThan(earliestFiling)
@@ -124,8 +160,16 @@
     isCalculating = true;
 
     try {
-      filingAgeRange1 = createFilingAgeRange(recipients[0], deathAge1);
-      filingAgeRange2 = createFilingAgeRange(recipients[1], deathAge2);
+      filingAgeRange1 = createFilingAgeRange(
+        recipients[0],
+        deathAge1,
+        alreadyFiled[0]
+      );
+      filingAgeRange2 = createFilingAgeRange(
+        recipients[1],
+        deathAge2,
+        alreadyFiled[1]
+      );
 
       const finalDates: [MonthDate, MonthDate] = [
         recipients[0].birthdate.dateAtLayAge(deathAge1),
@@ -301,6 +345,9 @@
       : generateDateHeaders(filingAgeRange2Array, recipients[1])}
     {@const range1Length = filingAgeRange1.getLength()}
     {@const range2Length = filingAgeRange2.getLength()}
+    {@const collapsedAxis = collapsedAxisOf(range1Length, range2Length)}
+    {@const cellPx = collapsedAxis === null ? CELL_PX : COLLAPSED_CELL_PX}
+    {@const axisLabelPx = collapsedAxis === null ? AXIS_LABEL_PX : 0}
 
     <div class="info-panel" class:is-pinned={isPinned}>
       <div class="info-panel-header">
@@ -346,10 +393,22 @@
       {/if}
     </div>
 
+    {#if collapsedAxis !== null}
+      {@const filedAt = alreadyFiled[collapsedAxis]}
+      <p class="collapsed-note">
+        <RecipientName r={recipients[collapsedAxis]} apos /> filing date is
+        fixed{filedAt
+          ? ` at ${filedAt.monthFullName()} ${filedAt.year()}`
+          : ""}; each cell varies
+        <RecipientName r={recipients[collapsedAxis === 0 ? 1 : 0]} apos />
+        filing {displayAsAges ? "age" : "date"}.
+      </p>
+    {/if}
+
     <div
       class="grid-wrapper"
-      style:grid-template-columns="20px 25px repeat({range2Length}, 8px)"
-      style:grid-template-rows="20px 20px repeat({range1Length}, 8px)"
+      style:grid-template-columns="{axisLabelPx}px 25px repeat({range2Length}, {cellPx}px)"
+      style:grid-template-rows="{axisLabelPx}px 20px repeat({range1Length}, {cellPx}px)"
       on:mouseleave={handleGridMouseLeave}
       role="grid"
       tabindex="0"
@@ -359,26 +418,30 @@
       <div class="corner-cell" style:grid-column="1" style:grid-row="2"></div>
       <div class="corner-cell" style:grid-column="2" style:grid-row="2"></div>
 
-      <div
-        class="recipient-header recipient-header-column"
-        style:grid-column="3 / {range2Length + 3}"
-        style:grid-row="1"
-      >
-        <RecipientName r={recipients[1]} apos />&nbsp;Filing {displayAsAges
-          ? "Age"
-          : "Date"}
-      </div>
-      <div
-        class="recipient-header recipient-header-row"
-        style:grid-column="1"
-        style:grid-row="3 / {range1Length + 3}"
-      >
-        <span class="recipient-text"
-          ><RecipientName r={recipients[0]} apos /> Filing {displayAsAges
-            ? "Age"
-            : "Date"}</span
+      {#if collapsedAxis === null}
+        <div
+          class="recipient-header recipient-header-column"
+          style:grid-column="3 / {range2Length + 3}"
+          style:grid-row="1"
         >
-      </div>
+          <RecipientName r={recipients[1]} apos />&nbsp;Filing {displayAsAges
+            ? "Age"
+            : "Date"}
+        </div>
+      {/if}
+      {#if collapsedAxis === null}
+        <div
+          class="recipient-header recipient-header-row"
+          style:grid-column="1"
+          style:grid-row="3 / {range1Length + 3}"
+        >
+          <span class="recipient-text"
+            ><RecipientName r={recipients[0]} apos /> Filing {displayAsAges
+              ? "Age"
+              : "Date"}</span
+          >
+        </div>
+      {/if}
 
       {#each yearHeaders2 as yearHeader, headerIndex}
         {@const colOffset = 3}
@@ -664,6 +727,13 @@
     font-weight: bold;
     font-size: 0.8rem;
     color: #333;
+  }
+
+  .collapsed-note {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #4b5563;
+    line-height: 1.5;
   }
 
   .recipient-header-row {

--- a/src/routes/strategy/components/FiledMonthInput.svelte
+++ b/src/routes/strategy/components/FiledMonthInput.svelte
@@ -171,7 +171,7 @@
         />
       </div>
       {#if error}
-        <span class="error-message" id={errorId}>{error}</span>
+        <span class="error-message" id={errorId} role="alert">{error}</span>
       {/if}
     </fieldset>
   {/if}

--- a/src/routes/strategy/components/FiledMonthInput.svelte
+++ b/src/routes/strategy/components/FiledMonthInput.svelte
@@ -1,0 +1,293 @@
+<!--
+  @component
+  @name FiledMonthInput
+  @description
+    The "already receives benefits" control for one recipient: a checkbox
+    that reveals a month select and a year input for the month benefits
+    started. Publishes a validated MonthDate (or null) through `bind:value`,
+    and reports through `onvaliditychange` whether the answer is complete,
+    so the parent can hold Continue while the box is ticked with no valid
+    month. The parent renders this only for someone old enough to have filed.
+-->
+
+<script lang="ts">
+  import type { Birthdate } from "$lib/birthday";
+  import InfoTip from "$lib/components/InfoTip.svelte";
+  import RecipientName from "$lib/components/RecipientName.svelte";
+  import { ALL_MONTHS_FULL } from "$lib/constants";
+  import { MonthDate } from "$lib/month-time";
+  import type { Recipient } from "$lib/recipient";
+  import {
+    earliestFilingDate,
+    validateFiledMonth,
+  } from "$lib/strategy/calculations/already-filed";
+  import { onMount } from "svelte";
+
+  /** Whose benefits these are; names the checkbox label. */
+  export let recipient: Recipient;
+  /** Non-null: the parent only renders this control for an eligible person. */
+  export let birthdate: Birthdate;
+  /** The month the form is being filled in; a filed month cannot be later. */
+  export let currentDate: MonthDate;
+  /** Prefix for the element ids, so two instances on a page stay distinct. */
+  export let inputId: string;
+  /** Bounds for the year field; shared with the birthdate field's check. */
+  export let yearRange: { min: number; max: number };
+  /** The validated filed month, or null when unticked, incomplete, or invalid. */
+  export let value: MonthDate | null = null;
+  /** Fires on any change, so the parent can refresh derived state. */
+  export let onchange: (() => void) | undefined = undefined;
+  /** False while the box is ticked but no valid month has been entered. */
+  export let onvaliditychange: ((isValid: boolean) => void) | undefined =
+    undefined;
+
+  let checked = false;
+  let monthIndex: number | null = null;
+  let year: number | null = null;
+  let error = "";
+
+  $: errorId = `${inputId}-error`;
+  $: yearMin = earliestFilingDate(birthdate).year();
+  $: onvaliditychange?.(!checked || (value !== null && error === ""));
+
+  // The birthdate can change while this stays mounted (an edit that keeps
+  // the person eligible). A filed month that the new birthdate rules out
+  // must not reach the optimizer, so re-validate and publish null with the
+  // error. Only `birthdate` is tracked here; the function reads the rest.
+  $: revalidateForBirthdate(birthdate);
+
+  function revalidateForBirthdate(_birthdate: Birthdate) {
+    if (checked) sync();
+  }
+
+  // Seed from the bound value. This covers a restored share URL and the
+  // Edit button, which remounts the form with the values already entered.
+  // The value is re-validated rather than trusted: a hash can carry a month
+  // that parses but is out of range for the birthdate.
+  onMount(() => {
+    if (value === null) return;
+    checked = true;
+    monthIndex = value.monthIndex();
+    year = value.year();
+    sync();
+  });
+
+  function handleToggle(event: Event) {
+    checked = (event.target as HTMLInputElement).checked;
+    if (!checked) {
+      monthIndex = null;
+      year = null;
+    }
+    sync();
+  }
+
+  function handleMonthChange(event: Event) {
+    const raw = (event.target as HTMLSelectElement).value;
+    monthIndex = raw === "" ? null : Number(raw);
+    sync();
+  }
+
+  function handleYearChange(event: Event) {
+    const n = Number.parseInt((event.target as HTMLInputElement).value, 10);
+    year = Number.isNaN(n) ? null : n;
+    sync();
+  }
+
+  /**
+   * Recomputes the filed month from the inputs, validates it against the
+   * birthdate, and publishes it. An unticked, incomplete, or invalid entry
+   * publishes null so the parent never sees a month the calculation would
+   * reject.
+   */
+  function sync() {
+    if (!checked || monthIndex === null || year === null) {
+      error = "";
+      value = null;
+    } else if (year < yearRange.min || year > yearRange.max) {
+      error = "Enter a four-digit year";
+      value = null;
+    } else {
+      const filedAt = MonthDate.initFromYearsMonths({
+        years: year,
+        months: monthIndex,
+      });
+      const problem = validateFiledMonth(birthdate, filedAt, currentDate);
+      error = problem ?? "";
+      value = problem === null ? filedAt : null;
+    }
+    onchange?.();
+  }
+</script>
+
+<div class="filed-block reveal">
+  <label class="filed-check" for="{inputId}-check">
+    <input
+      id="{inputId}-check"
+      type="checkbox"
+      {checked}
+      on:change={handleToggle}
+    />
+    <span>
+      <RecipientName r={recipient} /> already receives benefits
+      <InfoTip label="Why we ask">
+        If benefits have already started, that filing date is fixed. We will
+        show it as a fact and optimize only the other person's filing date.
+      </InfoTip>
+    </span>
+  </label>
+  {#if checked}
+    <fieldset class="filed-when reveal">
+      <legend class="filed-when-label">Month benefits started</legend>
+      <div class="filed-when-inputs">
+        <select
+          id="{inputId}-month"
+          class="filed-select"
+          class:invalid={error !== ""}
+          aria-label="Month"
+          aria-invalid={error !== ""}
+          aria-describedby={error !== "" ? errorId : undefined}
+          value={monthIndex ?? ""}
+          on:change={handleMonthChange}
+        >
+          <option value="">Month</option>
+          {#each ALL_MONTHS_FULL as name, m}
+            <option value={m}>{name}</option>
+          {/each}
+        </select>
+        <input
+          id="{inputId}-year"
+          class="filed-year"
+          class:invalid={error !== ""}
+          type="number"
+          inputmode="numeric"
+          placeholder="Year"
+          aria-label="Year"
+          aria-invalid={error !== ""}
+          aria-describedby={error !== "" ? errorId : undefined}
+          min={yearMin}
+          max={currentDate.year()}
+          value={year ?? ""}
+          on:input={handleYearChange}
+        />
+      </div>
+      {#if error}
+        <span class="error-message" id={errorId}>{error}</span>
+      {/if}
+    </fieldset>
+  {/if}
+</div>
+
+<style>
+  .filed-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+  .filed-check {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #1f2937;
+    cursor: pointer;
+  }
+  .filed-check input {
+    margin-top: 0.2rem;
+    flex: 0 0 auto;
+  }
+  /* A fieldset for the accessibility grouping only; its default border and
+     padding would break the indented layout. */
+  .filed-when {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin: 0 0 0 1.6rem;
+    padding: 0 0 0 0.75rem;
+    border: none;
+    border-left: 2px solid #d8dbe6;
+    min-width: 0;
+  }
+  .filed-when-label {
+    padding: 0;
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #1f2937;
+  }
+  .filed-when-inputs {
+    display: flex;
+    gap: 0.5rem;
+  }
+  /* Both controls match the PIA field's box so the form reads as one set of
+     inputs. */
+  .filed-select,
+  .filed-year {
+    font-size: 1rem;
+    line-height: 1.4;
+    padding: 0.65rem 0.85rem;
+    border: 1.5px solid #d1d5db;
+    border-radius: 6px;
+    background-color: white;
+    color: #0b0c0c;
+    font-family: inherit;
+    appearance: none;
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+  }
+  .filed-select {
+    flex: 1 1 auto;
+    min-width: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23374151' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 32px;
+  }
+  .filed-year {
+    flex: 0 0 6rem;
+    width: 6rem;
+  }
+  .filed-select:focus,
+  .filed-year:focus {
+    outline: none;
+    border-color: #081d88;
+    box-shadow: 0 0 0 3px rgba(8, 29, 136, 0.15);
+  }
+  .filed-select.invalid,
+  .filed-year.invalid {
+    border-color: #d4351c;
+    background-color: #fef5f5;
+  }
+  .filed-select.invalid:focus,
+  .filed-year.invalid:focus {
+    box-shadow: 0 0 0 3px rgba(212, 53, 28, 0.15);
+  }
+  .error-message {
+    color: #d4351c;
+    font-size: 0.85rem;
+    margin-top: 0.15rem;
+  }
+
+  /* Draws the eye whenever the control appears: when a birthdate first makes
+     the person eligible, when the box is ticked, and when the form remounts
+     via Edit. A re-render while it stays mounted does not replay it. */
+  .reveal {
+    animation: filed-reveal 320ms ease-out both;
+  }
+  @keyframes filed-reveal {
+    from {
+      opacity: 0;
+      transform: translateY(-6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .reveal {
+      animation: none;
+    }
+  }
+</style>

--- a/src/routes/strategy/components/NoFilingDecisionPanel.svelte
+++ b/src/routes/strategy/components/NoFilingDecisionPanel.svelte
@@ -3,37 +3,71 @@
   @name NoFilingDecisionPanel
   @description
     Shown in place of the death-age chart when nobody in the scenario has a
-    filing age left to choose. Past 70 there is no lifespan trade-off left to
-    draw: delayed retirement credits have stopped, so the chart would be a
-    single repeated value.
+    filing age left to choose, either because they are past 70 (delayed
+    retirement credits have stopped, so the chart would be a single repeated
+    value) or because they have already filed (the date is a fact).
 -->
 
 <script lang="ts">
-export let bothPastSeventy: boolean = false;
+/**
+ * Why nobody in the scenario has a filing age left to choose. Each
+ * variant gets copy that names the actual reason.
+ */
+export let variant:
+  | "past-seventy"
+  | "both-past-seventy"
+  | "both-filed"
+  | "filed-and-past-seventy" = "past-seventy";
 </script>
 
 <div class="no-decision-note">
   <h2>There is no filing age left to choose</h2>
-  {#if bothPastSeventy}
+  {#if variant === "both-filed"}
+    <p>
+      These charts normally show how the best filing ages shift with how long
+      each of you lives. You are both already receiving benefits, so those
+      dates are settled and there is nothing left to optimize here. The
+      expected lifetime benefit above is the value of what is still to come.
+    </p>
+  {:else if variant === "filed-and-past-seventy"}
+    <p>
+      These charts normally show how the best filing ages shift with how long
+      each of you lives. One of you already receives benefits, and the other
+      is past 70, where delayed retirement credits stop accruing. Waiting
+      longer no longer raises that monthly amount. It only skips payments that
+      could already be collected.
+    </p>
+    <p>
+      Whoever has not yet filed should file as soon as possible and ask SSA
+      to backdate the claim. Once past full retirement age, SSA can pay up to
+      six months of benefits retroactively.
+    </p>
+  {:else if variant === "both-past-seventy"}
     <p>
       These charts normally show how the best filing ages shift with how long
       each of you lives. You are both past 70, so that trade-off is settled:
       delayed retirement credits stop accruing at 70, so waiting longer no
-      longer raises either monthly amount — it only skips payments you could
+      longer raises either monthly amount. It only skips payments you could
       already be collecting.
+    </p>
+    <p>
+      File as soon as you can, and ask SSA to backdate the claim. Once past
+      full retirement age they can pay up to six months of benefits
+      retroactively.
     </p>
   {:else}
     <p>
       This chart normally shows how the best filing age shifts with how long
       you live. Past 70 that trade-off is settled: delayed retirement credits
       stop accruing at 70, so waiting longer no longer raises the monthly
-      amount — it only skips payments you could already be collecting.
+      amount. It only skips payments you could already be collecting.
+    </p>
+    <p>
+      File as soon as you can, and ask SSA to backdate the claim. Once past
+      full retirement age they can pay up to six months of benefits
+      retroactively.
     </p>
   {/if}
-  <p>
-    File as soon as you can, and ask SSA to backdate the claim. Once past full
-    retirement age they can pay up to six months of benefits retroactively.
-  </p>
 </div>
 
 <style>

--- a/src/routes/strategy/components/RecipientInputs.svelte
+++ b/src/routes/strategy/components/RecipientInputs.svelte
@@ -3,9 +3,16 @@
   import BirthdateInput from "$lib/components/BirthdateInput.svelte";
   import InfoTip from "$lib/components/InfoTip.svelte";
   import RecipientName from "$lib/components/RecipientName.svelte";
+  import { currentMonthDate } from "$lib/components/recommended-filing-card";
   import { Money } from "$lib/money";
+  import type { MonthDate } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
+  import { isEligibleToHaveFiled } from "$lib/strategy/calculations/already-filed";
   import { onMount } from "svelte";
+  import FiledMonthInput from "./FiledMonthInput.svelte";
+
+  /** Bounds for any four-digit year typed into this form. */
+  const YEAR_INPUT_RANGE = { min: 1900, max: 2100 };
 
   export let recipients: [Recipient, Recipient];
   export let piaValues: [number | null, number | null];
@@ -13,6 +20,11 @@
   export let isSingle: boolean = false;
   export let continueDisabled: boolean = true;
   export let errorMessage: string | null = null;
+  /**
+   * Per recipient, the month benefits actually started, or null. Couple mode
+   * only; the control never renders in single mode.
+   */
+  export let alreadyFiled: [MonthDate | null, MonthDate | null] = [null, null];
 
   export let onUpdate: (() => void) | undefined = undefined;
   export let onValidityChange: ((isValid: boolean) => void) | undefined =
@@ -26,12 +38,21 @@
   let piaValidity: boolean[] = [false, false];
   let piaErrors: string[] = ["", ""];
 
+  const currentDate = currentMonthDate();
+
+  // Per recipient, whether the "already receives benefits" answer is
+  // complete. Reported by FiledMonthInput: false while its box is ticked with
+  // no valid month, which blocks Continue the same way an empty PIA does.
+  let filedValid: [boolean, boolean] = [true, true];
+
   $: isValid = isSingle
     ? birthdateValidity[0] && piaValidity[0]
     : birthdateValidity[0] &&
       birthdateValidity[1] &&
       piaValidity[0] &&
-      piaValidity[1];
+      piaValidity[1] &&
+      filedValid[0] &&
+      filedValid[1];
 
   $: onValidityChange?.(isValid);
 
@@ -46,8 +67,8 @@
       // out-of-range values (e.g. year < 1900), which would otherwise
       // surface as an unhandled exception inside onMount.
       if (
-        year >= 1900 &&
-        year <= 2100 &&
+        year >= YEAR_INPUT_RANGE.min &&
+        year <= YEAR_INPUT_RANGE.max &&
         month >= 1 &&
         month <= 12 &&
         day >= 1 &&
@@ -68,8 +89,23 @@
       birthdateInputs = [...birthdateInputs];
       recipients[index].birthdate = newBirthdate;
       recipients = [...recipients];
+      // A birthdate that makes the person too young to have filed unmounts
+      // their FiledMonthInput, so its last published value and validity must
+      // be reset here; nothing else will. An eligible birthdate change is
+      // handled by the child, which re-validates against its new prop.
+      if (!isEligibleToHaveFiled(newBirthdate, currentDate)) {
+        alreadyFiled[index] = null;
+        alreadyFiled = [...alreadyFiled];
+        filedValid[index] = true;
+        filedValid = [...filedValid];
+      }
       onUpdate?.();
     }
+  }
+
+  function handleFiledValidityChange(index: number, isValid: boolean) {
+    filedValid[index] = isValid;
+    filedValid = [...filedValid];
   }
 
   function handlePiaChange(index: number, value: number | null) {
@@ -173,6 +209,7 @@
   <div class="input-grid" class:single={isSingle}>
     {#each recipients as recipient, i}
       {#if !isSingle || i === 0}
+        {@const birthdate = birthdates[i]}
         <div class="recipient-column">
         {#if !isSingle}
           <div class="input-pair">
@@ -245,6 +282,23 @@
             inputId={`birthdate${i}`}
           />
         </div>
+        <!-- Directly under the birthdate, because the birthdate is what makes
+             it appear: only someone who is at least 62 this month could have
+             filed, so nobody younger ever sees the control. It also comes
+             before PIA so the PIA field can react to the answer. Couple mode
+             only. -->
+        {#if !isSingle && birthdate !== null && isEligibleToHaveFiled(birthdate, currentDate)}
+          <FiledMonthInput
+            {recipient}
+            {birthdate}
+            {currentDate}
+            inputId={`filed${i}`}
+            yearRange={YEAR_INPUT_RANGE}
+            bind:value={alreadyFiled[i]}
+            onchange={() => onUpdate?.()}
+            onvaliditychange={(isValid) => handleFiledValidityChange(i, isValid)}
+          />
+        {/if}
         <div class="input-group">
           <label for="pia{i}">
             <RecipientName r={recipient} apos>Your</RecipientName> Primary Insurance
@@ -267,6 +321,16 @@
           </div>
           {#if piaValues[i] !== null && !piaValidity[i] && piaErrors[i]}
             <span class="error-message">{piaErrors[i]}</span>
+          {/if}
+          {#if alreadyFiled[i] !== null || !filedValid[i]}
+            <!-- Someone already receiving benefits has a reduced or increased
+                 monthly check in hand, and that is the number they are most
+                 likely to type here. Shown as soon as the box is ticked, before
+                 the month is filled in, so it is read before the PIA is. -->
+            <p class="pia-note">
+              Enter the PIA from your Social Security statement, not the
+              monthly amount you receive.
+            </p>
           {/if}
           <a class="pia-helper" href="/calculator" tabindex="-1">
             <span>Don't know your PIA? Start here first</span>
@@ -457,6 +521,12 @@
   .input-group input.pia-input {
     width: 100%;
     padding-left: 1.75rem;
+  }
+  .pia-note {
+    margin: 0.35rem 0 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: #444;
   }
   .pia-helper {
     margin-top: 0.45rem;

--- a/src/routes/strategy/components/RecipientInputs.svelte
+++ b/src/routes/strategy/components/RecipientInputs.svelte
@@ -5,9 +5,11 @@
   import RecipientName from "$lib/components/RecipientName.svelte";
   import { currentMonthDate } from "$lib/components/recommended-filing-card";
   import { Money } from "$lib/money";
-  import type { MonthDate } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
-  import { isEligibleToHaveFiled } from "$lib/strategy/calculations/already-filed";
+  import {
+    type AlreadyFiledInput,
+    isEligibleToHaveFiled,
+  } from "$lib/strategy/calculations/already-filed";
   import { onMount } from "svelte";
   import FiledMonthInput from "./FiledMonthInput.svelte";
 
@@ -24,7 +26,7 @@
    * Per recipient, the month benefits actually started, or null. Couple mode
    * only; the control never renders in single mode.
    */
-  export let alreadyFiled: [MonthDate | null, MonthDate | null] = [null, null];
+  export let alreadyFiled: AlreadyFiledInput = [null, null];
 
   export let onUpdate: (() => void) | undefined = undefined;
   export let onValidityChange: ((isValid: boolean) => void) | undefined =

--- a/src/routes/strategy/components/ScenarioDetail.svelte
+++ b/src/routes/strategy/components/ScenarioDetail.svelte
@@ -3,6 +3,10 @@
   import RecipientName from "$lib/components/RecipientName.svelte";
   import type { MonthDate, MonthDuration } from "$lib/month-time";
   import type { Recipient } from "$lib/recipient";
+  import {
+    type AlreadyFiled,
+    NOT_FILED,
+  } from "$lib/strategy/calculations/already-filed";
   import { BenefitType } from "$lib/strategy/calculations/benefit-period";
   import { strategySumPeriodsCouple } from "$lib/strategy/calculations/strategy-calc";
   import type { StrategyResult } from "$lib/strategy/ui";
@@ -13,6 +17,8 @@
   export let discountRate: number;
   export let displayAsAges: boolean = false;
   export let onBack: () => void;
+  /** Per recipient, the month benefits started, or null. */
+  export let alreadyFiled: AlreadyFiled = NOT_FILED;
 
   function formatProbability(prob: number | null | undefined): string {
     if (prob === null || prob === undefined) return "";
@@ -220,6 +226,7 @@
       optimalNPV={result.totalBenefit}
       optimalFilingAges={[result.filingAge1, result.filingAge2]}
       {displayAsAges}
+      {alreadyFiled}
     />
   </section>
 </div>

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+import type { ComponentProps } from 'svelte';
 import HowToReadChart from '$lib/components/HowToReadChart.svelte';
 import RecipientName from '$lib/components/RecipientName.svelte';
 import type { Recipient } from '$lib/recipient';
+import {
+  type AlreadyFiled,
+  NOT_FILED,
+} from '$lib/strategy/calculations/already-filed';
 import NoFilingDecisionPanel from './NoFilingDecisionPanel.svelte';
 import type {
   CalculationResults,
@@ -11,15 +16,22 @@ import type {
 import { CalculationStatus } from '$lib/strategy/ui';
 import StrategyMatrix from './StrategyMatrix.svelte';
 
+type NoChoiceVariant = NonNullable<
+  ComponentProps<NoFilingDecisionPanel>['variant']
+>;
+
 // Props
 export let recipients: [Recipient, Recipient];
 export let displayAsAges: boolean;
 /**
- * Per recipient: false once they are past 70. A recipient with no choice left
+ * Per recipient: false once they are past 70 or have already filed. A
+ * recipient with no choice left
  * has the same filing age in every cell, so their grid carries no
  * information and is not drawn at all.
  */
 export let hasFilingChoice: [boolean, boolean] = [true, true];
+/** Per recipient, the month benefits started, or null. Changes copy only. */
+export let alreadyFiled: AlreadyFiled = NOT_FILED;
 
 // Callback props for events
 export let onselectcell:
@@ -32,6 +44,18 @@ export let deathProbDistribution2: { age: number; probability: number }[];
 // Only recipients who still have a filing decision get a grid.
 $: gridIndexes = [0, 1].filter((i) => hasFilingChoice[i]);
 $: skippedIndex = [0, 1].find((i) => !hasFilingChoice[i]);
+
+// When nobody has a grid, name the actual reason. A single filed spouse can
+// only reach this state if the other is past 70.
+$: noChoiceVariant = noChoiceVariantFor(
+  alreadyFiled.filter((f) => f !== null).length
+);
+
+function noChoiceVariantFor(filedCount: number): NoChoiceVariant {
+  if (filedCount === 2) return 'both-filed';
+  if (filedCount === 1) return 'filed-and-past-seventy';
+  return 'both-past-seventy';
+}
 
 // Shared state for matrix hovering
 let hoveredCell: CellPosition | null = null;
@@ -48,7 +72,7 @@ function handleHoverCell(detail: CellPosition | null) {
          flash while a calculation is still running. -->
     {#if calculationResults.status() === CalculationStatus.Complete}
       <div class="result-content">
-        <NoFilingDecisionPanel bothPastSeventy={true} />
+        <NoFilingDecisionPanel variant={noChoiceVariant} />
       </div>
     {/if}
   {:else}
@@ -131,10 +155,16 @@ function handleHoverCell(detail: CellPosition | null) {
       {#if skippedIndex !== undefined}
         <div class="result-content">
           <p class="past-70-note">
-            <RecipientName r={recipients[skippedIndex]} /> is past 70, so there
-            is no grid for them: delayed retirement credits have stopped and
-            filing now is their only remaining option. The lifespan trade-off
-            below is <RecipientName
+            {#if alreadyFiled[skippedIndex] !== null}
+              <RecipientName r={recipients[skippedIndex]} /> already receives
+              benefits, so there is no grid for them: that filing date is
+              settled.
+            {:else}
+              <RecipientName r={recipients[skippedIndex]} /> is past 70, so
+              there is no grid for them: delayed retirement credits have
+              stopped and filing now is their only remaining option.
+            {/if}
+            The lifespan trade-off below is <RecipientName
               r={recipients[skippedIndex === 0 ? 1 : 0]}
             />'s alone.
           </p>

--- a/src/routes/strategy/components/StrategyMatrixDisplay.svelte
+++ b/src/routes/strategy/components/StrategyMatrixDisplay.svelte
@@ -25,9 +25,8 @@ export let recipients: [Recipient, Recipient];
 export let displayAsAges: boolean;
 /**
  * Per recipient: false once they are past 70 or have already filed. A
- * recipient with no choice left
- * has the same filing age in every cell, so their grid carries no
- * information and is not drawn at all.
+ * recipient with no choice left has the same filing age in every cell, so
+ * their grid carries no information and is not drawn at all.
  */
 export let hasFilingChoice: [boolean, boolean] = [true, true];
 /** Per recipient, the month benefits started, or null. Changes copy only. */
@@ -154,7 +153,7 @@ function handleHoverCell(detail: CellPosition | null) {
     {#if calculationResults.status() === CalculationStatus.Complete}
       {#if skippedIndex !== undefined}
         <div class="result-content">
-          <p class="past-70-note">
+          <p class="no-choice-note">
             {#if alreadyFiled[skippedIndex] !== null}
               <RecipientName r={recipients[skippedIndex]} /> already receives
               benefits, so there is no grid for them: that filing date is
@@ -197,7 +196,7 @@ function handleHoverCell(detail: CellPosition | null) {
     margin-top: 0.75rem;
   }
 
-  .past-70-note {
+  .no-choice-note {
     margin: 0 0 1rem;
     padding: 0.75rem 1rem;
     background: #f7f8fd;

--- a/src/stories/FiledMonthInput.stories.ts
+++ b/src/stories/FiledMonthInput.stories.ts
@@ -1,0 +1,87 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta } from '@storybook/svelte';
+import { Birthdate } from '../lib/birthday';
+import { Money } from '../lib/money';
+import { MonthDate } from '../lib/month-time';
+import { Recipient } from '../lib/recipient';
+import FiledMonthInput from '../routes/strategy/components/FiledMonthInput.svelte';
+
+const meta: Meta<FiledMonthInput> = {
+  title: 'Strategy/FiledMonthInput',
+  component: FiledMonthInput,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+const Template = ({ ...args }) => ({
+  Component: FiledMonthInput,
+  props: args,
+});
+
+// Born 15 June 1960: earliest filing month is July 2022. The current date is
+// fixed so the story does not drift as real time passes.
+const birthdate = Birthdate.FromYMD(1960, 5, 15);
+const recipient = new Recipient();
+recipient.birthdate = birthdate;
+recipient.name = 'Alex';
+recipient.setPia(Money.from(2000));
+const currentDate = MonthDate.initFromYearsMonths({ years: 2026, months: 8 });
+
+const baseArgs = {
+  recipient,
+  birthdate,
+  currentDate,
+  inputId: 'filed-story',
+  yearRange: { min: 1900, max: 2100 },
+  onchange: action('onchange'),
+  onvaliditychange: action('onvaliditychange'),
+};
+
+// Unticked: the checkbox alone, with no month inputs shown.
+export const Unticked = Template.bind({});
+Unticked.args = {
+  ...baseArgs,
+  value: null,
+};
+Unticked.parameters = {
+  docs: {
+    description: {
+      story:
+        'The control as first shown for an eligible person who has not been marked as already receiving benefits.',
+    },
+  },
+};
+
+// Ticked with a valid month: seeded from a bound value, as on restore.
+export const Ticked = Template.bind({});
+Ticked.args = {
+  ...baseArgs,
+  value: MonthDate.initFromYearsMonths({ years: 2024, months: 8 }),
+};
+Ticked.parameters = {
+  docs: {
+    description: {
+      story:
+        'Seeded with September 2024, a valid start month, so the box is ticked and the month and year are filled in.',
+    },
+  },
+};
+
+// Invalid: a month before the person could have filed shows the inline error.
+export const Invalid = Template.bind({});
+Invalid.args = {
+  ...baseArgs,
+  value: MonthDate.initFromYearsMonths({ years: 2021, months: 0 }),
+};
+Invalid.parameters = {
+  docs: {
+    description: {
+      story:
+        'Seeded with January 2021, before the first month this person could file (July 2022), so the inline error is shown and the published value is null.',
+    },
+  },
+};

--- a/src/test/strategy/already-filed.test.ts
+++ b/src/test/strategy/already-filed.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Tests for the "already receiving benefits" input to the strategy optimizer.
+ *
+ * A spouse who has already filed has no filing decision left: their filing
+ * age is a fact, not a variable. The optimizer pins that age and searches
+ * only the other spouse's ages. These tests cover the eligibility and
+ * validation rules, the collapsed filing range, and that every optimizer
+ * entry point honours the pin and agrees with a brute-force search.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Birthdate } from '$lib/birthday';
+import { filingChoices } from '$lib/components/recommended-filing-card';
+import { Money } from '$lib/money';
+import { MonthDate, MonthDuration } from '$lib/month-time';
+import { Recipient } from '$lib/recipient';
+import {
+  isEligibleToHaveFiled,
+  NOT_FILED,
+  validateFiledMonth,
+} from '$lib/strategy/calculations/already-filed';
+import {
+  expectedNPVCouple,
+  expectedNPVCoupleOptimized,
+} from '$lib/strategy/calculations/expected-npv';
+import { optimalStrategyCoupleFast } from '$lib/strategy/calculations/optimal-strategy-fast';
+import {
+  filingAgeRange,
+  optimalStrategyCouple,
+  optimalStrategyCoupleOptimized,
+  strategySumCentsCouple,
+} from '$lib/strategy/calculations/strategy-calc';
+
+function birthdate(year: number, monthIndex: number, day: number): Birthdate {
+  return Birthdate.FromYMD(year, monthIndex, day);
+}
+
+function monthDate(year: number, monthIndex: number): MonthDate {
+  return MonthDate.initFromYearsMonths({ years: year, months: monthIndex });
+}
+
+function makeRecipient(
+  piaDollars: number,
+  birthYear: number,
+  birthMonthIndex: number,
+  day: number = 15
+): Recipient {
+  const r = new Recipient();
+  r.birthdate = birthdate(birthYear, birthMonthIndex, day);
+  r.setPia(Money.from(piaDollars));
+  return r;
+}
+
+/**
+ * A flat death distribution from `fromAge` to 100. Shape does not matter;
+ * every remaining age needs some probability mass.
+ */
+function flatDeathDistribution(
+  fromAge: number
+): { age: number; probability: number }[] {
+  const ages: number[] = [];
+  for (let a = fromAge; a <= 100; a++) ages.push(a);
+  return ages.map((age) => ({ age, probability: 1 / ages.length }));
+}
+
+/**
+ * Brute force: with recipient `pinnedIndex` fixed at `pinnedAge`, scan the
+ * other recipient's full unpinned range and return the best pair.
+ */
+function bruteForcePinned(
+  recipients: [Recipient, Recipient],
+  finalDates: [MonthDate, MonthDate],
+  currentDate: MonthDate,
+  discountRate: number,
+  pinnedIndex: 0 | 1,
+  pinnedAge: MonthDuration
+): [MonthDuration, MonthDuration, number] {
+  const otherIndex = pinnedIndex === 0 ? 1 : 0;
+  const other = filingAgeRange(recipients[otherIndex], currentDate);
+  let best: [MonthDuration, MonthDuration, number] = [
+    new MonthDuration(0),
+    new MonthDuration(0),
+    -1,
+  ];
+  for (let m = other.earliest.asMonths(); m <= other.latest.asMonths(); m++) {
+    const strategy: [MonthDuration, MonthDuration] =
+      pinnedIndex === 0
+        ? [pinnedAge, new MonthDuration(m)]
+        : [new MonthDuration(m), pinnedAge];
+    const cents = strategySumCentsCouple(
+      recipients,
+      finalDates,
+      currentDate,
+      discountRate,
+      strategy
+    );
+    if (cents > best[2]) best = [strategy[0], strategy[1], cents];
+  }
+  return best;
+}
+
+describe('isEligibleToHaveFiled', () => {
+  // Born 15 March 1964: earliest filing month is the month after turning 62,
+  // April 2026 (see earliestFilingMonth for the 1st/2nd-of-month rule).
+  const bd = birthdate(1964, 2, 15);
+
+  it('is false the month before the earliest filing month', () => {
+    expect(isEligibleToHaveFiled(bd, monthDate(2026, 2))).toBe(false);
+  });
+
+  it('is true in the earliest filing month', () => {
+    expect(isEligibleToHaveFiled(bd, monthDate(2026, 3))).toBe(true);
+  });
+
+  it('is true well past 62', () => {
+    expect(isEligibleToHaveFiled(bd, monthDate(2040, 0))).toBe(true);
+  });
+
+  it('honours the 1st-of-month rule', () => {
+    // Born on the 1st: earliest filing month is the birthday month itself.
+    const first = birthdate(1964, 2, 1);
+    expect(isEligibleToHaveFiled(first, monthDate(2026, 2))).toBe(true);
+  });
+});
+
+describe('validateFiledMonth', () => {
+  const bd = birthdate(1964, 2, 15);
+  const now = monthDate(2030, 5);
+
+  it('accepts the earliest filing month', () => {
+    expect(validateFiledMonth(bd, monthDate(2026, 3), now)).toBeNull();
+  });
+
+  it('rejects the month before the earliest filing month', () => {
+    expect(validateFiledMonth(bd, monthDate(2026, 2), now)).toMatch(
+      /April 2026/
+    );
+  });
+
+  it('accepts the current month', () => {
+    expect(validateFiledMonth(bd, now, now)).toBeNull();
+  });
+
+  it('rejects next month', () => {
+    expect(validateFiledMonth(bd, monthDate(2030, 6), now)).toMatch(/future/);
+  });
+});
+
+describe('NOT_FILED', () => {
+  it('is a pair of nulls', () => {
+    expect(NOT_FILED).toEqual([null, null]);
+  });
+});
+
+describe('filingAgeRange with a filed month', () => {
+  // Born June 1960, filed at 64y3m (September 2024), now 66.
+  const r = makeRecipient(2000, 1960, 5);
+  const filedAt = monthDate(2024, 8);
+  const now = monthDate(2026, 8);
+
+  it('collapses to the filing age with no choice', () => {
+    const range = filingAgeRange(r, now, filedAt);
+    const expected = r.birthdate.ageAtSsaDate(filedAt);
+    expect(range.earliest.asMonths()).toBe(expected.asMonths());
+    expect(range.latest.asMonths()).toBe(expected.asMonths());
+    expect(range.hasChoice).toBe(false);
+  });
+
+  it('hands out distinct instances for earliest and latest', () => {
+    const range = filingAgeRange(r, now, filedAt);
+    expect(range.earliest).not.toBe(range.latest);
+  });
+
+  it('is unchanged when filedAt is null', () => {
+    const withNull = filingAgeRange(r, now, null);
+    const without = filingAgeRange(r, now);
+    expect(withNull.earliest.asMonths()).toBe(without.earliest.asMonths());
+    expect(withNull.latest.asMonths()).toBe(without.latest.asMonths());
+    expect(withNull.hasChoice).toBe(true);
+  });
+
+  it('rejects a filed month the person could not have filed in', () => {
+    expect(() => filingAgeRange(r, now, monthDate(2020, 0))).toThrow(/age 62/);
+  });
+
+  it('rejects a filed month in the future', () => {
+    expect(() => filingAgeRange(r, now, monthDate(2027, 0))).toThrow(/future/);
+  });
+});
+
+describe('filingChoices with a filed spouse', () => {
+  const a = makeRecipient(2000, 1960, 5);
+  const b = makeRecipient(2500, 1963, 2);
+  const now = monthDate(2026, 8);
+
+  it('marks only the filed spouse as having no choice', () => {
+    expect(filingChoices(a, b, now, [monthDate(2024, 8), null])).toEqual([
+      false,
+      true,
+    ]);
+    expect(filingChoices(a, b, now, [null, monthDate(2026, 0)])).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  it('defaults to nobody filed', () => {
+    expect(filingChoices(a, b, now)).toEqual([true, true]);
+  });
+});
+
+describe('couple optimizers with a filed spouse', () => {
+  // Alice, born June 1960, filed at 64y3m (September 2024). Bob, born March
+  // 1963, has not filed. Today is September 2026.
+  const alice = makeRecipient(2000, 1960, 5);
+  const bob = makeRecipient(2600, 1963, 2);
+  const recipients: [Recipient, Recipient] = [alice, bob];
+  const now = monthDate(2026, 8);
+  const filedAt = monthDate(2024, 8);
+  const aliceFiledAge = alice.birthdate.ageAtSsaDate(filedAt);
+  const alreadyFiled = [filedAt, null] as const;
+  const finalDates: [MonthDate, MonthDate] = [
+    alice.birthdate.dateAtLayAge(
+      MonthDuration.initFromYearsMonths({ years: 84, months: 6 })
+    ),
+    bob.birthdate.dateAtLayAge(
+      MonthDuration.initFromYearsMonths({ years: 88, months: 6 })
+    ),
+  ];
+  const discountRate = 0.025;
+
+  const expected = bruteForcePinned(
+    recipients,
+    finalDates,
+    now,
+    discountRate,
+    0,
+    aliceFiledAge
+  );
+
+  it('optimalStrategyCouple pins the filed spouse and matches brute force', () => {
+    const [a, b, cents] = optimalStrategyCouple(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      alreadyFiled
+    );
+    expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
+    expect(b.asMonths()).toBe(expected[1].asMonths());
+    expect(cents).toBe(expected[2]);
+  });
+
+  it('optimalStrategyCoupleOptimized matches brute force', () => {
+    const [a, b, cents] = optimalStrategyCoupleOptimized(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      alreadyFiled
+    );
+    expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
+    expect(b.asMonths()).toBe(expected[1].asMonths());
+    expect(cents).toBe(expected[2]);
+  });
+
+  it('optimalStrategyCoupleFast matches brute force to the cent', () => {
+    const [a, b, cents] = optimalStrategyCoupleFast(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      alreadyFiled
+    );
+    expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
+    expect(b.asMonths()).toBe(expected[1].asMonths());
+    expect(Math.abs(cents - expected[2])).toBeLessThanOrEqual(1);
+  });
+
+  it('pins the second spouse just as well', () => {
+    const bobFiledAt = monthDate(2025, 5);
+    const bobFiledAge = bob.birthdate.ageAtSsaDate(bobFiledAt);
+    const want = bruteForcePinned(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      1,
+      bobFiledAge
+    );
+    const [a, b, cents] = optimalStrategyCoupleFast(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      [null, bobFiledAt]
+    );
+    expect(b.asMonths()).toBe(bobFiledAge.asMonths());
+    expect(a.asMonths()).toBe(want[0].asMonths());
+    expect(Math.abs(cents - want[2])).toBeLessThanOrEqual(1);
+  });
+
+  it('a pinned age past the death date still yields a strategy', () => {
+    // Alice dies at 63, before her recorded filing at 64y3m. The scenario is
+    // odd but must not throw: Bob still has a decision.
+    const early: [MonthDate, MonthDate] = [
+      alice.birthdate.dateAtLayAge(
+        MonthDuration.initFromYearsMonths({ years: 63, months: 6 })
+      ),
+      finalDates[1],
+    ];
+    const [a, , cents] = optimalStrategyCoupleFast(
+      recipients,
+      early,
+      now,
+      discountRate,
+      alreadyFiled
+    );
+    expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
+    expect(cents).toBeGreaterThan(0);
+  });
+});
+
+describe('expected NPV with a filed spouse', () => {
+  const alice = makeRecipient(2000, 1960, 5);
+  const bob = makeRecipient(2600, 1963, 2);
+  const recipients: [Recipient, Recipient] = [alice, bob];
+  const now = monthDate(2026, 8);
+  const filedAt = monthDate(2024, 8);
+  const aliceFiledAge = alice.birthdate.ageAtSsaDate(filedAt);
+  const alreadyFiled = [filedAt, null] as const;
+  const dists: [
+    { age: number; probability: number }[],
+    { age: number; probability: number }[],
+  ] = [flatDeathDistribution(66), flatDeathDistribution(63)];
+
+  it('returns one result per age of the unpinned spouse', () => {
+    const results = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      0.025,
+      dists,
+      alreadyFiled
+    );
+    const bobRange = filingAgeRange(bob, now);
+    expect(results.length).toBe(
+      bobRange.latest.asMonths() - bobRange.earliest.asMonths() + 1
+    );
+    for (const r of results) {
+      expect(r.filingAges[0].asMonths()).toBe(aliceFiledAge.asMonths());
+    }
+  });
+
+  it('optimized matches the exact reference for every pair', () => {
+    const fast = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      0.025,
+      dists,
+      alreadyFiled
+    );
+    const slow = expectedNPVCouple(recipients, now, 0.025, dists, alreadyFiled);
+    expect(fast.length).toBe(slow.length);
+    const key = (a: MonthDuration, b: MonthDuration) =>
+      `${a.asMonths()}:${b.asMonths()}`;
+    const slowByKey = new Map(
+      slow.map((r) => [
+        key(r.filingAges[0], r.filingAges[1]),
+        r.expectedNPVCents,
+      ])
+    );
+    for (const r of fast) {
+      const want = slowByKey.get(key(r.filingAges[0], r.filingAges[1]));
+      expect(want).toBeDefined();
+      expect(
+        Math.abs(r.expectedNPVCents - (want as number))
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('pinning inside the unpinned range does not change any pair value', () => {
+    const unpinned = expectedNPVCoupleOptimized(recipients, now, 0.025, dists);
+    const key = (a: MonthDuration, b: MonthDuration) =>
+      `${a.asMonths()}:${b.asMonths()}`;
+    const byKey = new Map(
+      unpinned.map((r) => [
+        key(r.filingAges[0], r.filingAges[1]),
+        r.expectedNPVCents,
+      ])
+    );
+    // Alice's unpinned range starts at her current age, above her real filing
+    // age, so pin her at an age inside the unpinned range and compare.
+    const insideAge = filingAgeRange(alice, now).earliest;
+    const insideMonth = alice.birthdate.dateAtSsaAge(insideAge);
+    const pinnedInside = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      0.025,
+      dists,
+      [insideMonth, null]
+    );
+    expect(pinnedInside.length).toBeGreaterThan(0);
+    for (const r of pinnedInside) {
+      const want = byKey.get(key(r.filingAges[0], r.filingAges[1]));
+      expect(want).toBeDefined();
+      expect(r.expectedNPVCents).toBe(want);
+    }
+  });
+});

--- a/src/test/strategy/already-filed.test.ts
+++ b/src/test/strategy/already-filed.test.ts
@@ -121,6 +121,17 @@ describe('isEligibleToHaveFiled', () => {
     const first = birthdate(1964, 2, 1);
     expect(isEligibleToHaveFiled(first, monthDate(2026, 2))).toBe(true);
   });
+
+  it('draws the boundary between the 2nd and the 3rd of the month', () => {
+    // SSA treats a birthday on the 1st or 2nd as attained in the previous
+    // month, so the 2nd is eligible in the birthday month and the 3rd is not.
+    expect(
+      isEligibleToHaveFiled(birthdate(1964, 2, 2), monthDate(2026, 2))
+    ).toBe(true);
+    expect(
+      isEligibleToHaveFiled(birthdate(1964, 2, 3), monthDate(2026, 2))
+    ).toBe(false);
+  });
 });
 
 describe('validateFiledMonth', () => {
@@ -143,6 +154,19 @@ describe('validateFiledMonth', () => {
 
   it('rejects next month', () => {
     expect(validateFiledMonth(bd, monthDate(2030, 6), now)).toMatch(/future/);
+  });
+
+  it('accepts the birthday month for the 1st and 2nd but not the 3rd', () => {
+    const birthdayMonth = monthDate(2026, 2);
+    expect(
+      validateFiledMonth(birthdate(1964, 2, 1), birthdayMonth, now)
+    ).toBeNull();
+    expect(
+      validateFiledMonth(birthdate(1964, 2, 2), birthdayMonth, now)
+    ).toBeNull();
+    expect(
+      validateFiledMonth(birthdate(1964, 2, 3), birthdayMonth, now)
+    ).toMatch(/April 2026/);
   });
 });
 
@@ -206,6 +230,13 @@ describe('filingChoices with a filed spouse', () => {
 
   it('defaults to nobody filed', () => {
     expect(filingChoices(a, b, now)).toEqual([true, true]);
+  });
+
+  it('honours the filed month with no spouse', () => {
+    expect(filingChoices(a, null, now, [monthDate(2024, 8), null])).toEqual([
+      false,
+      true,
+    ]);
   });
 });
 
@@ -309,15 +340,241 @@ describe('couple optimizers with a filed spouse', () => {
       ),
       finalDates[1],
     ];
-    const [a, , cents] = optimalStrategyCoupleFast(
+    for (const optimize of [
+      optimalStrategyCouple,
+      optimalStrategyCoupleOptimized,
+      optimalStrategyCoupleFast,
+    ]) {
+      const [a, , cents] = optimize(
+        recipients,
+        early,
+        now,
+        discountRate,
+        alreadyFiled
+      );
+      expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
+      expect(cents).toBeGreaterThan(0);
+    }
+  });
+
+  it('filed exactly in the current month agrees with brute force', () => {
+    const nowAge = alice.birthdate.ageAtSsaDate(now);
+    const want = bruteForcePinned(
       recipients,
-      early,
+      finalDates,
+      now,
+      discountRate,
+      0,
+      nowAge
+    );
+    for (const optimize of [
+      optimalStrategyCouple,
+      optimalStrategyCoupleOptimized,
+      optimalStrategyCoupleFast,
+    ]) {
+      const [a, b, cents] = optimize(
+        recipients,
+        finalDates,
+        now,
+        discountRate,
+        [now, null]
+      );
+      expect(a.asMonths()).toBe(nowAge.asMonths());
+      expect(b.asMonths()).toBe(want[1].asMonths());
+      expect(Math.abs(cents - want[2])).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('both filed reduces to a single strategy sum', () => {
+    const bobFiledAt = monthDate(2025, 5);
+    const bobFiledAge = bob.birthdate.ageAtSsaDate(bobFiledAt);
+    const bothFiled = [filedAt, bobFiledAt] as const;
+    const want = strategySumCentsCouple(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      [aliceFiledAge, bobFiledAge]
+    );
+    for (const optimize of [
+      optimalStrategyCouple,
+      optimalStrategyCoupleOptimized,
+      optimalStrategyCoupleFast,
+    ]) {
+      const [a, b, cents] = optimize(
+        recipients,
+        finalDates,
+        now,
+        discountRate,
+        bothFiled
+      );
+      expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
+      expect(b.asMonths()).toBe(bobFiledAge.asMonths());
+      expect(Math.abs(cents - want)).toBeLessThanOrEqual(1);
+    }
+    const results = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      discountRate,
+      [flatDeathDistribution(66), flatDeathDistribution(63)],
+      bothFiled
+    );
+    expect(results.length).toBe(1);
+    expect(results[0].filingAges[0].asMonths()).toBe(aliceFiledAge.asMonths());
+    expect(results[0].filingAges[1].asMonths()).toBe(bobFiledAge.asMonths());
+  });
+});
+
+describe('a zero-PIA dependent who has already filed', () => {
+  // Alice has no record of her own and filed at 64y3m (September 2024),
+  // before Bob, the earner, has filed. The optimizers normally bump a
+  // zero-PIA dependent's reported age up to the earner's filing month, since
+  // every earlier age scores the same; a recorded month must stay put.
+  const alice = makeRecipient(0, 1960, 5);
+  const bob = makeRecipient(2600, 1963, 2);
+  const recipients: [Recipient, Recipient] = [alice, bob];
+  const now = monthDate(2026, 8);
+  const filedAt = monthDate(2024, 8);
+  const aliceFiledAge = alice.birthdate.ageAtSsaDate(filedAt);
+  const alreadyFiled = [filedAt, null] as const;
+  const finalDates: [MonthDate, MonthDate] = [
+    alice.birthdate.dateAtLayAge(
+      MonthDuration.initFromYearsMonths({ years: 84, months: 6 })
+    ),
+    bob.birthdate.dateAtLayAge(
+      MonthDuration.initFromYearsMonths({ years: 88, months: 6 })
+    ),
+  ];
+  const discountRate = 0.025;
+  const want = bruteForcePinned(
+    recipients,
+    finalDates,
+    now,
+    discountRate,
+    0,
+    aliceFiledAge
+  );
+
+  it.each([
+    ['optimalStrategyCouple', optimalStrategyCouple],
+    ['optimalStrategyCoupleOptimized', optimalStrategyCoupleOptimized],
+    ['optimalStrategyCoupleFast', optimalStrategyCoupleFast],
+  ])('%s reports the recorded filing age', (_name, optimize) => {
+    const [a, b, cents] = optimize(
+      recipients,
+      finalDates,
       now,
       discountRate,
       alreadyFiled
     );
     expect(a.asMonths()).toBe(aliceFiledAge.asMonths());
-    expect(cents).toBeGreaterThan(0);
+    expect(b.asMonths()).toBe(want[1].asMonths());
+    expect(Math.abs(cents - want[2])).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('a spouse who filed past 70', () => {
+  // Carol, born June 1954, filed at 71y0m (June 2025). Delayed credits stop
+  // at 70, so her benefit is the age-70 amount; the optimizers must report
+  // her actual filing age, not 70.
+  const carol = makeRecipient(2000, 1954, 5);
+  const bob = makeRecipient(2600, 1963, 2);
+  const recipients: [Recipient, Recipient] = [carol, bob];
+  const now = monthDate(2026, 8);
+  const age71 = MonthDuration.initFromYearsMonths({ years: 71, months: 0 });
+  const age70 = MonthDuration.initFromYearsMonths({ years: 70, months: 0 });
+  const filedAt = carol.birthdate.dateAtSsaAge(age71);
+  const alreadyFiled = [filedAt, null] as const;
+  const finalDates: [MonthDate, MonthDate] = [
+    carol.birthdate.dateAtLayAge(
+      MonthDuration.initFromYearsMonths({ years: 88, months: 6 })
+    ),
+    bob.birthdate.dateAtLayAge(
+      MonthDuration.initFromYearsMonths({ years: 88, months: 6 })
+    ),
+  ];
+  const discountRate = 0.025;
+
+  it('collapses the filing range to 852 months', () => {
+    const range = filingAgeRange(carol, now, filedAt);
+    expect(range.earliest.asMonths()).toBe(852);
+    expect(range.latest.asMonths()).toBe(852);
+    expect(range.hasChoice).toBe(false);
+  });
+
+  it('every optimizer reports 852 and scores it as filing at 70', () => {
+    const want = bruteForcePinned(
+      recipients,
+      finalDates,
+      now,
+      discountRate,
+      0,
+      age70
+    );
+    for (const optimize of [
+      optimalStrategyCouple,
+      optimalStrategyCoupleOptimized,
+      optimalStrategyCoupleFast,
+    ]) {
+      const [a, b, cents] = optimize(
+        recipients,
+        finalDates,
+        now,
+        discountRate,
+        alreadyFiled
+      );
+      expect(a.asMonths()).toBe(852);
+      expect(b.asMonths()).toBe(want[1].asMonths());
+      expect(Math.abs(cents - want[2])).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('expected NPV reports 852 for every pair', () => {
+    const results = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      discountRate,
+      [flatDeathDistribution(73), flatDeathDistribution(64)],
+      alreadyFiled
+    );
+    expect(results.length).toBeGreaterThan(0);
+    for (const r of results) {
+      expect(r.filingAges[0].asMonths()).toBe(852);
+    }
+  });
+});
+
+describe('one spouse filed and the other past 70y6m', () => {
+  // Dan, born January 1955, is 71y8m in September 2026 and has not filed;
+  // his range collapses on its own. Alice filed in September 2024.
+  const alice = makeRecipient(2000, 1960, 5);
+  const dan = makeRecipient(2600, 1955, 0);
+  const recipients: [Recipient, Recipient] = [alice, dan];
+  const now = monthDate(2026, 8);
+  const filedAt = monthDate(2024, 8);
+  const alreadyFiled = [filedAt, null] as const;
+
+  it('both ranges collapse and expected NPV has exactly one result', () => {
+    const aliceRange = filingAgeRange(alice, now, filedAt);
+    const danRange = filingAgeRange(dan, now, null);
+    expect(aliceRange.hasChoice).toBe(false);
+    expect(danRange.hasChoice).toBe(false);
+    expect(danRange.earliest.asMonths()).toBe(danRange.latest.asMonths());
+
+    const results = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      0.025,
+      [flatDeathDistribution(67), flatDeathDistribution(72)],
+      alreadyFiled
+    );
+    expect(results.length).toBe(1);
+    expect(results[0].filingAges[0].asMonths()).toBe(
+      aliceRange.earliest.asMonths()
+    );
+    expect(results[0].filingAges[1].asMonths()).toBe(
+      danRange.earliest.asMonths()
+    );
   });
 });
 
@@ -370,6 +627,38 @@ describe('expected NPV with a filed spouse', () => {
       ])
     );
     for (const r of fast) {
+      const want = slowByKey.get(key(r.filingAges[0], r.filingAges[1]));
+      expect(want).toBeDefined();
+      expect(
+        Math.abs(r.expectedNPVCents - (want as number))
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('optimized matches the exact reference with the earner pinned', () => {
+    const bobFiledAt = monthDate(2025, 5);
+    const earnerPinned = [null, bobFiledAt] as const;
+    const fast = expectedNPVCoupleOptimized(
+      recipients,
+      now,
+      0.025,
+      dists,
+      earnerPinned
+    );
+    const slow = expectedNPVCouple(recipients, now, 0.025, dists, earnerPinned);
+    expect(fast.length).toBe(slow.length);
+    expect(fast.length).toBeGreaterThan(0);
+    const key = (a: MonthDuration, b: MonthDuration) =>
+      `${a.asMonths()}:${b.asMonths()}`;
+    const slowByKey = new Map(
+      slow.map((r) => [
+        key(r.filingAges[0], r.filingAges[1]),
+        r.expectedNPVCents,
+      ])
+    );
+    const bobFiledAge = bob.birthdate.ageAtSsaDate(bobFiledAt);
+    for (const r of fast) {
+      expect(r.filingAges[1].asMonths()).toBe(bobFiledAge.asMonths());
       const want = slowByKey.get(key(r.filingAges[0], r.filingAges[1]));
       expect(want).toBeDefined();
       expect(

--- a/src/test/url-params.test.ts
+++ b/src/test/url-params.test.ts
@@ -820,6 +820,26 @@ describe('UrlParams', () => {
       expect(back.getSpouseFiledMonth()).toBeNull();
     });
 
+    it('orders filed1 before pia2 and filed2 last', () => {
+      const hash = buildStrategyHash({
+        isSingle: false,
+        pia1: 2000,
+        dob1: '1960-06-15',
+        pia2: 2600,
+        dob2: '1963-03-15',
+        name2: 'Bob',
+        gender2: 'male',
+        filed1: MonthDate.initFromYearsMonths({ years: 2024, months: 8 }),
+        filed2: MonthDate.initFromYearsMonths({ years: 2025, months: 5 }),
+      });
+      const parts = hash.slice(1).split('&');
+      expect(parts.indexOf('filed1=2024-09')).toBeGreaterThan(-1);
+      expect(parts.indexOf('filed1=2024-09')).toBeLessThan(
+        parts.indexOf('pia2=2600')
+      );
+      expect(parts[parts.length - 1]).toBe('filed2=2025-06');
+    });
+
     it('omits filed params in single mode', () => {
       const hash = buildStrategyHash({
         isSingle: true,

--- a/src/test/url-params.test.ts
+++ b/src/test/url-params.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { MonthDate } from '$lib/month-time';
 import { buildStrategyHash, UrlParams } from '$lib/url-params';
 
 describe('UrlParams', () => {
@@ -766,6 +767,67 @@ describe('UrlParams', () => {
       expect(params.getSpouseDob()).toBe('1962-07-22');
       expect(params.getSpouseName()).toBe('Casey');
       expect(params.getSpouseGender()).toBe('female');
+    });
+  });
+
+  describe('filed month params', () => {
+    it('parses filed1 and filed2 as MonthDate', () => {
+      const params = new UrlParams('#filed1=2024-03&filed2=2025-11');
+      expect(params.getRecipientFiledMonth()?.year()).toBe(2024);
+      expect(params.getRecipientFiledMonth()?.monthIndex()).toBe(2);
+      expect(params.getSpouseFiledMonth()?.year()).toBe(2025);
+      expect(params.getSpouseFiledMonth()?.monthIndex()).toBe(10);
+    });
+
+    it('returns null when absent', () => {
+      const params = new UrlParams('#pia1=3000&dob1=1965-09-21');
+      expect(params.getRecipientFiledMonth()).toBeNull();
+      expect(params.getSpouseFiledMonth()).toBeNull();
+    });
+
+    it('ignores malformed values', () => {
+      for (const bad of [
+        '2024',
+        '2024-13',
+        '2024-00',
+        'March-2024',
+        '24-03',
+        '2024-3',
+      ]) {
+        const params = new UrlParams(`#filed1=${bad}`);
+        expect(params.getRecipientFiledMonth(), bad).toBeNull();
+      }
+    });
+
+    it('round-trips through buildStrategyHash', () => {
+      const hash = buildStrategyHash({
+        isSingle: false,
+        pia1: 2000,
+        dob1: '1960-06-15',
+        pia2: 2600,
+        dob2: '1963-03-15',
+        filed1: MonthDate.initFromYearsMonths({ years: 2024, months: 8 }),
+      });
+      expect(hash).toContain('filed1=2024-09');
+      expect(hash).not.toContain('filed2');
+      const back = new UrlParams(hash);
+      expect(back.getRecipientFiledMonth()?.monthsSinceEpoch()).toBe(
+        MonthDate.initFromYearsMonths({
+          years: 2024,
+          months: 8,
+        }).monthsSinceEpoch()
+      );
+      expect(back.getSpouseFiledMonth()).toBeNull();
+    });
+
+    it('omits filed params in single mode', () => {
+      const hash = buildStrategyHash({
+        isSingle: true,
+        pia1: 2000,
+        dob1: '1960-06-15',
+        filed1: MonthDate.initFromYearsMonths({ years: 2024, months: 8 }),
+      });
+      expect(hash).not.toContain('filed1');
     });
   });
 });


### PR DESCRIPTION
## Summary

Lets a couple on `/strategy` say that one spouse already receives benefits. That spouse's filing month is pinned and the optimizer searches only the other spouse's ages. Follow-up to #589, which handled recipients past 70.

- **Calculation**: new `already-filed.ts` (tuple type, eligibility at 62, month validation). `filingAgeRange` takes an optional filed month and collapses to that age with `hasChoice: false`, the same shape the over-70 case produces. The five couple optimizer entry points and `filingChoices` take the tuple as a trailing argument. Single mode is untouched.
- **Persistence**: `filed1` / `filed2` (`YYYY-MM`) in the share URL hash. A value for someone under 62 is dropped on restore; an out-of-range value shows the inline error and blocks Continue.
- **Form**: `FiledMonthInput` child rendered under the birthdate, couple mode only, only for someone at least 62 this month. Checkbox reveals a month select and year input with inline validation folded into Continue. Ticking it shows a note under PIA asking for the PIA rather than the monthly amount received.
- **Results**: the filed spouse's card reads "Started benefits <Month Year>" with their monthly amount (omitted when PIA is zero), no grid is drawn for them, the alternatives grid collapses their axis with a note, and both-filed shows the no-decision panel. An eligible spouse who was not marked filed gets an "Already receiving benefits? Update your details" hint back to the form.

## Testing

- 24 new tests in `src/test/strategy/already-filed.test.ts`: eligibility and validation edges, collapsed range, brute-force pinned search equality for all three couple optimizers, optimized-vs-reference NPV per pair with a filed spouse, and pinning inside the unpinned range leaving every pair value unchanged.
- 5 new URL param tests (parse, absent, malformed, round trip, single-mode omission).
- Full suite: 83 files, 2206 tests. `npm run quality` and `npm run build` clean.
- Browser pass over 12 cases: gating under 62, reveal on birthdate change, invalid and future months, results card and grid, share URL restore, hint and return to form, both filed, single mode, ineligible restore, zero-PIA spouse, calculator card unaffected.

## Known limits

- A zero-PIA filed spouse gets no amount on the card: the card computes the personal benefit only, and their spousal amount depends on the earner's filing date.
- Retroactive lump sums are still worth $0 to the optimizer (unchanged from #589).
